### PR TITLE
AO3-1173 We need a comment preview

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -406,7 +406,7 @@ class CommentsController < ApplicationController
   # GET /comments/preview
   def preview
     if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
+      flash[:error] = t(".missing_commentable")
       redirect_back_or_to root_path
       return
     end
@@ -824,9 +824,7 @@ class CommentsController < ApplicationController
       context[:comment_id] = @commentable.id
     end
 
-    if controller_name == "inbox" && params[:filters]
-      context[:filters] = filter_params.to_h
-    end
+    context[:filters] = filter_params.to_h if controller_name == "inbox" && params[:filters]
 
     context
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -364,7 +364,7 @@ class CommentsController < ApplicationController
     render_comment_form
   end
 
-  # POST /comments/back_to_edit
+  # POST /comments/preview/edit
   def back_to_edit
     render_comment_form
     render :new unless performed?
@@ -778,7 +778,7 @@ class CommentsController < ApplicationController
 
   private
 
-  def render_comment_form
+  def load_comment_form
     if @commentable.nil?
       flash[:error] = t("comments.new.missing_commentable")
       redirect_back_or_to root_path

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -95,7 +95,7 @@ class CommentsController < ApplicationController
     return unless params[:comment][:pseud_id]
     pseud = Pseud.find(params[:comment][:pseud_id])
     return if pseud && current_user && current_user.pseuds.include?(pseud)
-    flash[:error] = ts("You can't comment with that pseud.")
+    flash[:error] = t("comments.check_pseud_ownership.error")
     redirect_to root_path
   end
 
@@ -113,12 +113,12 @@ class CommentsController < ApplicationController
     parent = find_parent
     # No one can create or update comments on something hidden by an admin.
     if parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
-      flash[:error] = ts("Sorry, you can't add or edit comments on a hidden work.")
+      flash[:error] = t("comments.commentable.permissions.work.hidden")
       redirect_to work_path(parent)
     end
     # No one can create or update comments on unrevealed works.
     if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
-      flash[:error] = ts("Sorry, you can't add or edit comments on an unrevealed work.")
+      flash[:error] = t("comments.commentable.permissions.work.unrevealed")
       redirect_to work_path(parent)
     end
 
@@ -190,7 +190,7 @@ class CommentsController < ApplicationController
   def check_unreviewed
     return unless @commentable.respond_to?(:unreviewed?) && @commentable.unreviewed?
 
-    flash[:error] = ts("Sorry, you cannot reply to an unapproved comment.")
+    flash[:error] = t("comments.check_unreviewed.error")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
@@ -218,7 +218,7 @@ class CommentsController < ApplicationController
   def check_permission_to_review
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent)
-    flash[:error] = ts("Sorry, you don't have permission to see those unreviewed comments.")
+    flash[:error] = t("comments.check_permission_to_review.error")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
@@ -226,14 +226,14 @@ class CommentsController < ApplicationController
     return unless @comment.unreviewed?
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent) || current_user_owns?(@comment)
-    flash[:error] = ts("Sorry, that comment is currently in moderation.")
+    flash[:error] = t("comments.check_permission_to_access_single_unreviewed.error")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
   def check_permission_to_moderate
     return if logged_in_as_admin? || current_user_owns?(find_parent)
 
-    flash[:error] = ts("Sorry, you don't have permission to moderate that comment.")
+    flash[:error] = t("comments.check_permission_to_moderate.error")
     redirect_to(logged_in? ? root_path : new_user_session_path(return_to: comment_path(@comment)))
   end
 
@@ -254,7 +254,7 @@ class CommentsController < ApplicationController
       flash[:error] = t("comments.check_permission_to_edit.error.frozen")
       redirect_back_or_to @comment
     elsif !@comment.count_all_comments.zero?
-      flash[:error] = ts("Comments with replies cannot be edited")
+      flash[:error] = t("comments.check_permission_to_edit.error.has_replies")
       redirect_back_or_to @comment
     end
   end
@@ -492,7 +492,7 @@ class CommentsController < ApplicationController
         end
       end
     else
-      flash[:error] = ts("Couldn't save comment!")
+      flash[:error] = t("comments.create.error")
       render action: "new"
     end
   end
@@ -502,7 +502,7 @@ class CommentsController < ApplicationController
   def update
     updated_comment_params = comment_params.merge(edited_at: Time.current)
     if @comment.update(updated_comment_params)
-      flash[:comment_notice] = ts('Comment was successfully updated.')
+      flash[:comment_notice] = t("comments.update.success")
       respond_to do |format|
         format.html do
           redirect_to comment_path(@comment) and return if @comment.unreviewed?
@@ -526,17 +526,17 @@ class CommentsController < ApplicationController
 
     if !@comment.destroy_or_mark_deleted
       # something went wrong?
-      flash[:comment_error] = ts("We couldn't delete that comment.")
+      flash[:comment_error] = t("comments.destroy.error")
       redirect_to_comment(@comment)
     elsif unreviewed
       # go back to the rest of the unreviewed comments
-      flash[:notice] = ts("Comment deleted.")
+      flash[:notice] = t("comments.destroy.success")
       redirect_back_or_to unreviewed_work_comments_path(@comment.commentable)
     elsif parent_comment
-      flash[:comment_notice] = ts("Comment deleted.")
+      flash[:comment_notice] = t("comments.destroy.success")
       redirect_to_comment(parent_comment)
     else
-      flash[:comment_notice] = ts("Comment deleted.")
+      flash[:comment_notice] = t("comments.destroy.success")
       redirect_to_all_comments(parent, {show_comments: true})
     end
   end
@@ -553,7 +553,7 @@ class CommentsController < ApplicationController
     @comment.toggle!(:unreviewed)
     # mark associated inbox comments as read
     InboxComment.where(user_id: current_user.id, feedback_comment_id: @comment.id).update_all(read: true) unless logged_in_as_admin?
-    flash[:notice] = ts("Comment approved.")
+    flash[:notice] = t("comments.review.success")
     respond_to do |format|
       format.html do
         if params[:approved_from] == "inbox"

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -397,7 +397,7 @@ class CommentsController < ApplicationController
     end
 
     @preview_mode = true
-    @context_params = build_context_params
+    @form_state = build_comment_form_state
     render :preview
   end
 
@@ -409,54 +409,55 @@ class CommentsController < ApplicationController
       return
     end
 
-    if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
+    unless @commentable.present?
+      flash[:error] = t("comments.create.missing_commentable")
       redirect_back_or_to root_path
-    else
-      @comment = Comment.new(comment_params)
-      @comment.ip_address = request.remote_ip
-      @comment.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
-      @comment.cloudflare_bot_score = request.env["HTTP_CF_BOT_SCORE"]
-      @comment.cloudflare_ja3_hash = request.env["HTTP_CF_JA3_HASH"]
-      @comment.cloudflare_ja4 = request.env["HTTP_CF_JA4"]
-      @comment.commentable = Comment.commentable_object(@commentable)
-      @controller_name = params[:controller_name]
+      return
+    end
 
-      # First, try saving the comment
-      if @comment.save
-        flash[:comment_notice] = if @comment.unreviewed?
-                                   # i18n-tasks-use t("comments.create.success.moderated.admin_post")
-                                   # i18n-tasks-use t("comments.create.success.moderated.work")
-                                   t("comments.create.success.moderated.#{@comment.ultimate_parent.model_name.i18n_key}")
-                                 else
-                                   t("comments.create.success.not_moderated")
-                                 end
-        respond_to do |format|
-          format.html do
-            if request.referer&.match(/inbox/)
-              redirect_to user_inbox_path(current_user, filters: filter_params, page: params[:page])
-            elsif request.referer&.match(/new/) || (@comment.unreviewed? && current_user)
-              # If the referer is the new comment page, go to the comment's page
-              # instead of reloading the full work.
-              # If the comment is unreviewed and commenter is logged in, take
-              # them to the comment's page so they can access the edit and
-              # delete options for the comment, since unreviewed comments don't
-              # appear on the commentable.
-              redirect_to comment_path(@comment)
-            elsif request.referer == root_url
-              # replying on the homepage
-              redirect_to root_path
-            elsif @comment.unreviewed?
-              redirect_to_all_comments(@commentable)
-            else
-              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
-            end
+    @comment = Comment.new(comment_params)
+    @comment.ip_address = request.remote_ip
+    @comment.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
+    @comment.cloudflare_bot_score = request.env["HTTP_CF_BOT_SCORE"]
+    @comment.cloudflare_ja3_hash = request.env["HTTP_CF_JA3_HASH"]
+    @comment.cloudflare_ja4 = request.env["HTTP_CF_JA4"]
+    @comment.commentable = Comment.commentable_object(@commentable)
+    @controller_name = params[:controller_name]
+
+    # First, try saving the comment
+    if @comment.save
+      flash[:comment_notice] = if @comment.unreviewed?
+                                 # i18n-tasks-use t("comments.create.success.moderated.admin_post")
+                                 # i18n-tasks-use t("comments.create.success.moderated.work")
+                                 t("comments.create.success.moderated.#{@comment.ultimate_parent.model_name.i18n_key}")
+                               else
+                                 t("comments.create.success.not_moderated")
+                               end
+      respond_to do |format|
+        format.html do
+          if request.referer&.match(/inbox/)
+            redirect_to user_inbox_path(current_user, filters: filter_params, page: params[:page])
+          elsif request.referer&.match(/new/) || (@comment.unreviewed? && current_user)
+            # If the referer is the new comment page, go to the comment's page
+            # instead of reloading the full work.
+            # If the comment is unreviewed and commenter is logged in, take
+            # them to the comment's page so they can access the edit and
+            # delete options for the comment, since unreviewed comments don't
+            # appear on the commentable.
+            redirect_to comment_path(@comment)
+          elsif request.referer == root_url
+            # replying on the homepage
+            redirect_to root_path
+          elsif @comment.unreviewed?
+            redirect_to_all_comments(@commentable)
+          else
+            redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
           end
         end
-      else
-        flash[:error] = ts("Couldn't save comment!")
-        render action: "new"
       end
+    else
+      flash[:error] = ts("Couldn't save comment!")
+      render action: "new"
     end
   end
 
@@ -779,64 +780,66 @@ class CommentsController < ApplicationController
 
   def render_comment_form
     if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
+      flash[:error] = t("comments.new.missing_commentable")
       redirect_back_or_to root_path
     else
-      if params[:comment_content].present? || params[:comment].present?
-        comment_attrs = {
-          comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
-          pseud_id: params[:pseud_id] || params.dig(:comment, :pseud_id),
-          name: params[:name] || params.dig(:comment, :name),
-          email: params[:email] || params.dig(:comment, :email)
-        }
-        @comment = Comment.new(comment_attrs.compact)
-      else
-        @comment = Comment.new
-      end
+      @comment = build_comment_for_form
       @controller_name = params[:controller_name] if params[:controller_name]
       @name =
         case @commentable.class.name
-        when /Work/
+        when /Work/, /AdminPost/
           @commentable.title
         when /Chapter/
           @commentable.work.title
         when /Tag/
           @commentable.name
-        when /AdminPost/
-          @commentable.title
         when /Comment/
-          ts("Previous Comment")
+          t("comments.new.previous_comment")
         else
           @commentable.class.name
         end
     end
   end
 
-  def build_context_params
-    context = { comment_content: @comment.comment_content }
-    context[:pseud_id] = @comment.pseud_id if @comment.pseud_id
-    context[:name] = @comment.name if @comment.name
-    context[:email] = @comment.email if @comment.email
-    context[:view_full_work] = params[:view_full_work] if params[:view_full_work]
-    context[:page] = params[:page] if params[:page]
-    context[:controller_name] = params[:controller_name] if params[:controller_name]
+  def build_comment_for_form
+    if params[:comment_content].present? || params[:comment].present?
+      comment_attrs = {
+        comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
+        pseud_id: params[:pseud_id] || params.dig(:comment, :pseud_id),
+        name: params[:name] || params.dig(:comment, :name),
+        email: params[:email] || params.dig(:comment, :email)
+      }
+      Comment.new(comment_attrs.compact)
+    else
+      Comment.new
+    end
+  end
+
+  def build_comment_form_state
+    state = { comment_content: @comment.comment_content }
+    state[:pseud_id] = @comment.pseud_id if @comment.pseud_id
+    state[:name] = @comment.name if @comment.name
+    state[:email] = @comment.email if @comment.email
+    state[:view_full_work] = params[:view_full_work] if params[:view_full_work]
+    state[:page] = params[:page] if params[:page]
+    state[:controller_name] = params[:controller_name] if params[:controller_name]
 
     case @commentable
     when Work
-      context[:work_id] = @commentable.id
+      state[:work_id] = @commentable.id
     when Chapter
-      context[:chapter_id] = @commentable.id
+      state[:chapter_id] = @commentable.id
     when AdminPost
-      context[:admin_post_id] = @commentable.id
+      state[:admin_post_id] = @commentable.id
     when Tag
-      context[:tag_id] = @commentable.name
+      state[:tag_id] = @commentable.name
     when Comment
-      context[:comment_id] = @commentable.id
+      state[:comment_id] = @commentable.id
     end
 
-    context[:filters] = filter_params.to_h if controller_name == "inbox" && params[:filters]
+    state[:filters] = filter_params.to_h if controller_name == "inbox" && params[:filters]
 
-    context
+    state
   end
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,36 +1,36 @@
 class CommentsController < ApplicationController
   before_action :load_commentable,
-                only: [:index, :new, :draft, :create, :preview, :edit, :update, :show_comments,
+                only: [:index, :new, :create, :preview, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
-  before_action :check_user_status, only: [:new, :draft, :create, :preview, :edit, :update, :destroy]
+  before_action :check_user_status, only: [:new, :create, :preview, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
   before_action :check_if_restricted
   before_action :check_tag_wrangler_access
   before_action :check_parent_visible
   before_action :check_modify_parent,
-                only: [:new, :draft, :create, :preview, :edit, :update, :add_comment_reply,
+                only: [:new, :create, :preview, :edit, :update, :add_comment_reply,
                        :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update]
   before_action :check_permission_to_delete, only: [:delete_comment, :destroy]
-  before_action :check_guest_comment_admin_setting, only: [:new, :draft, :create, :preview, :add_comment_reply]
-  before_action :check_parent_comment_permissions, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_guest_comment_admin_setting, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_parent_comment_permissions, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
-  before_action :check_frozen, only: [:new, :draft, :create, :preview, :add_comment_reply]
-  before_action :check_hidden_by_admin, only: [:new, :draft, :create, :preview, :add_comment_reply]
-  before_action :check_not_replying_to_spam, only: [:new, :draft, :create, :preview, :add_comment_reply]
-  before_action :check_guest_replies_preference, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_frozen, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_hidden_by_admin, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
   before_action :check_permission_to_modify_frozen_status, only: [:freeze, :unfreeze]
   before_action :check_permission_to_modify_hidden_status, only: [:hide, :unhide]
   before_action :check_guest_email_is_from_suspended_or_banned_user, only: [:create]
-  before_action :admin_logout_required, only: [:new, :draft, :create, :add_comment_reply]
+  before_action :admin_logout_required, only: [:new, :create, :add_comment_reply]
   before_action :set_page_subtitle, only: [:index, :new, :show, :unreviewed]
 
   include WorksHelper
@@ -381,32 +381,6 @@ class CommentsController < ApplicationController
           @commentable.class.name
         end
     end
-  end
-
-  # POST /comments/draft
-  def draft
-    if @commentable.nil?
-      flash[:error] = t("comments.new.missing_commentable")
-      redirect_back_or_to root_path
-    else
-      @comment = build_comment_for_form
-      @controller_name = params[:controller_name] if params[:controller_name]
-      @name =
-        case @commentable.class.name
-        when /Work/, /AdminPost/
-          @commentable.title
-        when /Chapter/
-          @commentable.work.title
-        when /Tag/
-          @commentable.name
-        when /Comment/
-          t("comments.new.previous_comment")
-        else
-          @commentable.class.name
-        end
-    end
-
-    render :new
   end
 
   # GET /comments/1/edit

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -41,15 +41,15 @@ class CommentsController < ApplicationController
     parent = find_parent
 
     if blocked_by?(parent)
-      flash[:comment_error] = ts("Sorry, you have been blocked by one or more of this work's creators.")
+      flash[:comment_error] = t("comments.check_blocked.parent")
       redirect_to_all_comments(parent, show_comments: true)
     elsif @comment && blocked_by_comment?(@comment.commentable)
       # edit and update set @comment to the comment being edited
-      flash[:comment_error] = ts("Sorry, you have been blocked by that user.")
+      flash[:comment_error] = t("comments.check_blocked.reply")
       redirect_to_all_comments(parent, show_comments: true)
     elsif @comment.nil? && blocked_by_comment?(@commentable)
       # new, create, and add_comment_reply don't set @comment, but do set @commentable
-      flash[:comment_error] = ts("Sorry, you have been blocked by that user.")
+      flash[:comment_error] = t("comments.check_blocked.reply")
       redirect_to_all_comments(parent, show_comments: true)
     end
   end
@@ -113,12 +113,12 @@ class CommentsController < ApplicationController
     parent = find_parent
     # No one can create or update comments on something hidden by an admin.
     if parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
-      flash[:error] = ts("That work is hidden.")
+      flash[:error] = ts("Sorry, you can't add or edit comments on a hidden work.")
       redirect_to work_path(parent)
     end
     # No one can create or update comments on unrevealed works.
     if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
-      flash[:error] = ts("That work hasn't been revealed yet.")
+      flash[:error] = t("comments.check_modify_parent.draft")
       redirect_to work_path(parent)
     end
 
@@ -163,10 +163,10 @@ class CommentsController < ApplicationController
     end
 
     if parent.disable_all_comments?
-      flash[:error] = ts("You can't leave comments right now.")
+      flash[:error] = t("comments.commentable.permissions.#{translation_key}.disable_all")
       redirect_to parent
     elsif parent.disable_anon_comments? && !logged_in?
-      flash[:error] = ts("Anonymous users can't comment right now.")
+      flash[:error] = t("comments.commentable.permissions.#{translation_key}.disable_anon")
       redirect_to parent
     end
   end
@@ -176,14 +176,14 @@ class CommentsController < ApplicationController
 
     return unless admin_settings.guest_comments_off? && guest?
 
-    flash[:error] = ts("Sorry, the Archive doesn't allow guests to comment right now.")
+    flash[:error] = t("comments.commentable.guest_comments_disabled")
     redirect_back_or_to find_parent
   end
 
   def check_guest_replies_preference
     return unless guest? && @commentable.respond_to?(:guest_replies_disallowed?) && @commentable.guest_replies_disallowed?
 
-    flash[:error] = ts("Sorry, this user doesn't allow non-Archive users to reply to their comments.")
+    flash[:error] = t("comments.check_guest_replies_preference.error")
     redirect_back_or_to find_parent
   end
 
@@ -197,7 +197,7 @@ class CommentsController < ApplicationController
   def check_frozen
     return unless @commentable.respond_to?(:iced?) && @commentable.iced?
 
-    flash[:error] = ts("Sorry, you cannot reply to a frozen comment.")
+    flash[:error] = t("comments.check_frozen.error")
     redirect_back_or_to find_parent
   end
 
@@ -211,7 +211,7 @@ class CommentsController < ApplicationController
   def check_not_replying_to_spam
     return unless @commentable.respond_to?(:approved?) && !@commentable.approved?
 
-    flash[:error] = ts("Sorry, you can't reply to a comment that has been marked as spam.")
+    flash[:error] = t("comments.check_not_replying_to_spam.error")
     redirect_back_or_to find_parent
   end
 
@@ -251,10 +251,10 @@ class CommentsController < ApplicationController
   # Comments cannot be edited after they've been replied to or if they are frozen.
   def check_permission_to_edit
     if @comment.iced?
-      flash[:error] = ts("Frozen comments cannot be edited.")
+      flash[:error] = t("comments.check_permission_to_edit.error.frozen")
       redirect_back_or_to @comment
     elsif !@comment.count_all_comments.zero?
-      flash[:error] = t("comments.check_permission_to_edit.error.has_replies")
+      flash[:error] = ts("Comments with replies cannot be edited")
       redirect_back_or_to @comment
     end
   end
@@ -269,7 +269,7 @@ class CommentsController < ApplicationController
 
     # i18n-tasks-use t('comments.freeze.permission_denied')
     # i18n-tasks-use t('comments.unfreeze.permission_denied')
-    flash[:error] = ts("Sorry, that comment thread could not be frozen.")
+    flash[:error] = t("comments.#{action_name}.permission_denied")
     redirect_back_or_to @comment
   end
 
@@ -278,7 +278,7 @@ class CommentsController < ApplicationController
 
     # i18n-tasks-use t('comments.hide.permission_denied')
     # i18n-tasks-use t('comments.unhide.permission_denied')
-    flash[:error] = ts("Sorry, you don't have permission to modify that comment.")
+    flash[:error] = t("comments.#{action_name}.permission_denied")
     redirect_back_or_to @comment
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -41,15 +41,15 @@ class CommentsController < ApplicationController
     parent = find_parent
 
     if blocked_by?(parent)
-      flash[:comment_error] = t("comments.check_blocked.parent")
+      flash[:comment_error] = ts("Sorry, you have been blocked by one or more of this work's creators.")
       redirect_to_all_comments(parent, show_comments: true)
     elsif @comment && blocked_by_comment?(@comment.commentable)
       # edit and update set @comment to the comment being edited
-      flash[:comment_error] = t("comments.check_blocked.reply")
+      flash[:comment_error] = ts("Sorry, you have been blocked by that user.")
       redirect_to_all_comments(parent, show_comments: true)
     elsif @comment.nil? && blocked_by_comment?(@commentable)
       # new, create, and add_comment_reply don't set @comment, but do set @commentable
-      flash[:comment_error] = t("comments.check_blocked.reply")
+      flash[:comment_error] = ts("Sorry, you have been blocked by that user.")
       redirect_to_all_comments(parent, show_comments: true)
     end
   end
@@ -95,7 +95,7 @@ class CommentsController < ApplicationController
     return unless params[:comment][:pseud_id]
     pseud = Pseud.find(params[:comment][:pseud_id])
     return if pseud && current_user && current_user.pseuds.include?(pseud)
-    flash[:error] = t("comments.check_pseud_ownership.error")
+    flash[:error] = ts("You can't comment with that pseud.")
     redirect_to root_path
   end
 
@@ -113,19 +113,19 @@ class CommentsController < ApplicationController
     parent = find_parent
     # No one can create or update comments on something hidden by an admin.
     if parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin
-      flash[:error] = t("comments.commentable.permissions.work.hidden")
+      flash[:error] = ts("That work is hidden.")
       redirect_to work_path(parent)
     end
     # No one can create or update comments on unrevealed works.
     if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
-      flash[:error] = t("comments.commentable.permissions.work.unrevealed")
+      flash[:error] = ts("That work hasn't been revealed yet.")
       redirect_to work_path(parent)
     end
 
     # No one can create or update comments on unpublished (A.K.A. unposted) works.
     return unless parent.respond_to?(:posted) && !parent.posted
 
-    flash[:error] = t("comments.check_modify_parent.draft")
+    flash[:error] = ts("You can't comment on a draft.")
     redirect_to work_path(parent)
   end
 
@@ -163,10 +163,10 @@ class CommentsController < ApplicationController
     end
 
     if parent.disable_all_comments?
-      flash[:error] = t("comments.commentable.permissions.#{translation_key}.disable_all")
+      flash[:error] = ts("You can't leave comments right now.")
       redirect_to parent
     elsif parent.disable_anon_comments? && !logged_in?
-      flash[:error] = t("comments.commentable.permissions.#{translation_key}.disable_anon")
+      flash[:error] = ts("Anonymous users can't comment right now.")
       redirect_to parent
     end
   end
@@ -176,49 +176,49 @@ class CommentsController < ApplicationController
 
     return unless admin_settings.guest_comments_off? && guest?
 
-    flash[:error] = t("comments.commentable.guest_comments_disabled")
+    flash[:error] = ts("Sorry, the Archive doesn't allow guests to comment right now.")
     redirect_back_or_to find_parent
   end
 
   def check_guest_replies_preference
     return unless guest? && @commentable.respond_to?(:guest_replies_disallowed?) && @commentable.guest_replies_disallowed?
 
-    flash[:error] = t("comments.check_guest_replies_preference.error")
+    flash[:error] = ts("Sorry, this user doesn't allow non-Archive users to reply to their comments.")
     redirect_back_or_to find_parent
   end
 
   def check_unreviewed
     return unless @commentable.respond_to?(:unreviewed?) && @commentable.unreviewed?
 
-    flash[:error] = t("comments.check_unreviewed.error")
+    flash[:error] = ts("Sorry, you cannot reply to an unapproved comment.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
   def check_frozen
     return unless @commentable.respond_to?(:iced?) && @commentable.iced?
 
-    flash[:error] = t("comments.check_frozen.error")
+    flash[:error] = ts("Sorry, you cannot reply to a frozen comment.")
     redirect_back_or_to find_parent
   end
 
   def check_hidden_by_admin
     return unless @commentable.respond_to?(:hidden_by_admin?) && @commentable.hidden_by_admin?
 
-    flash[:error] = t("comments.check_hidden_by_admin.error")
+    flash[:error] = ts("Sorry, you cannot reply to a hidden comment.")
     redirect_back_or_to find_parent
   end
 
   def check_not_replying_to_spam
     return unless @commentable.respond_to?(:approved?) && !@commentable.approved?
 
-    flash[:error] = t("comments.check_not_replying_to_spam.error")
+    flash[:error] = ts("Sorry, you can't reply to a comment that has been marked as spam.")
     redirect_back_or_to find_parent
   end
 
   def check_permission_to_review
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent)
-    flash[:error] = t("comments.check_permission_to_review.error")
+    flash[:error] = ts("Sorry, you don't have permission to see those unreviewed comments.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
@@ -226,14 +226,14 @@ class CommentsController < ApplicationController
     return unless @comment.unreviewed?
     parent = find_parent
     return if logged_in_as_admin? || current_user_owns?(parent) || current_user_owns?(@comment)
-    flash[:error] = t("comments.check_permission_to_access_single_unreviewed.error")
+    flash[:error] = ts("Sorry, that comment is currently in moderation.")
     redirect_to logged_in? ? root_path : new_user_session_path(return_to: request.fullpath)
   end
 
   def check_permission_to_moderate
     return if logged_in_as_admin? || current_user_owns?(find_parent)
 
-    flash[:error] = t("comments.check_permission_to_moderate.error")
+    flash[:error] = ts("Sorry, you don't have permission to moderate that comment.")
     redirect_to(logged_in? ? root_path : new_user_session_path(return_to: comment_path(@comment)))
   end
 
@@ -251,7 +251,7 @@ class CommentsController < ApplicationController
   # Comments cannot be edited after they've been replied to or if they are frozen.
   def check_permission_to_edit
     if @comment.iced?
-      flash[:error] = t("comments.check_permission_to_edit.error.frozen")
+      flash[:error] = ts("Frozen comments cannot be edited.")
       redirect_back_or_to @comment
     elsif !@comment.count_all_comments.zero?
       flash[:error] = t("comments.check_permission_to_edit.error.has_replies")
@@ -269,7 +269,7 @@ class CommentsController < ApplicationController
 
     # i18n-tasks-use t('comments.freeze.permission_denied')
     # i18n-tasks-use t('comments.unfreeze.permission_denied')
-    flash[:error] = t("comments.#{action_name}.permission_denied")
+    flash[:error] = ts("Sorry, that comment thread could not be frozen.")
     redirect_back_or_to @comment
   end
 
@@ -278,7 +278,7 @@ class CommentsController < ApplicationController
 
     # i18n-tasks-use t('comments.hide.permission_denied')
     # i18n-tasks-use t('comments.unhide.permission_denied')
-    flash[:error] = t("comments.#{action_name}.permission_denied")
+    flash[:error] = ts("Sorry, you don't have permission to modify that comment.")
     redirect_back_or_to @comment
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -724,7 +724,7 @@ class CommentsController < ApplicationController
         redirect_to_comment(@comment, options)
       end
       format.js
-    end# Allow pre-populating from preview or edit forms
+    end
   end
 
   def cancel_comment_delete

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -365,8 +365,6 @@ class CommentsController < ApplicationController
       flash[:error] = ts("What did you want to comment on?")
       redirect_back_or_to root_path
     else
-      # Allow pre-populating from preview or edit forms
-      # Handle both flat params (from GET) and nested params (from POST)
       if params[:comment_content].present? || params[:comment].present?
         comment_attrs = {
           comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
@@ -416,23 +414,52 @@ class CommentsController < ApplicationController
     @comment = Comment.new(comment_params)
     @comment.commentable = Comment.commentable_object(@commentable)
 
-    # Set parent and unreviewed status for nested comments
     @comment.set_parent_and_unreviewed
 
-    # Validate to catch errors early
     unless @comment.valid?
       render :new, locals: { show_errors: true }
       return
     end
 
     @preview_mode = true
+    @context_params = build_context_params
     render :preview
+  end
+
+  private
+
+  def build_context_params
+    params = { comment_content: @comment.comment_content }
+    params[:pseud_id] = @comment.pseud_id if @comment.pseud_id
+    params[:name] = @comment.name if @comment.name
+    params[:email] = @comment.email if @comment.email
+    params[:view_full_work] = request.parameters[:view_full_work] if request.parameters[:view_full_work]
+    params[:page] = request.parameters[:page] if request.parameters[:page]
+    params[:controller_name] = request.parameters[:controller_name] if request.parameters[:controller_name]
+    
+    case @commentable
+    when Work
+      params[:work_id] = @commentable.id
+    when Chapter
+      params[:chapter_id] = @commentable.id
+    when AdminPost
+      params[:admin_post_id] = @commentable.id
+    when Tag
+      params[:tag_id] = @commentable.name
+    when Comment
+      params[:comment_id] = @commentable.id
+    end
+
+    if controller_name == "inbox" && request.parameters[:filters]
+      params[:filters] = request.parameters[:filters]
+    end
+
+    params
   end
 
   # POST /comments
   # POST /comments.xml
   def create
-    # Check if this is a preview request
     if params[:preview_button]
       preview
       return
@@ -728,7 +755,7 @@ class CommentsController < ApplicationController
         redirect_to_comment(@comment, options)
       end
       format.js
-    end
+    end# Allow pre-populating from preview or edit forms
   end
 
   def cancel_comment_delete

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,29 +1,29 @@
 class CommentsController < ApplicationController
   before_action :load_commentable,
-                only: [:index, :new, :back_to_edit, :create, :preview, :edit, :update, :show_comments,
+                only: [:index, :new, :create, :preview, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
-  before_action :check_user_status, only: [:new, :back_to_edit, :create, :preview, :edit, :update, :destroy]
+  before_action :check_user_status, only: [:new, :create, :preview, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
   before_action :check_if_restricted
   before_action :check_tag_wrangler_access
   before_action :check_parent_visible
   before_action :check_modify_parent,
-                only: [:new, :back_to_edit, :create, :preview, :edit, :update, :add_comment_reply,
+                only: [:new, :create, :preview, :edit, :update, :add_comment_reply,
                        :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update]
   before_action :check_permission_to_delete, only: [:delete_comment, :destroy]
-  before_action :check_guest_comment_admin_setting, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
-  before_action :check_parent_comment_permissions, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_guest_comment_admin_setting, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_parent_comment_permissions, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
-  before_action :check_frozen, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
-  before_action :check_hidden_by_admin, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
-  before_action :check_not_replying_to_spam, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
-  before_action :check_guest_replies_preference, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_frozen, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_hidden_by_admin, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
@@ -36,7 +36,7 @@ class CommentsController < ApplicationController
   include WorksHelper
   include BlockHelper
 
-  before_action :check_blocked, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply, :edit, :update]
+  before_action :check_blocked, only: [:new, :create, :preview, :add_comment_reply, :edit, :update]
   def check_blocked
     parent = find_parent
 
@@ -359,7 +359,8 @@ class CommentsController < ApplicationController
     params[:comment_id] = params[:id]
   end
 
-  # GET /comments/new
+  # GET /comments/new (blank form)
+  # POST /comments/new (form with preview data)
   def new
     if @commentable.nil?
       flash[:error] = t("comments.new.missing_commentable")
@@ -381,32 +382,6 @@ class CommentsController < ApplicationController
           @commentable.class.name
         end
     end
-  end
-
-  # POST /comments/preview/edit
-  def back_to_edit
-    if @commentable.nil?
-      flash[:error] = t("comments.new.missing_commentable")
-      redirect_back_or_to root_path
-    else
-      @comment = build_comment_for_form
-      @controller_name = params[:controller_name] if params[:controller_name]
-      @name =
-        case @commentable.class.name
-        when /Work/, /AdminPost/
-          @commentable.title
-        when /Chapter/
-          @commentable.work.title
-        when /Tag/
-          @commentable.name
-        when /Comment/
-          t("comments.new.previous_comment")
-        else
-          @commentable.class.name
-        end
-    end
-
-    render :new unless performed?
   end
 
   # GET /comments/1/edit
@@ -436,7 +411,29 @@ class CommentsController < ApplicationController
     end
 
     @preview_mode = true
-    @form_state = build_comment_form_state
+    @form_state = { comment_content: @comment.comment_content }
+    @form_state[:pseud_id] = @comment.pseud_id if @comment.pseud_id
+    @form_state[:name] = @comment.name if @comment.name
+    @form_state[:email] = @comment.email if @comment.email
+    @form_state[:view_full_work] = params[:view_full_work] if params[:view_full_work]
+    @form_state[:page] = params[:page] if params[:page]
+    @form_state[:controller_name] = params[:controller_name] if params[:controller_name]
+
+    case @commentable
+    when Work
+      @form_state[:work_id] = @commentable.id
+    when Chapter
+      @form_state[:chapter_id] = @commentable.id
+    when AdminPost
+      @form_state[:admin_post_id] = @commentable.id
+    when Tag
+      @form_state[:tag_id] = @commentable.name
+    when Comment
+      @form_state[:comment_id] = @commentable.id
+    end
+
+    @form_state[:filters] = filter_params.to_h if controller_name == "inbox" && params[:filters]
+
     render :preview
   end
 
@@ -829,33 +826,6 @@ class CommentsController < ApplicationController
     else
       Comment.new
     end
-  end
-
-  def build_comment_form_state
-    state = { comment_content: @comment.comment_content }
-    state[:pseud_id] = @comment.pseud_id if @comment.pseud_id
-    state[:name] = @comment.name if @comment.name
-    state[:email] = @comment.email if @comment.email
-    state[:view_full_work] = params[:view_full_work] if params[:view_full_work]
-    state[:page] = params[:page] if params[:page]
-    state[:controller_name] = params[:controller_name] if params[:controller_name]
-
-    case @commentable
-    when Work
-      state[:work_id] = @commentable.id
-    when Chapter
-      state[:chapter_id] = @commentable.id
-    when AdminPost
-      state[:admin_post_id] = @commentable.id
-    when Tag
-      state[:tag_id] = @commentable.name
-    when Comment
-      state[:comment_id] = @commentable.id
-    end
-
-    state[:filters] = filter_params.to_h if controller_name == "inbox" && params[:filters]
-
-    state
   end
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -426,37 +426,6 @@ class CommentsController < ApplicationController
     render :preview
   end
 
-  private
-
-  def build_context_params
-    params = { comment_content: @comment.comment_content }
-    params[:pseud_id] = @comment.pseud_id if @comment.pseud_id
-    params[:name] = @comment.name if @comment.name
-    params[:email] = @comment.email if @comment.email
-    params[:view_full_work] = request.parameters[:view_full_work] if request.parameters[:view_full_work]
-    params[:page] = request.parameters[:page] if request.parameters[:page]
-    params[:controller_name] = request.parameters[:controller_name] if request.parameters[:controller_name]
-    
-    case @commentable
-    when Work
-      params[:work_id] = @commentable.id
-    when Chapter
-      params[:chapter_id] = @commentable.id
-    when AdminPost
-      params[:admin_post_id] = @commentable.id
-    when Tag
-      params[:tag_id] = @commentable.name
-    when Comment
-      params[:comment_id] = @commentable.id
-    end
-
-    if controller_name == "inbox" && request.parameters[:filters]
-      params[:filters] = request.parameters[:filters]
-    end
-
-    params
-  end
-
   # POST /comments
   # POST /comments.xml
   def create
@@ -832,6 +801,35 @@ class CommentsController < ApplicationController
   end
 
   private
+
+  def build_context_params
+    context = { comment_content: @comment.comment_content }
+    context[:pseud_id] = @comment.pseud_id if @comment.pseud_id
+    context[:name] = @comment.name if @comment.name
+    context[:email] = @comment.email if @comment.email
+    context[:view_full_work] = params[:view_full_work] if params[:view_full_work]
+    context[:page] = params[:page] if params[:page]
+    context[:controller_name] = params[:controller_name] if params[:controller_name]
+
+    case @commentable
+    when Work
+      context[:work_id] = @commentable.id
+    when Chapter
+      context[:chapter_id] = @commentable.id
+    when AdminPost
+      context[:admin_post_id] = @commentable.id
+    when Tag
+      context[:tag_id] = @commentable.name
+    when Comment
+      context[:comment_id] = @commentable.id
+    end
+
+    if controller_name == "inbox" && params[:filters]
+      context[:filters] = filter_params.to_h
+    end
+
+    context
+  end
 
   def comment_params
     params.require(:comment).permit(

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,29 +1,29 @@
 class CommentsController < ApplicationController
   before_action :load_commentable,
-                only: [:index, :new, :create, :preview, :edit, :update, :show_comments,
+                only: [:index, :new, :back_to_edit, :create, :preview, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
-  before_action :check_user_status, only: [:new, :create, :preview, :edit, :update, :destroy]
+  before_action :check_user_status, only: [:new, :back_to_edit, :create, :preview, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
   before_action :check_if_restricted
   before_action :check_tag_wrangler_access
   before_action :check_parent_visible
   before_action :check_modify_parent,
-                only: [:new, :create, :preview, :edit, :update, :add_comment_reply,
+                only: [:new, :back_to_edit, :create, :preview, :edit, :update, :add_comment_reply,
                        :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update]
   before_action :check_permission_to_delete, only: [:delete_comment, :destroy]
-  before_action :check_guest_comment_admin_setting, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_parent_comment_permissions, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_guest_comment_admin_setting, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_parent_comment_permissions, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
-  before_action :check_frozen, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_hidden_by_admin, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_not_replying_to_spam, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_guest_replies_preference, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_frozen, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_hidden_by_admin, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
@@ -36,7 +36,7 @@ class CommentsController < ApplicationController
   include WorksHelper
   include BlockHelper
 
-  before_action :check_blocked, only: [:new, :create, :preview, :add_comment_reply, :edit, :update]
+  before_action :check_blocked, only: [:new, :back_to_edit, :create, :preview, :add_comment_reply, :edit, :update]
   def check_blocked
     parent = find_parent
 
@@ -361,38 +361,13 @@ class CommentsController < ApplicationController
 
   # GET /comments/new
   def new
-    if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
-      redirect_back_or_to root_path
-    else
-      if params[:comment_content].present? || params[:comment].present?
-        comment_attrs = {
-          comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
-          pseud_id: params[:pseud_id] || params.dig(:comment, :pseud_id),
-          name: params[:name] || params.dig(:comment, :name),
-          email: params[:email] || params.dig(:comment, :email)
-        }
-        @comment = Comment.new(comment_attrs.compact)
-      else
-        @comment = Comment.new
-      end
-      @controller_name = params[:controller_name] if params[:controller_name]
-      @name =
-        case @commentable.class.name
-        when /Work/
-          @commentable.title
-        when /Chapter/
-          @commentable.work.title
-        when /Tag/
-          @commentable.name
-        when /AdminPost/
-          @commentable.title
-        when /Comment/
-          ts("Previous Comment")
-        else
-          @commentable.class.name
-        end
-    end
+    render_comment_form
+  end
+
+  # POST /comments/back_to_edit
+  def back_to_edit
+    render_comment_form
+    render :new unless performed?
   end
 
   # GET /comments/1/edit
@@ -801,6 +776,41 @@ class CommentsController < ApplicationController
   end
 
   private
+
+  def render_comment_form
+    if @commentable.nil?
+      flash[:error] = ts("What did you want to comment on?")
+      redirect_back_or_to root_path
+    else
+      if params[:comment_content].present? || params[:comment].present?
+        comment_attrs = {
+          comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
+          pseud_id: params[:pseud_id] || params.dig(:comment, :pseud_id),
+          name: params[:name] || params.dig(:comment, :name),
+          email: params[:email] || params.dig(:comment, :email)
+        }
+        @comment = Comment.new(comment_attrs.compact)
+      else
+        @comment = Comment.new
+      end
+      @controller_name = params[:controller_name] if params[:controller_name]
+      @name =
+        case @commentable.class.name
+        when /Work/
+          @commentable.title
+        when /Chapter/
+          @commentable.work.title
+        when /Tag/
+          @commentable.name
+        when /AdminPost/
+          @commentable.title
+        when /Comment/
+          ts("Previous Comment")
+        else
+          @commentable.class.name
+        end
+    end
+  end
 
   def build_context_params
     context = { comment_content: @comment.comment_content }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -118,14 +118,14 @@ class CommentsController < ApplicationController
     end
     # No one can create or update comments on unrevealed works.
     if parent.respond_to?(:in_unrevealed_collection) && parent.in_unrevealed_collection
-      flash[:error] = t("comments.check_modify_parent.draft")
+      flash[:error] = ts("Sorry, you can't add or edit comments on an unrevealed work.")
       redirect_to work_path(parent)
     end
 
     # No one can create or update comments on unpublished (A.K.A. unposted) works.
     return unless parent.respond_to?(:posted) && !parent.posted
 
-    flash[:error] = ts("You can't comment on a draft.")
+    flash[:error] = t("comments.check_modify_parent.draft")
     redirect_to work_path(parent)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,36 +1,36 @@
 class CommentsController < ApplicationController
   before_action :load_commentable,
-                only: [:index, :new, :create, :preview, :edit, :update, :show_comments,
+                only: [:index, :new, :draft, :create, :preview, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
-  before_action :check_user_status, only: [:new, :create, :preview, :edit, :update, :destroy]
+  before_action :check_user_status, only: [:new, :draft, :create, :preview, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
   before_action :check_if_restricted
   before_action :check_tag_wrangler_access
   before_action :check_parent_visible
   before_action :check_modify_parent,
-                only: [:new, :create, :preview, :edit, :update, :add_comment_reply,
+                only: [:new, :draft, :create, :preview, :edit, :update, :add_comment_reply,
                        :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update]
   before_action :check_permission_to_delete, only: [:delete_comment, :destroy]
-  before_action :check_guest_comment_admin_setting, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_parent_comment_permissions, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_guest_comment_admin_setting, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_parent_comment_permissions, only: [:new, :draft, :create, :preview, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
-  before_action :check_frozen, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_hidden_by_admin, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_not_replying_to_spam, only: [:new, :create, :preview, :add_comment_reply]
-  before_action :check_guest_replies_preference, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_frozen, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_hidden_by_admin, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :draft, :create, :preview, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :draft, :create, :preview, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
   before_action :check_permission_to_modify_frozen_status, only: [:freeze, :unfreeze]
   before_action :check_permission_to_modify_hidden_status, only: [:hide, :unhide]
   before_action :check_guest_email_is_from_suspended_or_banned_user, only: [:create]
-  before_action :admin_logout_required, only: [:new, :create, :add_comment_reply]
+  before_action :admin_logout_required, only: [:new, :draft, :create, :add_comment_reply]
   before_action :set_page_subtitle, only: [:index, :new, :show, :unreviewed]
 
   include WorksHelper
@@ -359,8 +359,7 @@ class CommentsController < ApplicationController
     params[:comment_id] = params[:id]
   end
 
-  # GET /comments/new (blank form)
-  # POST /comments/new (form with preview data)
+  # GET /comments/new
   def new
     if @commentable.nil?
       flash[:error] = t("comments.new.missing_commentable")
@@ -382,6 +381,32 @@ class CommentsController < ApplicationController
           @commentable.class.name
         end
     end
+  end
+
+  # POST /comments/draft
+  def draft
+    if @commentable.nil?
+      flash[:error] = t("comments.new.missing_commentable")
+      redirect_back_or_to root_path
+    else
+      @comment = build_comment_for_form
+      @controller_name = params[:controller_name] if params[:controller_name]
+      @name =
+        case @commentable.class.name
+        when /Work/, /AdminPost/
+          @commentable.title
+        when /Chapter/
+          @commentable.work.title
+        when /Tag/
+          @commentable.name
+        when /Comment/
+          t("comments.new.previous_comment")
+        else
+          @commentable.class.name
+        end
+    end
+
+    render :new
   end
 
   # GET /comments/1/edit

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -445,7 +445,7 @@ class CommentsController < ApplicationController
       return
     end
 
-    unless @commentable.present?
+    if @commentable.blank?
       flash[:error] = t("comments.create.missing_commentable")
       redirect_back_or_to root_path
       return

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -361,12 +361,51 @@ class CommentsController < ApplicationController
 
   # GET /comments/new
   def new
-    render_comment_form
+    if @commentable.nil?
+      flash[:error] = t("comments.new.missing_commentable")
+      redirect_back_or_to root_path
+    else
+      @comment = build_comment_for_form
+      @controller_name = params[:controller_name] if params[:controller_name]
+      @name =
+        case @commentable.class.name
+        when /Work/, /AdminPost/
+          @commentable.title
+        when /Chapter/
+          @commentable.work.title
+        when /Tag/
+          @commentable.name
+        when /Comment/
+          t("comments.new.previous_comment")
+        else
+          @commentable.class.name
+        end
+    end
   end
 
   # POST /comments/preview/edit
   def back_to_edit
-    render_comment_form
+    if @commentable.nil?
+      flash[:error] = t("comments.new.missing_commentable")
+      redirect_back_or_to root_path
+    else
+      @comment = build_comment_for_form
+      @controller_name = params[:controller_name] if params[:controller_name]
+      @name =
+        case @commentable.class.name
+        when /Work/, /AdminPost/
+          @commentable.title
+        when /Chapter/
+          @commentable.work.title
+        when /Tag/
+          @commentable.name
+        when /Comment/
+          t("comments.new.previous_comment")
+        else
+          @commentable.class.name
+        end
+    end
+
     render :new unless performed?
   end
 
@@ -777,29 +816,6 @@ class CommentsController < ApplicationController
   end
 
   private
-
-  def load_comment_form
-    if @commentable.nil?
-      flash[:error] = t("comments.new.missing_commentable")
-      redirect_back_or_to root_path
-    else
-      @comment = build_comment_for_form
-      @controller_name = params[:controller_name] if params[:controller_name]
-      @name =
-        case @commentable.class.name
-        when /Work/, /AdminPost/
-          @commentable.title
-        when /Chapter/
-          @commentable.work.title
-        when /Tag/
-          @commentable.name
-        when /Comment/
-          t("comments.new.previous_comment")
-        else
-          @commentable.class.name
-        end
-    end
-  end
 
   def build_comment_for_form
     if params[:comment_content].present? || params[:comment].present?

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,29 +1,29 @@
 class CommentsController < ApplicationController
   before_action :load_commentable,
-                only: [:index, :new, :create, :edit, :update, :show_comments,
+                only: [:index, :new, :create, :preview, :edit, :update, :show_comments,
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
-  before_action :check_user_status, only: [:new, :create, :edit, :update, :destroy]
+  before_action :check_user_status, only: [:new, :create, :preview, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
   before_action :check_if_restricted
   before_action :check_tag_wrangler_access
   before_action :check_parent_visible
   before_action :check_modify_parent,
-                only: [:new, :create, :edit, :update, :add_comment_reply,
+                only: [:new, :create, :preview, :edit, :update, :add_comment_reply,
                        :cancel_comment_reply, :cancel_comment_edit]
   before_action :check_pseud_ownership, only: [:create, :update]
   before_action :check_ownership, only: [:edit, :update, :cancel_comment_edit]
   before_action :check_permission_to_edit, only: [:edit, :update]
   before_action :check_permission_to_delete, only: [:delete_comment, :destroy]
-  before_action :check_guest_comment_admin_setting, only: [:new, :create, :add_comment_reply]
-  before_action :check_parent_comment_permissions, only: [:new, :create, :add_comment_reply]
+  before_action :check_guest_comment_admin_setting, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_parent_comment_permissions, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_unreviewed, only: [:add_comment_reply]
-  before_action :check_frozen, only: [:new, :create, :add_comment_reply]
-  before_action :check_hidden_by_admin, only: [:new, :create, :add_comment_reply]
-  before_action :check_not_replying_to_spam, only: [:new, :create, :add_comment_reply]
-  before_action :check_guest_replies_preference, only: [:new, :create, :add_comment_reply]
+  before_action :check_frozen, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_hidden_by_admin, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_not_replying_to_spam, only: [:new, :create, :preview, :add_comment_reply]
+  before_action :check_guest_replies_preference, only: [:new, :create, :preview, :add_comment_reply]
   before_action :check_permission_to_review, only: [:unreviewed]
   before_action :check_permission_to_access_single_unreviewed, only: [:show]
   before_action :check_permission_to_moderate, only: [:approve, :reject]
@@ -36,7 +36,7 @@ class CommentsController < ApplicationController
   include WorksHelper
   include BlockHelper
 
-  before_action :check_blocked, only: [:new, :create, :add_comment_reply, :edit, :update]
+  before_action :check_blocked, only: [:new, :create, :preview, :add_comment_reply, :edit, :update]
   def check_blocked
     parent = find_parent
 
@@ -365,7 +365,19 @@ class CommentsController < ApplicationController
       flash[:error] = ts("What did you want to comment on?")
       redirect_back_or_to root_path
     else
-      @comment = Comment.new
+      # Allow pre-populating from preview or edit forms
+      # Handle both flat params (from GET) and nested params (from POST)
+      if params[:comment_content].present? || params[:comment].present?
+        comment_attrs = {
+          comment_content: params[:comment_content] || params.dig(:comment, :comment_content),
+          pseud_id: params[:pseud_id] || params.dig(:comment, :pseud_id),
+          name: params[:name] || params.dig(:comment, :name),
+          email: params[:email] || params.dig(:comment, :email)
+        }
+        @comment = Comment.new(comment_attrs.compact)
+      else
+        @comment = Comment.new
+      end
       @controller_name = params[:controller_name] if params[:controller_name]
       @name =
         case @commentable.class.name
@@ -393,9 +405,39 @@ class CommentsController < ApplicationController
     end
   end
 
+  # GET /comments/preview
+  def preview
+    if @commentable.nil?
+      flash[:error] = ts("What did you want to comment on?")
+      redirect_back_or_to root_path
+      return
+    end
+
+    @comment = Comment.new(comment_params)
+    @comment.commentable = Comment.commentable_object(@commentable)
+
+    # Set parent and unreviewed status for nested comments
+    @comment.set_parent_and_unreviewed
+
+    # Validate to catch errors early
+    unless @comment.valid?
+      render :new, locals: { show_errors: true }
+      return
+    end
+
+    @preview_mode = true
+    render :preview
+  end
+
   # POST /comments
   # POST /comments.xml
   def create
+    # Check if this is a preview request
+    if params[:preview_button]
+      preview
+      return
+    end
+
     if @commentable.nil?
       flash[:error] = ts("What did you want to comment on?")
       redirect_back_or_to root_path

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -204,7 +204,7 @@ class CommentsController < ApplicationController
   def check_hidden_by_admin
     return unless @commentable.respond_to?(:hidden_by_admin?) && @commentable.hidden_by_admin?
 
-    flash[:error] = ts("Sorry, you cannot reply to a hidden comment.")
+    flash[:error] = t("comments.check_hidden_by_admin.error")
     redirect_back_or_to find_parent
   end
 
@@ -501,7 +501,7 @@ class CommentsController < ApplicationController
   def update
     updated_comment_params = comment_params.merge(edited_at: Time.current)
     if @comment.update(updated_comment_params)
-      flash[:comment_notice] = t("comments.update.success")
+      flash[:comment_notice] = ts('Comment was successfully updated.')
       respond_to do |format|
         format.html do
           redirect_to comment_path(@comment) and return if @comment.unreviewed?
@@ -525,17 +525,17 @@ class CommentsController < ApplicationController
 
     if !@comment.destroy_or_mark_deleted
       # something went wrong?
-      flash[:comment_error] = t("comments.destroy.error")
+      flash[:comment_error] = ts("We couldn't delete that comment.")
       redirect_to_comment(@comment)
     elsif unreviewed
       # go back to the rest of the unreviewed comments
-      flash[:notice] = t("comments.destroy.success")
+      flash[:notice] = ts("Comment deleted.")
       redirect_back_or_to unreviewed_work_comments_path(@comment.commentable)
     elsif parent_comment
-      flash[:comment_notice] = t("comments.destroy.success")
+      flash[:comment_notice] = ts("Comment deleted.")
       redirect_to_comment(parent_comment)
     else
-      flash[:comment_notice] = t("comments.destroy.success")
+      flash[:comment_notice] = ts("Comment deleted.")
       redirect_to_all_comments(parent, {show_comments: true})
     end
   end
@@ -552,7 +552,7 @@ class CommentsController < ApplicationController
     @comment.toggle!(:unreviewed)
     # mark associated inbox comments as read
     InboxComment.where(user_id: current_user.id, feedback_comment_id: @comment.id).update_all(read: true) unless logged_in_as_admin?
-    flash[:notice] = t("comments.review.success")
+    flash[:notice] = ts("Comment approved.")
     respond_to do |format|
       format.html do
         if params[:approved_from] == "inbox"

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -102,6 +102,7 @@
             maximum_length: ArchiveConfig.COMMENT_MAX,
             tooLongMessage: t(".comment_too_long", count: ArchiveConfig.COMMENT_MAX) %>
       <p class="submit actions">
+          <%= f.submit t(".preview_button"), name: "preview_button", id: "comment_preview_for_#{commentable.id}" %>
           <%= f.submit button_name, id: "comment_submit_for_#{commentable.id}", data: { disable_with: t(".processing_message") } %>
           <% if controller.controller_name == 'inbox' %>
             <a name="comment_cancel" id="comment_cancel"><%= t(".cancel_action") %></a>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -105,7 +105,7 @@
           <%= f.submit t(".preview_button"), name: "preview_button", id: "comment_preview_for_#{commentable.id}" %>
           <%= f.submit button_name, id: "comment_submit_for_#{commentable.id}", data: { disable_with: t(".processing_message") } %>
           <% if local_assigns[:cancel_redirect] %>
-            <%= link_to ts("Cancel"), local_assigns[:cancel_path], data: { confirm: ts("You will lose any changes you have made. Are you sure?") } %>
+            <%= link_to t(".cancel_action"), local_assigns[:cancel_path], data: { confirm: t(".cancel_redirect_warning") } %>
           <% elsif controller.controller_name == 'inbox' %>
             <a name="comment_cancel" id="comment_cancel"><%= t(".cancel_action") %></a>
           <% elsif comment.persisted? %>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -104,7 +104,9 @@
       <p class="submit actions">
           <%= f.submit t(".preview_button"), name: "preview_button", id: "comment_preview_for_#{commentable.id}" %>
           <%= f.submit button_name, id: "comment_submit_for_#{commentable.id}", data: { disable_with: t(".processing_message") } %>
-          <% if controller.controller_name == 'inbox' %>
+          <% if local_assigns[:cancel_redirect] %>
+            <%= link_to ts("Cancel"), local_assigns[:cancel_path], data: { confirm: ts("You will lose any changes you have made. Are you sure?") } %>
+          <% elsif controller.controller_name == 'inbox' %>
             <a name="comment_cancel" id="comment_cancel"><%= t(".cancel_action") %></a>
           <% elsif comment.persisted? %>
             <%= cancel_edit_comment_link(comment) %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -7,7 +7,7 @@
     <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
       <h4 class="heading byline">
         <% if @comment.by_anonymous_creator? %>
-          <%= ts("Anonymous Creator") %>
+          <%= t(".anonymous_creator") %>
         <% else %>
           <%= get_commenter_pseud_or_name(@comment) %>
         <% end %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -37,7 +37,7 @@
 <!--action buttons-->
 <ul class="actions right">
   <%= form_with url: back_to_edit_comments_path, method: :post, local: true do |f| %>
-    <% @context_params.each do |key, value| %>
+    <% @form_state.each do |key, value| %>
       <% if value.is_a?(Hash) %>
         <% value.each do |sub_key, sub_value| %>
           <%= hidden_field_tag "#{key}[#{sub_key}]", sub_value %>
@@ -59,7 +59,7 @@
       <%= f.hidden_field :email %>
     <% end %>
 
-    <% @context_params.each do |key, value| %>
+    <% @form_state.each do |key, value| %>
       <% next if key.in?([:comment_content, :pseud_id, :name, :email]) %>
       <% if value.is_a?(Hash) %>
         <% value.each do |sub_key, sub_value| %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -36,7 +36,7 @@
 
 <!--action buttons-->
 <ul class="actions right">
-  <%= form_with url: new_comment_path, method: :post, local: true do |f| %>
+  <%= form_with url: draft_comments_path, method: :post, local: true do |f| %>
     <% @form_state.each do |key, value| %>
       <% if value.is_a?(Hash) %>
         <% value.each do |sub_key, sub_value| %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -103,7 +103,7 @@
 <div id="edit_comment_on_preview">
   <h3 class="heading"><%= t(".edit_comment_heading") %></h3>
   <% cancel_target = @commentable.is_a?(Comment) ? @commentable.ultimate_parent : @commentable %>
-  <%= render partial: 'comments/comment_form',
+  <%= render partial: "comments/comment_form",
         locals: {
           comment: @comment,
           commentable: @commentable,

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -39,7 +39,7 @@
 
   <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
     <%= f.hidden_field :comment_content %>
-    
+
     <% if @comment.pseud_id %>
       <%= f.hidden_field :pseud_id %>
     <% elsif @comment.name %>
@@ -48,8 +48,14 @@
     <% end %>
 
     <% @context_params.each do |key, value| %>
-      <% next if key.in?(:comment_content, :pseud_id, :name, :email) %>
-      <%= hidden_field_tag key, value %>
+      <% next if key.in?([:comment_content, :pseud_id, :name, :email]) %>
+      <% if value.is_a?(Hash) %>
+        <% value.each do |sub_key, sub_value| %>
+          <%= hidden_field_tag "#{key}[#{sub_key}]", sub_value %>
+        <% end %>
+      <% else %>
+        <%= hidden_field_tag key, value %>
+      <% end %>
     <% end %>
 
     <%= f.submit t(".post_comment"), class: "button submit" %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -1,4 +1,5 @@
 <h2 class="heading"><%= t(".page_heading") %></h2>
+<p><%= t(".commenting_on", commentable_link: link_to_comment_ultimate_parent(@comment)) %></p>
 
 <!--main content-->
 <div id="previewpane">

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -1,0 +1,123 @@
+<!--Descriptive page name, messages and instructions-->
+<h2 class="heading"><%= t(".page_heading") %></h2>
+<%# error_messages_for :comment %>
+<!--/descriptions-->
+
+<!--main content-->
+<div id="previewpane">
+  <ul class="comment-list">
+    <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
+      <h4 class="heading byline">
+        <% if @comment.by_anonymous_creator? %>
+          <%= ts("Anonymous Creator") %>
+        <% else %>
+          <%= get_commenter_pseud_or_name(@comment) %>
+        <% end %>
+        <span class="posted datetime">
+          <%= time_in_zone(Time.current) %>
+        </span>
+      </h4>
+      <div class="icon">
+        <% if !@comment.pseud.nil? %>
+          <% if @comment.by_anonymous_creator? %>
+            <span class="anonymous icon"><!-- anonymous creator icon holder --></span>
+          <% else %>
+            <%= icon_display(@comment.pseud.user, @comment.pseud) %>
+          <% end %>
+        <% else %>
+          <span class="visitor icon"><!-- visitor icon holder --></span>
+        <% end %>
+      </div>
+      <blockquote class="userstuff">
+        <%= raw sanitize_field(@comment, :comment_content) %>
+      </blockquote>
+    </li>
+  </ul>
+</div>
+<!--/content-->
+
+<!-- Action buttons -->
+<div class="actions right">
+  <%# Back to Edit - submit form with all data to repopulate the form %>
+  <%= form_with url: new_comment_path, method: :get, local: true, html: { id: "back_to_edit_form" } do |f| %>
+    <%# Use hidden_field_tag for all fields to ensure flat params %>
+    <%= hidden_field_tag :comment_content, @comment.comment_content %>
+    
+    <% if @comment.pseud_id %>
+      <%= hidden_field_tag :pseud_id, @comment.pseud_id %>
+    <% elsif @comment.name %>
+      <%= hidden_field_tag :name, @comment.name %>
+      <%= hidden_field_tag :email, @comment.email %>
+    <% end %>
+
+    <%# Preserve commentable context - use hidden_field_tag for non-nested params %>
+    <% if @commentable.is_a?(Work) %>
+      <%= hidden_field_tag :work_id, @commentable.id %>
+    <% elsif @commentable.is_a?(Chapter) %>
+      <%= hidden_field_tag :chapter_id, @commentable.id %>
+    <% elsif @commentable.is_a?(AdminPost) %>
+      <%= hidden_field_tag :admin_post_id, @commentable.id %>
+    <% elsif @commentable.is_a?(Tag) %>
+      <%= hidden_field_tag :tag_id, @commentable.name %>
+    <% elsif @commentable.is_a?(Comment) %>
+      <%= hidden_field_tag :comment_id, @commentable.id %>
+    <% end %>
+
+    <%# Preserve contextual params %>
+    <% if params[:view_full_work] %>
+      <%= hidden_field_tag :view_full_work, params[:view_full_work] %>
+    <% end %>
+    <% if params[:page] %>
+      <%= hidden_field_tag :page, params[:page] %>
+    <% end %>
+    <% if controller.controller_name == "inbox" && params[:filters] %>
+      <%= hidden_field_tag "filters[read]", params[:filters][:read] %>
+      <%= hidden_field_tag "filters[replied_to]", params[:filters][:replied_to] %>
+      <%= hidden_field_tag "filters[date]", params[:filters][:date] %>
+    <% end %>
+    <%= hidden_field_tag :controller_name, @controller_name if @controller_name %>
+
+    <%= submit_tag t(".back_to_edit"), class: "button" %>
+  <% end %>
+
+  <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
+    <%= f.hidden_field :comment_content %>
+    
+    <% if @comment.pseud_id %>
+      <%= f.hidden_field :pseud_id %>
+    <% elsif @comment.name %>
+      <%= f.hidden_field :name %>
+      <%= f.hidden_field :email %>
+    <% end %>
+
+    <%# Preserve commentable context - use hidden_field_tag for non-nested params %>
+    <% if @commentable.is_a?(Work) %>
+      <%= hidden_field_tag :work_id, @commentable.id %>
+    <% elsif @commentable.is_a?(Chapter) %>
+      <%= hidden_field_tag :chapter_id, @commentable.id %>
+    <% elsif @commentable.is_a?(AdminPost) %>
+      <%= hidden_field_tag :admin_post_id, @commentable.id %>
+    <% elsif @commentable.is_a?(Tag) %>
+      <%= hidden_field_tag :tag_id, @commentable.name %>
+    <% elsif @commentable.is_a?(Comment) %>
+      <%= hidden_field_tag :comment_id, @commentable.id %>
+    <% end %>
+
+    <%# Preserve contextual params %>
+    <% if params[:view_full_work] %>
+      <%= hidden_field_tag :view_full_work, params[:view_full_work] %>
+    <% end %>
+    <% if params[:page] %>
+      <%= hidden_field_tag :page, params[:page] %>
+    <% end %>
+    <% if controller.controller_name == "inbox" && params[:filters] %>
+      <%= hidden_field_tag "filters[read]", params[:filters][:read] %>
+      <%= hidden_field_tag "filters[replied_to]", params[:filters][:replied_to] %>
+      <%= hidden_field_tag "filters[date]", params[:filters][:date] %>
+    <% end %>
+    <%= hidden_field_tag :controller_name, @controller_name if @controller_name %>
+
+    <%= f.submit t(".post_comment"), class: "button submit" %>
+  <% end %>
+</div>
+<!--/actions-->

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -2,7 +2,7 @@
 
 <!--main content-->
 <div id="previewpane">
-  <ul class="comment-list">
+  <ol class="thread">
     <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
       <h4 class="heading byline">
         <% if @comment.by_anonymous_creator? %>
@@ -15,7 +15,7 @@
         </span>
       </h4>
       <div class="icon">
-        <% if !@comment.pseud.nil? %>
+        <% if @comment.pseud %>
           <% if @comment.by_anonymous_creator? %>
             <span class="anonymous icon"></span>
           <% else %>
@@ -29,12 +29,12 @@
         <%= raw sanitize_field(@comment, :comment_content) %>
       </blockquote>
     </li>
-  </ul>
+  </ol>
 </div>
 <!--/content-->
 
 <!--action buttons-->
-<div class="actions right">
+<ul class="actions">
   <%= link_to t(".back_to_edit"), new_comment_path(@context_params), class: "button" %>
 
   <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
@@ -60,5 +60,5 @@
 
     <%= f.submit t(".post_comment"), class: "button submit" %>
   <% end %>
-</div>
+</ul>
 <!--/actions-->

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -36,7 +36,7 @@
 
 <!--action buttons-->
 <ul class="actions right">
-  <%= form_with url: preview_edit_comments_path, method: :post, local: true do |f| %>
+  <%= form_with url: new_comment_path, method: :post, local: true do |f| %>
     <% @form_state.each do |key, value| %>
       <% if value.is_a?(Hash) %>
         <% value.each do |sub_key, sub_value| %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -102,10 +102,13 @@
 <!--inline edit form-->
 <div id="edit_comment_on_preview">
   <h3 class="heading"><%= t(".edit_comment_heading") %></h3>
+  <% cancel_target = @commentable.is_a?(Comment) ? @commentable.ultimate_parent : @commentable %>
   <%= render partial: 'comments/comment_form',
         locals: {
           comment: @comment,
           commentable: @commentable,
-          button_name: t(".post_comment")
+          button_name: t(".post_comment"),
+          cancel_redirect: true,
+          cancel_path: cancel_target.is_a?(Tag) ? tag_path(cancel_target) : polymorphic_path(cancel_target)
         } %>
 </div>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -4,73 +4,108 @@
 <!--main content-->
 <div id="previewpane">
   <ol class="thread">
-    <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
-      <h4 class="heading byline">
-        <% if @comment.by_anonymous_creator? %>
-          <%= t(".anonymous_creator") %>
+    <% if @commentable.is_a?(Comment) %>
+      <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@commentable) %>" id="comment_<%= @commentable.id %>" role="article">
+        <% if @commentable.is_deleted %>
+          <p><%= ts("(Previous comment deleted.)") %></p>
+        <% elsif !can_see_hidden_comment?(@commentable) %>
+          <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
         <% else %>
-          <%= get_commenter_pseud_or_name(@comment) %>
+          <h4 class="heading byline">
+            <% if @commentable.by_anonymous_creator? %>
+              <%= ts("Anonymous Creator") %>
+            <% else %>
+              <%= get_commenter_pseud_or_name(@commentable) %>
+            <% end %>
+            <span class="posted datetime">
+              <%= time_in_zone(@commentable.created_at) %>
+            </span>
+          </h4>
+          <div class="icon">
+            <% if @commentable.pseud %>
+              <% if @commentable.by_anonymous_creator? %>
+                <span class="anonymous icon"></span>
+              <% else %>
+                <%= icon_display(@commentable.pseud.user, @commentable.pseud) %>
+              <% end %>
+            <% else %>
+              <span class="visitor icon"></span>
+            <% end %>
+          </div>
+          <blockquote class="userstuff">
+            <%= raw sanitize_field(@commentable, :comment_content) %>
+          </blockquote>
         <% end %>
-        <span class="posted datetime">
-          <%= time_in_zone(Time.current) %>
-        </span>
-      </h4>
-      <div class="icon">
-        <% if @comment.pseud %>
+      </li>
+      <li>
+        <ol class="thread">
+          <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
+          <h4 class="heading byline">
+            <% if @comment.by_anonymous_creator? %>
+              <%= t(".anonymous_creator") %>
+            <% else %>
+              <%= get_commenter_pseud_or_name(@comment) %>
+            <% end %>
+            <span class="posted datetime">
+              <%= time_in_zone(Time.current) %>
+            </span>
+          </h4>
+          <div class="icon">
+            <% if @comment.pseud %>
+              <% if @comment.by_anonymous_creator? %>
+                <span class="anonymous icon"></span>
+              <% else %>
+                <%= icon_display(@comment.pseud.user, @comment.pseud) %>
+              <% end %>
+            <% else %>
+              <span class="visitor icon"></span>
+            <% end %>
+          </div>
+          <blockquote class="userstuff">
+            <%= raw sanitize_field(@comment, :comment_content) %>
+          </blockquote>
+        </li>
+        </ol>
+      </li>
+    <% else %>
+      <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@comment) %> preview" id="comment_preview" role="article">
+        <h4 class="heading byline">
           <% if @comment.by_anonymous_creator? %>
-            <span class="anonymous icon"></span>
+            <%= t(".anonymous_creator") %>
           <% else %>
-            <%= icon_display(@comment.pseud.user, @comment.pseud) %>
+            <%= get_commenter_pseud_or_name(@comment) %>
           <% end %>
-        <% else %>
-          <span class="visitor icon"></span>
-        <% end %>
-      </div>
-      <blockquote class="userstuff">
-        <%= raw sanitize_field(@comment, :comment_content) %>
-      </blockquote>
-    </li>
+          <span class="posted datetime">
+            <%= time_in_zone(Time.current) %>
+          </span>
+        </h4>
+        <div class="icon">
+          <% if @comment.pseud %>
+            <% if @comment.by_anonymous_creator? %>
+              <span class="anonymous icon"></span>
+            <% else %>
+              <%= icon_display(@comment.pseud.user, @comment.pseud) %>
+            <% end %>
+          <% else %>
+            <span class="visitor icon"></span>
+          <% end %>
+        </div>
+        <blockquote class="userstuff">
+          <%= raw sanitize_field(@comment, :comment_content) %>
+        </blockquote>
+      </li>
+    <% end %>
   </ol>
 </div>
 <!--/content-->
 
-<!--action buttons-->
-<ul class="actions right">
-  <%= form_with url: draft_comments_path, method: :post, local: true do |f| %>
-    <% @form_state.each do |key, value| %>
-      <% if value.is_a?(Hash) %>
-        <% value.each do |sub_key, sub_value| %>
-          <%= hidden_field_tag "#{key}[#{sub_key}]", sub_value %>
-        <% end %>
-      <% else %>
-        <%= f.hidden_field key, name: key, value: value %>
-      <% end %>
-    <% end %>
-    <%= f.submit t(".back_to_edit"), class: "button" %>
-  <% end %>
-
-  <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
-    <%= f.hidden_field :comment_content %>
-
-    <% if @comment.pseud_id %>
-      <%= f.hidden_field :pseud_id %>
-    <% elsif @comment.name %>
-      <%= f.hidden_field :name %>
-      <%= f.hidden_field :email %>
-    <% end %>
-
-    <% @form_state.each do |key, value| %>
-      <% next if key.in?([:comment_content, :pseud_id, :name, :email]) %>
-      <% if value.is_a?(Hash) %>
-        <% value.each do |sub_key, sub_value| %>
-          <%= hidden_field_tag "#{key}[#{sub_key}]", sub_value %>
-        <% end %>
-      <% else %>
-        <%= hidden_field_tag key, value %>
-      <% end %>
-    <% end %>
-
-    <%= f.submit t(".post_comment"), class: "button submit" %>
-  <% end %>
-</ul>
-<!--/actions-->
+<!--inline edit form-->
+<div id="edit_comment_on_preview">
+  <h3 class="heading"><%= t(".edit_comment_heading") %></h3>
+  <%= render partial: 'comments/comment_form',
+        locals: {
+          comment: @comment,
+          commentable: @commentable,
+          button_name: t(".post_comment")
+        } %>
+</div>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -1,5 +1,4 @@
-<h2 class="heading"><%= t(".page_heading") %></h2>
-<p><%= t(".commenting_on_html", commentable_link: link_to_comment_ultimate_parent(@comment)) %></p>
+<h2 class="heading"><%= t(".page_heading_html", commentable_link: link_to_comment_ultimate_parent(@comment)) %></h2>
 
 <!--main content-->
 <div id="previewpane">

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -1,7 +1,4 @@
-<!--Descriptive page name, messages and instructions-->
 <h2 class="heading"><%= t(".page_heading") %></h2>
-<%# error_messages_for :comment %>
-<!--/descriptions-->
 
 <!--main content-->
 <div id="previewpane">
@@ -20,12 +17,12 @@
       <div class="icon">
         <% if !@comment.pseud.nil? %>
           <% if @comment.by_anonymous_creator? %>
-            <span class="anonymous icon"><!-- anonymous creator icon holder --></span>
+            <span class="anonymous icon"></span>
           <% else %>
             <%= icon_display(@comment.pseud.user, @comment.pseud) %>
           <% end %>
         <% else %>
-          <span class="visitor icon"><!-- visitor icon holder --></span>
+          <span class="visitor icon"></span>
         <% end %>
       </div>
       <blockquote class="userstuff">
@@ -36,49 +33,9 @@
 </div>
 <!--/content-->
 
-<!-- Action buttons -->
+<!--action buttons-->
 <div class="actions right">
-  <%# Back to Edit - submit form with all data to repopulate the form %>
-  <%= form_with url: new_comment_path, method: :get, local: true, html: { id: "back_to_edit_form" } do |f| %>
-    <%# Use hidden_field_tag for all fields to ensure flat params %>
-    <%= hidden_field_tag :comment_content, @comment.comment_content %>
-    
-    <% if @comment.pseud_id %>
-      <%= hidden_field_tag :pseud_id, @comment.pseud_id %>
-    <% elsif @comment.name %>
-      <%= hidden_field_tag :name, @comment.name %>
-      <%= hidden_field_tag :email, @comment.email %>
-    <% end %>
-
-    <%# Preserve commentable context - use hidden_field_tag for non-nested params %>
-    <% if @commentable.is_a?(Work) %>
-      <%= hidden_field_tag :work_id, @commentable.id %>
-    <% elsif @commentable.is_a?(Chapter) %>
-      <%= hidden_field_tag :chapter_id, @commentable.id %>
-    <% elsif @commentable.is_a?(AdminPost) %>
-      <%= hidden_field_tag :admin_post_id, @commentable.id %>
-    <% elsif @commentable.is_a?(Tag) %>
-      <%= hidden_field_tag :tag_id, @commentable.name %>
-    <% elsif @commentable.is_a?(Comment) %>
-      <%= hidden_field_tag :comment_id, @commentable.id %>
-    <% end %>
-
-    <%# Preserve contextual params %>
-    <% if params[:view_full_work] %>
-      <%= hidden_field_tag :view_full_work, params[:view_full_work] %>
-    <% end %>
-    <% if params[:page] %>
-      <%= hidden_field_tag :page, params[:page] %>
-    <% end %>
-    <% if controller.controller_name == "inbox" && params[:filters] %>
-      <%= hidden_field_tag "filters[read]", params[:filters][:read] %>
-      <%= hidden_field_tag "filters[replied_to]", params[:filters][:replied_to] %>
-      <%= hidden_field_tag "filters[date]", params[:filters][:date] %>
-    <% end %>
-    <%= hidden_field_tag :controller_name, @controller_name if @controller_name %>
-
-    <%= submit_tag t(".back_to_edit"), class: "button" %>
-  <% end %>
+  <%= link_to t(".back_to_edit"), new_comment_path(@context_params), class: "button" %>
 
   <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
     <%= f.hidden_field :comment_content %>
@@ -90,32 +47,10 @@
       <%= f.hidden_field :email %>
     <% end %>
 
-    <%# Preserve commentable context - use hidden_field_tag for non-nested params %>
-    <% if @commentable.is_a?(Work) %>
-      <%= hidden_field_tag :work_id, @commentable.id %>
-    <% elsif @commentable.is_a?(Chapter) %>
-      <%= hidden_field_tag :chapter_id, @commentable.id %>
-    <% elsif @commentable.is_a?(AdminPost) %>
-      <%= hidden_field_tag :admin_post_id, @commentable.id %>
-    <% elsif @commentable.is_a?(Tag) %>
-      <%= hidden_field_tag :tag_id, @commentable.name %>
-    <% elsif @commentable.is_a?(Comment) %>
-      <%= hidden_field_tag :comment_id, @commentable.id %>
+    <% @context_params.each do |key, value| %>
+      <% next if key.in?(:comment_content, :pseud_id, :name, :email) %>
+      <%= hidden_field_tag key, value %>
     <% end %>
-
-    <%# Preserve contextual params %>
-    <% if params[:view_full_work] %>
-      <%= hidden_field_tag :view_full_work, params[:view_full_work] %>
-    <% end %>
-    <% if params[:page] %>
-      <%= hidden_field_tag :page, params[:page] %>
-    <% end %>
-    <% if controller.controller_name == "inbox" && params[:filters] %>
-      <%= hidden_field_tag "filters[read]", params[:filters][:read] %>
-      <%= hidden_field_tag "filters[replied_to]", params[:filters][:replied_to] %>
-      <%= hidden_field_tag "filters[date]", params[:filters][:date] %>
-    <% end %>
-    <%= hidden_field_tag :controller_name, @controller_name if @controller_name %>
 
     <%= f.submit t(".post_comment"), class: "button submit" %>
   <% end %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -35,8 +35,19 @@
 <!--/content-->
 
 <!--action buttons-->
-<ul class="actions">
-  <%= link_to t(".back_to_edit"), new_comment_path(@context_params), class: "button" %>
+<ul class="actions right">
+  <%= form_with url: back_to_edit_comments_path, method: :post, local: true do |f| %>
+    <% @context_params.each do |key, value| %>
+      <% if value.is_a?(Hash) %>
+        <% value.each do |sub_key, sub_value| %>
+          <%= hidden_field_tag "#{key}[#{sub_key}]", sub_value %>
+        <% end %>
+      <% else %>
+        <%= f.hidden_field key, name: key, value: value %>
+      <% end %>
+    <% end %>
+    <%= f.submit t(".back_to_edit"), class: "button" %>
+  <% end %>
 
   <%= form_for @comment, url: comments_path, method: :post, local: true, html: { id: "post_comment_from_preview" } do |f| %>
     <%= f.hidden_field :comment_content %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -7,13 +7,13 @@
     <% if @commentable.is_a?(Comment) %>
       <li class="<%= cycle :odd, :even %> <%= css_classes_for_comment(@commentable) %>" id="comment_<%= @commentable.id %>" role="article">
         <% if @commentable.is_deleted %>
-          <p><%= ts("(Previous comment deleted.)") %></p>
+          <p><%= t(".deleted_comment") %></p>
         <% elsif !can_see_hidden_comment?(@commentable) %>
-          <p class="message"><%= ts("(This comment is under review by an admin and is currently unavailable.)") %></p>
+          <p class="message"><%= t(".hidden_comment") %></p>
         <% else %>
           <h4 class="heading byline">
             <% if @commentable.by_anonymous_creator? %>
-              <%= ts("Anonymous Creator") %>
+              <%= t(".anonymous_creator") %>
             <% else %>
               <%= get_commenter_pseud_or_name(@commentable) %>
             <% end %>

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -1,5 +1,5 @@
 <h2 class="heading"><%= t(".page_heading") %></h2>
-<p><%= t(".commenting_on", commentable_link: link_to_comment_ultimate_parent(@comment)) %></p>
+<p><%= t(".commenting_on_html", commentable_link: link_to_comment_ultimate_parent(@comment)) %></p>
 
 <!--main content-->
 <div id="previewpane">

--- a/app/views/comments/preview.html.erb
+++ b/app/views/comments/preview.html.erb
@@ -36,7 +36,7 @@
 
 <!--action buttons-->
 <ul class="actions right">
-  <%= form_with url: back_to_edit_comments_path, method: :post, local: true do |f| %>
+  <%= form_with url: preview_edit_comments_path, method: :post, local: true do |f| %>
     <% @form_state.each do |key, value| %>
       <% if value.is_a?(Hash) %>
         <% value.each do |sub_key, sub_value| %>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -147,6 +147,9 @@ en:
     check_blocked:
       parent: Sorry, you have been blocked by one or more of this work's creators.
       reply: Sorry, you have been blocked by that user.
+    check_permission_to_edit:
+      error:
+        frozen: Frozen comments cannot be edited.
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.
     check_guest_email_is_from_suspended_or_banned_user:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -159,6 +159,9 @@ en:
       draft: Sorry, you can't comment on a draft.
     check_not_replying_to_spam:
       error: Sorry, you can't reply to a comment that has been marked as spam.
+    check_permission_to_edit:
+      error:
+        frozen: Frozen comments cannot be edited.
     create:
       error: Couldn't save comment!
       missing_commentable: What did you want to comment on?

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -159,9 +159,6 @@ en:
       draft: Sorry, you can't comment on a draft.
     check_not_replying_to_spam:
       error: Sorry, you can't reply to a comment that has been marked as spam.
-    check_permission_to_edit:
-      error:
-        frozen: Frozen comments cannot be edited.
     create:
       success:
         moderated:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -147,9 +147,6 @@ en:
     check_blocked:
       parent: Sorry, you have been blocked by one or more of this work's creators.
       reply: Sorry, you have been blocked by that user.
-    check_permission_to_edit:
-      error:
-        frozen: Frozen comments cannot be edited.
     check_frozen:
       error: Sorry, you cannot reply to a frozen comment.
     check_guest_email_is_from_suspended_or_banned_user:
@@ -163,6 +160,8 @@ en:
     check_not_replying_to_spam:
       error: Sorry, you can't reply to a comment that has been marked as spam.
     create:
+      error: Couldn't save comment!
+      missing_commentable: What did you want to comment on?
       success:
         moderated:
           admin_post: Your comment was received! It will appear publicly after it has been approved.
@@ -179,7 +178,10 @@ en:
     index:
       page_title: Comments on %{name}
     new:
+      missing_commentable: What did you want to comment on?
       page_title: New Comment on %{name}
+    preview:
+      missing_commentable: What did you want to comment on?
     rate_limited:
       error: You have made too many requests in a short time period. Please wait a while before trying again. If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
     show:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -924,6 +924,7 @@ en:
     preview:
       back_to_edit: Back to Edit
       commenting_on: 'Commenting on: %{commentable_link}'
+      missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
     show:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -847,19 +847,6 @@ en:
       tags: Tags
       works: Works (%{count})
   comments:
-    check_permission_to_access_single_unreviewed:
-      error: Sorry, that comment is currently in moderation.
-    check_permission_to_edit:
-      error:
-        has_replies: Comments with replies cannot be edited
-    check_permission_to_moderate:
-      error: Sorry, you don't have permission to moderate that comment.
-    check_permission_to_review:
-      error: Sorry, you don't have permission to see those unreviewed comments.
-    check_pseud_ownership:
-      error: You can't comment with that pseud.
-    check_unreviewed:
-      error: Sorry, you cannot reply to an unapproved comment.
     comment_actions:
       approve: Approve
       comment: Comment
@@ -930,9 +917,6 @@ en:
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
-    destroy:
-      error: We couldn't delete that comment.
-      success: Comment deleted.
     edit:
       back: Back
       page_heading: Editing comment
@@ -961,8 +945,6 @@ en:
         admin_post: Please note that comments cannot be unapproved once you have approved them. After you delete any comments you do not wish to appear on the news post, you can approve all that remain.
         work: Please note that comments cannot be unapproved once you have reviewed them. After you delete any comments you do not wish to appear on your work, you can approve all that remain.
       page_heading_html: Unreviewed Comments on %{commentable_link}
-    update:
-      success: Comment was successfully updated.
   downloads:
     download_afterword:
       afterword: Afterword

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -874,6 +874,7 @@ en:
         comment: Comment
         note: Note
       legend: Post Comment
+      preview_button: Preview
       processing_message: Please wait...
     commentable:
       actions:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -923,7 +923,7 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
-      commenting_on: 'Commenting on: %{commentable_link}'
+      commenting_on_html: 'Commenting on: %{commentable_link}'
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -855,6 +855,8 @@ en:
       parent_thread: Parent Thread
       reply_to_this: Reply to this comment
       thread: Thread
+    create:
+      missing_commentable: What did you want to comment on?
     comment_form:
       anonymous_creator: Anonymous Creator
       anonymous_forewarning: While this work is anonymous, comments you post will also be listed anonymously.
@@ -921,6 +923,9 @@ en:
       page_heading: Editing comment
       show: Show
       update: Update
+    new:
+      missing_commentable: What did you want to comment on?
+      previous_comment: Previous Comment
     preview:
       anonymous_creator: Anonymous Creator
       back_to_edit: Back to Edit

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -847,6 +847,20 @@ en:
       tags: Tags
       works: Works (%{count})
   comments:
+    check_permission_to_access_single_unreviewed:
+      error: "Sorry, that comment is currently in moderation."
+    check_permission_to_edit:
+      error:
+        frozen: "This comment is frozen."
+        has_replies: "Comments with replies cannot be edited"
+    check_permission_to_moderate:
+      error: "Sorry, you don't have permission to moderate that comment."
+    check_permission_to_review:
+      error: "Sorry, you don't have permission to see those unreviewed comments."
+    check_pseud_ownership:
+      error: "You can't comment with that pseud."
+    check_unreviewed:
+      error: "Sorry, you cannot reply to an unapproved comment."
     comment_actions:
       approve: Approve
       comment: Comment
@@ -856,6 +870,7 @@ en:
       reply_to_this: Reply to this comment
       thread: Thread
     create:
+      error: "Couldn't save comment!"
       missing_commentable: What did you want to comment on?
     comment_form:
       anonymous_creator: Anonymous Creator
@@ -918,6 +933,9 @@ en:
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
+    destroy:
+      error: "We couldn't delete that comment."
+      success: "Comment deleted."
     edit:
       back: Back
       page_heading: Editing comment
@@ -935,6 +953,8 @@ en:
       post_comment: Post Comment
     show:
       comment_on_html: Comment on %{commentable_link}
+    review:
+      success: "Comment approved."
     single_comment:
       on_chapter_html: on %{commentable_link}
     unreviewed:
@@ -944,6 +964,8 @@ en:
         admin_post: Please note that comments cannot be unapproved once you have approved them. After you delete any comments you do not wish to appear on the news post, you can approve all that remain.
         work: Please note that comments cannot be unapproved once you have reviewed them. After you delete any comments you do not wish to appear on your work, you can approve all that remain.
       page_heading_html: Unreviewed Comments on %{commentable_link}
+    update:
+      success: "Comment was successfully updated."
   downloads:
     download_afterword:
       afterword: Afterword

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -930,9 +930,6 @@ en:
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
-    create:
-      error: Couldn't save comment!
-      missing_commentable: What did you want to comment on?
     destroy:
       error: We couldn't delete that comment.
       success: Comment deleted.
@@ -942,7 +939,6 @@ en:
       show: Show
       update: Update
     new:
-      missing_commentable: What did you want to comment on?
       previous_comment: Previous Comment
     preview:
       anonymous_creator: Anonymous Creator
@@ -950,7 +946,6 @@ en:
       deleted_comment: "(Previous comment deleted.)"
       edit_comment_heading: Edit Comment
       hidden_comment: "(This comment is under review by an admin and is currently unavailable.)"
-      missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
     review:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -859,6 +859,7 @@ en:
       anonymous_creator: Anonymous Creator
       anonymous_forewarning: While this work is anonymous, comments you post will also be listed anonymously.
       cancel_action: Cancel
+      cancel_redirect_warning: You will lose any changes you have made. Are you sure?
       choose_name_field_title: Choose Name
       comment_as: Comment as
       comment_field_title: Enter Comment
@@ -876,7 +877,6 @@ en:
       legend: Post Comment
       preview_button: Preview
       processing_message: Please wait...
-      cancel_redirect_warning: You will lose any changes you have made. Are you sure?
     commentable:
       actions:
         comment: Comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -948,7 +948,9 @@ en:
     preview:
       anonymous_creator: Anonymous Creator
       commenting_on_html: 'Commenting on: %{commentable_link}'
+      deleted_comment: "(Previous comment deleted.)"
       edit_comment_heading: Edit Comment
+      hidden_comment: "(This comment is under review by an admin and is currently unavailable.)"
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
+        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: '%{login} - User Creations'
+        page_title: "%{login} - User Creations"
       history:
         heading: User History
         table:
@@ -244,7 +244,7 @@ en:
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
         page_heading: 'User: %{login} (%{id})'
-        page_title: '%{login} - User Administration'
+        page_title: "%{login} - User Administration"
         status:
           form:
             admin_action:
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: '%{count} emails found'
+        other: "%{count} emails found"
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: '%{minimum} to %{maximum} characters'
+          password_length: "%{minimum} to %{maximum} characters"
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
-          other: '%{count} people are scheduled to be sent invitations at %{time}.'
+          one: "%{count} person is scheduled to be sent an invitation at %{time}."
+          other: "%{count} people are scheduled to be sent invitations at %{time}."
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -682,7 +682,7 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: '%{title_link} (Draft)'
+      header_draft_html: "%{title_link} (Draft)"
       stats:
         creation:
           posted: 'Posted:'
@@ -874,7 +874,6 @@ en:
         comment: Comment
         note: Note
       legend: Post Comment
-      preview_button: Preview
       processing_message: Please wait...
     commentable:
       actions:
@@ -912,7 +911,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
+      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -922,8 +921,9 @@ en:
       show: Show
       update: Update
     preview:
+      anonymous_creator: Anonymous Creator
       back_to_edit: Back to Edit
-      commenting_on_html: 'Commenting on: %{commentable_link}'
+      commenting_on_html: "Commenting on: %{commentable_link}"
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
@@ -944,8 +944,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link}'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link}"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -980,7 +980,7 @@ en:
       series_list_html: Part %{position} of %{series_link}
       stats: 'Stats:'
       summary: Summary
-      tag_type: '%{tag_type}:'
+      tag_type: "%{tag_type}:"
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
@@ -1092,7 +1092,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
+      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1119,7 +1119,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
+      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1139,7 +1139,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: '@status.archiveofourown.org'
+        bluesky: "@status.archiveofourown.org"
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1240,26 +1240,26 @@ en:
         description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
         example:
           blockquote:
-            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
+            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
             text: To quote a block of text
-          chapter_title: '<h3>Chapter title<h3>'
+          chapter_title: "<h3>Chapter title<h3>"
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
+            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
             rodney: Rodney
-          footnote_title: '<h6>Footnote title<h6>'
+          footnote_title: "<h6>Footnote title<h6>"
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: '<h4>Scene title<h4>'
+          scene_title: "<h4>Scene title<h4>"
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: '<h2>Subtitle<h2>'
-          subtitle_h5: '<h5>Subtitle<h5>'
-          title: '<h1>Title<h1>'
+          subtitle_h2: "<h2>Subtitle<h2>"
+          subtitle_h5: "<h5>Subtitle<h5>"
+          title: "<h1>Title<h1>"
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
@@ -1377,9 +1377,9 @@ en:
         reverse_underscore: Start with fandom, then with author, then title, with underscores instead of dashes.
       page_heading: Work Title Format
     rte:
-      description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
+      description_html: 'The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you''re pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:'
       enter_once:
-        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
+        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1494,7 +1494,7 @@ en:
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
-          em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
+          em_unit_html: 'PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer''s current font size! It will make your layouts much more flexible and responsive to different browser/font settings.'
           precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
@@ -1507,7 +1507,7 @@ en:
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
+        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1608,7 +1608,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
+        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1677,14 +1677,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
+        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
         legal_advocacy: Legal Advocacy
-        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
+        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
         open_doors: Open Doors
-        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
+        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
         title: 'Our other major projects include:'
         twc: Transformative Works and Cultures
-        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
+        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1697,7 +1697,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1706,20 +1706,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
+        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1741,7 +1741,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1754,7 +1754,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1762,7 +1762,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1771,7 +1771,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
+        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1790,13 +1790,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1812,14 +1812,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1830,7 +1830,7 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
@@ -1845,7 +1845,7 @@ en:
         html: This work is licensed under a %{creative_commons_by_sa_link}.
         image_alt: Creative Commons License
       some_essential_parts: some essential parts
-      still_missing_html: "We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we'll get there."
+      still_missing_html: 'We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we''ll get there.'
       terms_of_service: Terms of Service
       we_build_for: We are building this archive for you. Come be a part of it.
       welcome_header: You are welcome at the Archive of Our Own.
@@ -1886,7 +1886,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: '@status.archiveofourown.org on Bluesky'
+        bluesky: "@status.archiveofourown.org on Bluesky"
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -2149,17 +2149,17 @@ en:
           privacy_policy: Privacy Policy
         entirety_of_agreement:
           entirety_of_agreement: 'Entirety of agreement:'
-          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
+          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
         heading: I.A. General terms
         jurisdiction:
-          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
+          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
           jurisdiction: 'Jurisdiction:'
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
+          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
           limitation_on_claims: 'Limitation on claims:'
         no_assignment:
-          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
+          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
           no_assignment: 'No assignment:'
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
@@ -2252,7 +2252,7 @@ en:
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: '%{arrow} Top'
+      top: "%{arrow} Top"
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2334,7 +2334,7 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: '%{closed_bold} For more information, please check the %{news_link}.'
+        html: "%{closed_bold} For more information, please check the %{news_link}."
         news: '"Invitations" tag on AO3 News'
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
@@ -2347,10 +2347,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2387,11 +2387,11 @@ en:
     status:
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       heading: Invitation Request Status
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2399,12 +2399,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: '%{count} guest has also left kudos'
-      other: '%{count} guests have also left kudos'
+      one: "%{count} guest has also left kudos"
+      other: "%{count} guests have also left kudos"
     user_links:
       more_link:
-        one: '%{count} more user'
-        other: '%{count} more users'
+        one: "%{count} more user"
+        other: "%{count} more users"
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2417,15 +2417,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: '(%{code})'
+      language_code_format_html: "(%{code})"
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: '%{formatted_count} work'
-        other: '%{formatted_count} works'
+        one: "%{formatted_count} work"
+        other: "%{formatted_count} works"
   layouts:
     banner:
       hide: hide banner
@@ -2451,7 +2451,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: '%{license_link} by the %{otw_link}'
+        license_details_html: "%{license_link} by the %{otw_link}"
         view_license: View License
       landmark: Footer
       otw:
@@ -2570,7 +2570,7 @@ en:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: '← Previous'
+    prev: "← Previous"
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
@@ -2665,8 +2665,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: '%{count} more pseud'
-        other: '%{count} more pseuds'
+        one: "%{count} more pseud"
+        other: "%{count} more pseuds"
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2698,11 +2698,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: ' %{pseud}'
+      delete_landmark_text: " %{pseud}"
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: ' %{pseud}'
+      edit_landmark_text: " %{pseud}"
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: ' by %{pseud}'
+      orphan_landmark_text: " by %{pseud}"
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2741,16 +2741,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: '(Hidden by Admin)'
+      hidden_by_admin_alt: "(Hidden by Admin)"
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: '(Restricted)'
-      series_by_html: '%{series_title_link} by %{byline}'
+      restricted_alt: "(Restricted)"
+      series_by_html: "%{series_title_link} by %{byline}"
     series_order:
-      draft_work_title: '%{title} (DRAFT)'
+      draft_work_title: "%{title} (DRAFT)"
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2815,13 +2815,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: '(Series)'
-      work: '(Work)'
+      series: "(Series)"
+      work: "(Work)"
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: '%{type} (%{count} left to review)'
-      paginated: '%{from} - %{to} of %{total} %{type}'
+      left_to_review: "%{type} (%{count} left to review)"
+      paginated: "%{from} - %{to} of %{total} %{type}"
   tag_wranglers:
     index:
       filters:
@@ -2830,42 +2830,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
+      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
+        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
+        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
+        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
+        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
         heading: 'General Wrangling Resources:'
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
+        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
+        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
+        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
+        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
+        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
+        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
+        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
+        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
+        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
+        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2877,8 +2877,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
-        tw_wranglers_slack: '#tw-wranglers'
+        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
+        tw_wranglers_slack: "#tw-wranglers"
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2896,7 +2896,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: '%{tag_type} (%{count})'
+      tag_type_and_count: "%{tag_type} (%{count})"
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2906,7 +2906,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: '%{use_type} (%{count})'
+      use_type_and_count: "%{use_type} (%{count})"
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2998,7 +2998,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
+        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3024,8 +3024,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: '%{minimum} to %{count} character'
-        other: '%{minimum} to %{count} characters'
+        one: "%{minimum} to %{count} character"
+        other: "%{minimum} to %{count} characters"
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3047,7 +3047,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3108,8 +3108,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: '%{minimum} to %{count} character'
-          other: '%{minimum} to %{count} characters'
+          one: "%{minimum} to %{count} character"
+          other: "%{minimum} to %{count} characters"
         submit: Submit
       new:
         email_html: Email address
@@ -3139,10 +3139,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: '%{minimum} to %{maximum} characters'
+        password_requirements: "%{minimum} to %{maximum} characters"
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3264,7 +3264,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: '%{work_link} (Draft)'
+      draft_work_title_html: "%{work_link} (Draft)"
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3322,7 +3322,7 @@ en:
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: ' (Draft)'
+      draft: " (Draft)"
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3334,8 +3334,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3360,11 +3360,11 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
-        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
+        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
+        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
         more_notes: more notes
         notes: notes
-        related_works_html: '(See the end of the work for %{related_works_link}.)'
+        related_works_html: "(See the end of the work for %{related_works_link}.)"
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -926,12 +926,11 @@ en:
       previous_comment: Previous Comment
     preview:
       anonymous_creator: Anonymous Creator
-      commenting_on_html: 'Commenting on: %{commentable_link}'
       deleted_comment: "(Previous comment deleted.)"
       edit_comment_heading: Edit Comment
       hidden_comment: "(This comment is under review by an admin and is currently unavailable.)"
-      page_heading: Preview Comment
-      post_comment: Post Comment
+      page_heading_html: 'Comment on %{commentable_link}'
+      post_comment: Comment
     review:
       success: Comment approved.
     show:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
+        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: "%{login} - User Creations"
+        page_title: '%{login} - User Creations'
       history:
         heading: User History
         table:
@@ -244,7 +244,7 @@ en:
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
         page_heading: 'User: %{login} (%{id})'
-        page_title: "%{login} - User Administration"
+        page_title: '%{login} - User Administration'
         status:
           form:
             admin_action:
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: "%{count} emails found"
+        other: '%{count} emails found'
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: "%{minimum} to %{maximum} characters"
+          password_length: '%{minimum} to %{maximum} characters'
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: "%{count} person is scheduled to be sent an invitation at %{time}."
-          other: "%{count} people are scheduled to be sent invitations at %{time}."
+          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
+          other: '%{count} people are scheduled to be sent invitations at %{time}.'
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -682,7 +682,7 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: "%{title_link} (Draft)"
+      header_draft_html: '%{title_link} (Draft)'
       stats:
         creation:
           posted: 'Posted:'
@@ -912,7 +912,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
+      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -923,6 +923,7 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
+      commenting_on: 'Commenting on: %{commentable_link}'
       page_heading: Preview Comment
       post_comment: Post Comment
     show:
@@ -942,8 +943,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link}"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link}'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -978,7 +979,7 @@ en:
       series_list_html: Part %{position} of %{series_link}
       stats: 'Stats:'
       summary: Summary
-      tag_type: "%{tag_type}:"
+      tag_type: '%{tag_type}:'
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
@@ -1090,7 +1091,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
+      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1117,7 +1118,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
+      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1137,7 +1138,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: "@status.archiveofourown.org"
+        bluesky: '@status.archiveofourown.org'
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1238,26 +1239,26 @@ en:
         description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
         example:
           blockquote:
-            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
+            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
             text: To quote a block of text
-          chapter_title: "<h3>Chapter title<h3>"
+          chapter_title: '<h3>Chapter title<h3>'
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
+            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
             rodney: Rodney
-          footnote_title: "<h6>Footnote title<h6>"
+          footnote_title: '<h6>Footnote title<h6>'
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: "<h4>Scene title<h4>"
+          scene_title: '<h4>Scene title<h4>'
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: "<h2>Subtitle<h2>"
-          subtitle_h5: "<h5>Subtitle<h5>"
-          title: "<h1>Title<h1>"
+          subtitle_h2: '<h2>Subtitle<h2>'
+          subtitle_h5: '<h5>Subtitle<h5>'
+          title: '<h1>Title<h1>'
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
@@ -1375,9 +1376,9 @@ en:
         reverse_underscore: Start with fandom, then with author, then title, with underscores instead of dashes.
       page_heading: Work Title Format
     rte:
-      description_html: 'The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you''re pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:'
+      description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
       enter_once:
-        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
+        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1492,7 +1493,7 @@ en:
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
-          em_unit_html: 'PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer''s current font size! It will make your layouts much more flexible and responsive to different browser/font settings.'
+          em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
           precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
@@ -1505,7 +1506,7 @@ en:
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
+        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1606,7 +1607,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
+        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1675,14 +1676,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
+        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
         legal_advocacy: Legal Advocacy
-        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
+        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
         open_doors: Open Doors
-        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
+        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
         title: 'Our other major projects include:'
         twc: Transformative Works and Cultures
-        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
+        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1695,7 +1696,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1704,20 +1705,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
+        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1739,7 +1740,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1752,7 +1753,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1760,7 +1761,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1769,7 +1770,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
+        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1788,13 +1789,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1810,14 +1811,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1828,7 +1829,7 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
@@ -1843,7 +1844,7 @@ en:
         html: This work is licensed under a %{creative_commons_by_sa_link}.
         image_alt: Creative Commons License
       some_essential_parts: some essential parts
-      still_missing_html: 'We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we''ll get there.'
+      still_missing_html: "We know that there are %{some_essential_parts_link} that are still missing to make the Archive truly panfandom: the ability to host fanworks other than text, an interface in languages other than English, and more ways for you to connect with each other, to name just a few. But with your support, we'll get there."
       terms_of_service: Terms of Service
       we_build_for: We are building this archive for you. Come be a part of it.
       welcome_header: You are welcome at the Archive of Our Own.
@@ -1884,7 +1885,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: "@status.archiveofourown.org on Bluesky"
+        bluesky: '@status.archiveofourown.org on Bluesky'
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -2147,17 +2148,17 @@ en:
           privacy_policy: Privacy Policy
         entirety_of_agreement:
           entirety_of_agreement: 'Entirety of agreement:'
-          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
+          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
         heading: I.A. General terms
         jurisdiction:
-          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
+          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
           jurisdiction: 'Jurisdiction:'
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
+          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
           limitation_on_claims: 'Limitation on claims:'
         no_assignment:
-          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
+          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
           no_assignment: 'No assignment:'
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
@@ -2250,7 +2251,7 @@ en:
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: "%{arrow} Top"
+      top: '%{arrow} Top'
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2332,7 +2333,7 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: "%{closed_bold} For more information, please check the %{news_link}."
+        html: '%{closed_bold} For more information, please check the %{news_link}.'
         news: '"Invitations" tag on AO3 News'
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
@@ -2345,10 +2346,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2385,11 +2386,11 @@ en:
     status:
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       heading: Invitation Request Status
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2397,12 +2398,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: "%{count} guest has also left kudos"
-      other: "%{count} guests have also left kudos"
+      one: '%{count} guest has also left kudos'
+      other: '%{count} guests have also left kudos'
     user_links:
       more_link:
-        one: "%{count} more user"
-        other: "%{count} more users"
+        one: '%{count} more user'
+        other: '%{count} more users'
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2415,15 +2416,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: "(%{code})"
+      language_code_format_html: '(%{code})'
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: "%{formatted_count} work"
-        other: "%{formatted_count} works"
+        one: '%{formatted_count} work'
+        other: '%{formatted_count} works'
   layouts:
     banner:
       hide: hide banner
@@ -2449,7 +2450,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: "%{license_link} by the %{otw_link}"
+        license_details_html: '%{license_link} by the %{otw_link}'
         view_license: View License
       landmark: Footer
       otw:
@@ -2568,7 +2569,7 @@ en:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: "← Previous"
+    prev: '← Previous'
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
@@ -2663,8 +2664,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: "%{count} more pseud"
-        other: "%{count} more pseuds"
+        one: '%{count} more pseud'
+        other: '%{count} more pseuds'
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2696,11 +2697,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: " %{pseud}"
+      delete_landmark_text: ' %{pseud}'
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: " %{pseud}"
+      edit_landmark_text: ' %{pseud}'
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: " by %{pseud}"
+      orphan_landmark_text: ' by %{pseud}'
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2739,16 +2740,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: "(Hidden by Admin)"
+      hidden_by_admin_alt: '(Hidden by Admin)'
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: "(Restricted)"
-      series_by_html: "%{series_title_link} by %{byline}"
+      restricted_alt: '(Restricted)'
+      series_by_html: '%{series_title_link} by %{byline}'
     series_order:
-      draft_work_title: "%{title} (DRAFT)"
+      draft_work_title: '%{title} (DRAFT)'
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2813,13 +2814,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: "(Series)"
-      work: "(Work)"
+      series: '(Series)'
+      work: '(Work)'
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: "%{type} (%{count} left to review)"
-      paginated: "%{from} - %{to} of %{total} %{type}"
+      left_to_review: '%{type} (%{count} left to review)'
+      paginated: '%{from} - %{to} of %{total} %{type}'
   tag_wranglers:
     index:
       filters:
@@ -2828,42 +2829,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
+      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
+        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
+        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
+        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
+        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
         heading: 'General Wrangling Resources:'
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
+        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
+        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
+        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
+        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
+        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
+        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
+        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
+        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
+        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
+        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2875,8 +2876,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
-        tw_wranglers_slack: "#tw-wranglers"
+        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
+        tw_wranglers_slack: '#tw-wranglers'
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2894,7 +2895,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: "%{tag_type} (%{count})"
+      tag_type_and_count: '%{tag_type} (%{count})'
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2904,7 +2905,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: "%{use_type} (%{count})"
+      use_type_and_count: '%{use_type} (%{count})'
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2996,7 +2997,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
+        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3022,8 +3023,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: "%{minimum} to %{count} character"
-        other: "%{minimum} to %{count} characters"
+        one: '%{minimum} to %{count} character'
+        other: '%{minimum} to %{count} characters'
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3045,7 +3046,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3106,8 +3107,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: "%{minimum} to %{count} character"
-          other: "%{minimum} to %{count} characters"
+          one: '%{minimum} to %{count} character'
+          other: '%{minimum} to %{count} characters'
         submit: Submit
       new:
         email_html: Email address
@@ -3137,10 +3138,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: "%{minimum} to %{maximum} characters"
+        password_requirements: '%{minimum} to %{maximum} characters'
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3262,7 +3263,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: "%{work_link} (Draft)"
+      draft_work_title_html: '%{work_link} (Draft)'
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3320,7 +3321,7 @@ en:
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: " (Draft)"
+      draft: ' (Draft)'
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3332,8 +3333,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3358,11 +3359,11 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
-        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
+        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
+        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
         more_notes: more notes
         notes: notes
-        related_works_html: "(See the end of the work for %{related_works_link}.)"
+        related_works_html: '(See the end of the work for %{related_works_link}.)'
       translated_to:
         restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
         revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -848,19 +848,19 @@ en:
       works: Works (%{count})
   comments:
     check_permission_to_access_single_unreviewed:
-      error: "Sorry, that comment is currently in moderation."
+      error: Sorry, that comment is currently in moderation.
     check_permission_to_edit:
       error:
-        frozen: "This comment is frozen."
-        has_replies: "Comments with replies cannot be edited"
+        frozen: This comment is frozen.
+        has_replies: Comments with replies cannot be edited
     check_permission_to_moderate:
-      error: "Sorry, you don't have permission to moderate that comment."
+      error: Sorry, you don't have permission to moderate that comment.
     check_permission_to_review:
-      error: "Sorry, you don't have permission to see those unreviewed comments."
+      error: Sorry, you don't have permission to see those unreviewed comments.
     check_pseud_ownership:
-      error: "You can't comment with that pseud."
+      error: You can't comment with that pseud.
     check_unreviewed:
-      error: "Sorry, you cannot reply to an unapproved comment."
+      error: Sorry, you cannot reply to an unapproved comment.
     comment_actions:
       approve: Approve
       comment: Comment
@@ -869,9 +869,6 @@ en:
       parent_thread: Parent Thread
       reply_to_this: Reply to this comment
       thread: Thread
-    create:
-      error: "Couldn't save comment!"
-      missing_commentable: What did you want to comment on?
     comment_form:
       anonymous_creator: Anonymous Creator
       anonymous_forewarning: While this work is anonymous, comments you post will also be listed anonymously.
@@ -933,9 +930,12 @@ en:
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
+    create:
+      error: Couldn't save comment!
+      missing_commentable: What did you want to comment on?
     destroy:
-      error: "We couldn't delete that comment."
-      success: "Comment deleted."
+      error: We couldn't delete that comment.
+      success: Comment deleted.
     edit:
       back: Back
       page_heading: Editing comment
@@ -947,14 +947,14 @@ en:
     preview:
       anonymous_creator: Anonymous Creator
       back_to_edit: Back to Edit
-      commenting_on_html: "Commenting on: %{commentable_link}"
+      commenting_on_html: 'Commenting on: %{commentable_link}'
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
+    review:
+      success: Comment approved.
     show:
       comment_on_html: Comment on %{commentable_link}
-    review:
-      success: "Comment approved."
     single_comment:
       on_chapter_html: on %{commentable_link}
     unreviewed:
@@ -965,7 +965,7 @@ en:
         work: Please note that comments cannot be unapproved once you have reviewed them. After you delete any comments you do not wish to appear on your work, you can approve all that remain.
       page_heading_html: Unreviewed Comments on %{commentable_link}
     update:
-      success: "Comment was successfully updated."
+      success: Comment was successfully updated.
   downloads:
     download_afterword:
       afterword: Afterword

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -874,6 +874,7 @@ en:
         comment: Comment
         note: Note
       legend: Post Comment
+      preview_button: Preview
       processing_message: Please wait...
     commentable:
       actions:
@@ -920,6 +921,11 @@ en:
       page_heading: Editing comment
       show: Show
       update: Update
+    preview:
+      back_to_edit: Back to Edit
+      commenting_on: "Commenting on: %{commentable_link}"
+      page_heading: Preview Comment
+      post_comment: Post Comment
     show:
       comment_on_html: Comment on %{commentable_link}
     single_comment:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
+        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -41,7 +41,7 @@ en:
         page_title: Policy Questions & Abuse Reports
       include:
         evidence_html: links to any relevant %{sources_link} or screenshots
-        intro: "What to include in your report description:"
+        intro: 'What to include in your report description:'
         other_content: links to any of their other content that you would like to report
         quote: a quote from or summary of the content that violates the Terms of Service
         reported_username: username of the person you are reporting
@@ -69,7 +69,7 @@ en:
         email: an email explaining why
         hack: You believe that your AO3 account was hacked.
         harassment: You have experienced or witnessed harassment taking place on AO3.
-        intro_html: "Potential reasons to submit a report to the %{pac_link} team:"
+        intro_html: 'Potential reasons to submit a report to the %{pac_link} team:'
         pac: Policy & Abuse
         suspended_html: You have been suspended or your work has been removed, and you have not received %{email_link}.
         tos: Terms of Service
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: "%{login} - User Creations"
+        page_title: '%{login} - User Creations'
       history:
         heading: User History
         table:
@@ -201,7 +201,7 @@ en:
             current:
               action: Most Recent Login
               no_details: No login recorded
-            details: "IP Address: %{ip}"
+            details: 'IP Address: %{ip}'
             last:
               action: Previous Login
               no_details: No previous login recorded
@@ -219,20 +219,20 @@ en:
             submit: Update Fannish Next of Kin
           heading: Fannish Next of Kin
         info:
-          email: "Email:"
+          email: 'Email:'
           heading: User Information
-          invitation: "Invitation:"
+          invitation: 'Invitation:'
           no_invitation: Created without invitation
           no_role: No roles
           past_emails:
-            one: "Past email:"
-            other: "Past emails:"
+            one: 'Past email:'
+            other: 'Past emails:'
           past_logins:
-            one: "Past username:"
-            other: "Past usernames:"
+            one: 'Past username:'
+            other: 'Past usernames:'
           role:
-            one: "Role:"
-            other: "Roles:"
+            one: 'Role:'
+            other: 'Roles:'
         navigation:
           activate: Activate
           creations: Creations
@@ -243,16 +243,16 @@ en:
           roles: Manage Roles
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
-        page_heading: "User: %{login} (%{id})"
-        page_title: "%{login} - User Administration"
+        page_heading: 'User: %{login} (%{id})'
+        page_title: '%{login} - User Administration'
         status:
           form:
             admin_action:
               ban: Suspend permanently (ban user)
               legend: Warnings and Suspensions
               note: Record note
-              spamban: "Spammer: ban and delete all creations"
-              suspend: "Suspend: enter a whole number of days"
+              spamban: 'Spammer: ban and delete all creations'
+              suspend: 'Suspend: enter a whole number of days'
               unban: Lift permanent suspension, effective immediately.
               unsuspend: Lift temporary suspension, effective immediately.
               warn: Record warning
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: "%{count} emails found"
+        other: '%{count} emails found'
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: "%{minimum} to %{maximum} characters"
+          password_length: '%{minimum} to %{maximum} characters'
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: "%{count} person is scheduled to be sent an invitation at %{time}."
-          other: "%{count} people are scheduled to be sent invitations at %{time}."
+          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
+          other: '%{count} people are scheduled to be sent invitations at %{time}.'
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -484,13 +484,13 @@ en:
           general_info: Two-step verification, also called two-factor authentication, helps prevent other people from accessing your account even if they know your password. All you need to set it up is an authenticator app such as 1Password, Google Authenticator, or Twilio Authy.
           heading: About Two-Step Verification
         app_setup:
-          heading: "Step 1: Set up your authenticator app"
+          heading: 'Step 1: Set up your authenticator app'
           instructions: Use your authenticator app to scan the QR code or enter the manual setup key. The app will give you a 6-digit code, which you'll use in the next step.
           key:
             format_note: Spaces and capitalization don't matter
             heading: Setup Key
         enter_code:
-          heading: "Step 2: Enter your 6-digit code"
+          heading: 'Step 2: Enter your 6-digit code'
           instructions: Enter the 6-digit code from your app to enable two-step verification
           label: 6-digit code
           please_wait: Please wait...
@@ -501,7 +501,7 @@ en:
         copy_to_clipboard: Copy Backup Codes to Clipboard
         finish: Finish
         page_heading: Two-Step Verification Backup Codes
-        write_codes_down: "Keep these backup codes in a safe and secure place in case you lose access to your authenticator app:"
+        write_codes_down: 'Keep these backup codes in a safe and secure place in case you lose access to your authenticator app:'
     user_creations:
       confirm_remove_pseud:
         caution: Are you sure you want to remove the creator's pseud from this work?
@@ -569,7 +569,7 @@ en:
       elasticsearch_update_notice_html: Our search engine has recently been updated, and this FAQ is based on our old version. We're working on bringing you more up-to-date information, but in the meantime, you can find out more in our %{elasticsearch_news_link}!
       no_category_entries: We're sorry, there are currently no entries in this category.
       page_heading: Archive FAQ
-      screencast: "Screencast:"
+      screencast: 'Screencast:'
   blocked:
     block: Block
     unblock: Unblock
@@ -585,20 +585,20 @@ en:
         will:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
-          intro: "Blocking a user prevents them from:"
+          intro: 'Blocking a user prevents them from:'
           replying: replying to your comments anywhere on the site
         will_not:
           comments_elsewhere: hide their comments elsewhere on the site
           comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
           hide_works: hide their works or bookmarks from you
-          intro: "Blocking a user will not:"
+          intro: 'Blocking a user will not:'
       confirm_unblock:
         button: Yes, Unblock User
         cancel: Cancel
         resume:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
-          intro: "Unblocking a user allows them to resume:"
+          intro: 'Unblocking a user allows them to resume:'
           replying: replying to your comments anywhere on the site
         sure_html: Are you sure you want to %{unblock} %{username}?
         title: Unblock %{name}
@@ -619,14 +619,14 @@ en:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
           intro:
-            one: "You can block up to %{block_limit} user. Blocking a user prevents them from:"
-            other: "You can block up to %{block_limit} users. Blocking a user prevents them from:"
+            one: 'You can block up to %{block_limit} user. Blocking a user prevents them from:'
+            other: 'You can block up to %{block_limit} users. Blocking a user prevents them from:'
           replying: replying to your comments anywhere on the site
         will_not:
           comments_elsewhere: hide their comments elsewhere on the site
           comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
           hide_works: hide their works or bookmarks from you
-          intro: "Blocking a user will not:"
+          intro: 'Blocking a user will not:'
   bookmarks:
     bookmark_blurb:
       deleted: This has been deleted, sorry!
@@ -682,14 +682,14 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: "%{title_link} (Draft)"
+      header_draft_html: '%{title_link} (Draft)'
       stats:
         creation:
-          posted: "Posted:"
-          unposted: "Created:"
+          posted: 'Posted:'
+          unposted: 'Created:'
         status:
           fulfilled: Complete!
-          header: "Status:"
+          header: 'Status:'
           unapproved: Unapproved
           unposted: Unposted
     to_default:
@@ -768,32 +768,32 @@ en:
   collection_profile:
     show:
       meta:
-        collection_tags: "Collection tags:"
+        collection_tags: 'Collection tags:'
   collections:
     collection_blurb:
-      collection_tags: "Collection Tags:"
-      signups_close_at: "Sign-ups close at:"
+      collection_tags: 'Collection Tags:'
+      signups_close_at: 'Sign-ups close at:'
       summary: Summary
     filters:
       clear_filters: Clear Filters
       closed:
-        exclude: "No"
+        exclude: 'No'
         include: Either
         label: Closed
-        only: "Yes"
+        only: 'Yes'
       landmark: Filters
       leave_filters: Top of Collections Index
-      legend: "Filter collections:"
+      legend: 'Filter collections:'
       moderated:
-        exclude: "No"
+        exclude: 'No'
         include: Either
         label: Moderated
-        only: "Yes"
+        only: 'Yes'
       multifandom:
-        exclude: "No"
+        exclude: 'No'
         include: Either
         label: Multifandom
-        only: "Yes"
+        only: 'Yes'
       sort:
         column: Sort by
         direction:
@@ -912,7 +912,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
+      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -923,8 +923,7 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
-      commenting_on_html: "Commenting on: %{commentable_link}"
-      missing_commentable: What did you want to comment on?
+      commenting_on: 'Commenting on: %{commentable_link}'
       page_heading: Preview Comment
       post_comment: Post Comment
     show:
@@ -944,8 +943,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link}"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link}'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -955,42 +954,42 @@ en:
       chapter_end_notes_without_chapter_notes: notes
       chapter_notes: Chapter Notes
       chapter_summary: Chapter Summary
-      full_chapter_title_with_title: "Chapter %{chapter_number}: %{title}"
+      full_chapter_title_with_title: 'Chapter %{chapter_number}: %{title}'
       full_chapter_title_without_title: Chapter %{chapter_number}
       section_chapter_end_notes: Chapter End Notes
       see_chapter_end_notes_html: See the end of the chapter for %{chapter_end_notes_link}
     download_preface:
       byline_html: by %{byline_names_link}
-      chapters: "Chapters: %{chapter_total_display}"
-      collections: "Collections:"
-      completed: "Completed: %{date}"
+      chapters: 'Chapters: %{chapter_total_display}'
+      collections: 'Collections:'
+      completed: 'Completed: %{date}'
       end_notes_with_work_notes: more notes
       end_notes_without_work_notes: notes
       inspired_by:
         restricted_html: Inspired by [Restricted Work] by %{creator_link}
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
-      language: "Language:"
+      language: 'Language:'
       notes: Notes
       originally_posted_html: Posted originally on the %{archive_link} at %{work_url}.
       preface: Preface
-      published: "Published: %{date}"
+      published: 'Published: %{date}'
       see_end_notes_html: See the end of the work for %{end_notes_link}
-      series: "Series:"
+      series: 'Series:'
       series_list_html: Part %{position} of %{series_link}
-      stats: "Stats:"
+      stats: 'Stats:'
       summary: Summary
-      tag_type: "%{tag_type}:"
+      tag_type: '%{tag_type}:'
       translated_to:
-        restricted_html: "Translation into %{language} available: [Restricted Work] by %{creator_link}"
-        revealed_html: "Translation into %{language} available: %{work_link} by %{creator_link}"
-        unrevealed_html: "Translation into %{language} available: A work in an unrevealed collection"
+        restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
+        revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
+        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection'
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link}
         revealed_html: A translation of %{work_link} by %{creator_link}
         unrevealed: A translation of a work in an unrevealed collection
-      updated: "Updated: %{date}"
-      words: "Words: %{count_with_delimiters}"
+      updated: 'Updated: %{date}'
+      words: 'Words: %{count_with_delimiters}'
   errors:
     '429':
       browse_more_slowly: If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
@@ -1036,7 +1035,7 @@ en:
         other: Claim your works as %{current_user}. If you would like to claim these works under a different account (or create a new account to claim them with), log out and reload this page first.
       contact_open_doors: contact Open Doors
       dashboard: dashboard
-      import_without_email: "Important: If you tick "Do not email me in future" but do not tick "Do not import works", works may be imported without you being told. If that''s not what you want, turn off importing as well as emails."
+      import_without_email: 'Important: If you tick "Do not email me in future" but do not tick "Do not import works", works may be imported without you being told. If that''s not what you want, turn off importing as well as emails.'
       invitation_to_create_account:
         one: We invite you to create an account on %{app_name}! The work will automatically be added to your account and you will have full control over it.
         other: We invite you to create an account on %{app_name}! The works will automatically be added to your account and you will have full control over them.
@@ -1092,7 +1091,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
+      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1119,7 +1118,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
+      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1130,7 +1129,7 @@ en:
         fnok:
           concerning_html: Setting up, changing, or activating your %{fnok_link}
           fnok: Fannish Next of Kin
-        intro: "Some issues you can contact Support about include:"
+        intro: 'Some issues you can contact Support about include:'
         lost_access: Lost password or email preventing access to your account
         new_features: Feature requests for future development
         orphaned_works: Questions about orphaned works
@@ -1139,7 +1138,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: "@status.archiveofourown.org"
+        bluesky: '@status.archiveofourown.org'
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1187,11 +1186,11 @@ en:
         html: To open the Post New Work page, just select the %{post_new_link} link from the menu of the Post tab located at the top right of the page in the default browser skin. Visit the %{posting_editing_faq_link} or check out our %{tutorial_link} for more information.
         post_new: Post New
         posting_editing_faq: Posting and Editing FAQ
-        tutorial: "Tutorial: Posting a Work on AO3"
+        tutorial: 'Tutorial: Posting a Work on AO3'
       preferences:
         edit_my_profile: Edit My Profile
         header: Preferences
-        html: ""%{set_my_preferences_link}" is located next to the "%{edit_my_profile_link}" button, and allows you to adjust certain settings to personalize your experience on the site. The Preferences area controls both the Archive''s behavior (such as whether your history is saved) and the Archive''s appearance. Go to the %{preferences_faq_link} for more details."
+        html: '"%{set_my_preferences_link}" is located next to the "%{edit_my_profile_link}" button, and allows you to adjust certain settings to personalize your experience on the site. The Preferences area controls both the Archive''s behavior (such as whether your history is saved) and the Archive''s appearance. Go to the %{preferences_faq_link} for more details.'
         preferences_faq: Preferences FAQ
         set_my_preferences: Set My Preferences
         skins_detail_html: For more information on how to customize the skins and interface of the Archive, refer to the %{skins_faq_link} and %{tutorials_list_link}.
@@ -1226,7 +1225,7 @@ en:
         tos_faq: Terms of Service FAQ
       warnings:
         archive_specific_warnings: Archive-specific warnings
-        description_html: "The Archive defines four "primary" %{archive_specific_warnings_link}: "Graphic Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and "Underage Sex". When posting a work, you have the option to explicitly select warnings for this content, deny the presence of such content ("No Archive Warnings Apply"), or choose not to apply warnings regardless of whether or not these warnings are applicable ("Creator Chose Not To Use Archive Warnings"). Remember, "No Archive Warnings Apply" only refers to the listed primary warnings."
+        description_html: 'The Archive defines four "primary" %{archive_specific_warnings_link}: "Graphic Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and "Underage Sex". When posting a work, you have the option to explicitly select warnings for this content, deny the presence of such content ("No Archive Warnings Apply"), or choose not to apply warnings regardless of whether or not these warnings are applicable ("Creator Chose Not To Use Archive Warnings"). Remember, "No Archive Warnings Apply" only refers to the listed primary warnings.'
         header: Warnings
         symbols_html: When browsing the Archive, warnings will be displayed in the blurb of each work. Official warning tags are displayed in bold. A four square grid in the top left corner of each work's blurb indicates the work's rating, completion status, pairing category, and any Archive warnings that apply to it. Refer to the %{symbols_key_chart_link} for more information.
         symbols_key_chart: Symbols Key Chart
@@ -1237,43 +1236,43 @@ en:
       formatting:
         a_blank_line: If you leave a blank line between two paragraphs, we will put paragraph tags in for you around the two paragraphs.
         after_first_put_note: When you edit your HTML after you first put it in, you will see the results of our formatting work, so you can correct any mistakes our formatter might have made. Please note that the best way to get good results is to put in good HTML -- that is how you can be sure your story will look right across various browsers, screen readers, mobile devices, and downloads.
-        description: "When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:"
+        description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
         example:
           blockquote:
-            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
+            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
             text: To quote a block of text
-          chapter_title: "<h3>Chapter title<h3>"
+          chapter_title: '<h3>Chapter title<h3>'
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
+            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
             rodney: Rodney
-          footnote_title: "<h6>Footnote title<h6>"
+          footnote_title: '<h6>Footnote title<h6>'
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: "<h4>Scene title<h4>"
+          scene_title: '<h4>Scene title<h4>'
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: "<h2>Subtitle<h2>"
-          subtitle_h5: "<h5>Subtitle<h5>"
-          title: "<h1>Title<h1>"
+          subtitle_h2: '<h2>Subtitle<h2>'
+          subtitle_h5: '<h5>Subtitle<h5>'
+          title: '<h1>Title<h1>'
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
         misnested_tags:
           corrected_text: text!
-          description_html: "If you have mis-nested tags like this: &lt;em&gt;&lt;strong&gt;%{text_bold_italic}&lt;/em&gt;&lt;/strong&gt; we will fix the mis-nesting (so it would become &lt;em&gt;&lt;strong&gt;%{corrected_text_bold_italic}&lt;/strong&gt;&lt;/em&gt;)."
+          description_html: 'If you have mis-nested tags like this: &lt;em&gt;&lt;strong&gt;%{text_bold_italic}&lt;/em&gt;&lt;/strong&gt; we will fix the mis-nesting (so it would become &lt;em&gt;&lt;strong&gt;%{corrected_text_bold_italic}&lt;/strong&gt;&lt;/em&gt;).'
           text: text!
         negation: don't
         not_satisfied_note: If you find yourself putting in HTML that doesn't mean the right thing, in order to get a particular visual effect, please resist! The work skin feature allows you to apply custom CSS to works, and that lets you make them look just about any way you want them to (and is easier if you are starting from good HTML).
         recommendations:
           emphasis_html: For emphasis, use emphasis tags %{emphasis_tags_code}
-          headings_html: "For headings, use heading tags: %{heading_tags_code}"
-          lead_in: "Some specific recommendations:"
-          quote_html: "To quote poetry, phrases or titles use quote tags: %{quote_tags_code}"
+          headings_html: 'For headings, use heading tags: %{heading_tags_code}'
+          lead_in: 'Some specific recommendations:'
+          quote_html: 'To quote poetry, phrases or titles use quote tags: %{quote_tags_code}'
         single_carriage_return: If you have a single carriage return between two lines of text, we will put in a break tag for you.
         tags_spanning_paragraphs: If you open a formatting tag in one paragraph and close it several paragraphs later, we will reopen/close it within each paragraph.
         two_blank_lines: If you have two blank lines in a row between paragraphs, we will add extra whitespace in for you (with <p>&nbsp;</p>)
@@ -1370,7 +1369,7 @@ en:
       page_heading: Privacy Preferences
       preferences_faq: Preferences FAQ
     preferences_work_title_format:
-      description: "Specify how the page title looks in your browser when you are reading a story. Some examples:"
+      description: 'Specify how the page title looks in your browser when you are reading a story. Some examples:'
       example:
         default: This is the default format.
         no_fandom: Don't include the fandom.
@@ -1379,7 +1378,7 @@ en:
     rte:
       description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
       enter_once:
-        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
+        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1425,7 +1424,7 @@ en:
         scrivener:
           copy_as: Select either "Copy as HTML" or "Copy as HTML (Basic, using <p> and <span>)"
           copy_special: Choose Copy Special
-          description_html: "Scrivener users will typically get better results by pasting into the %{html_abbreviation} editor and then switching to the %{rte_abbreviation} to make changes. To copy HTML from Scrivener, do the following:"
+          description_html: 'Scrivener users will typically get better results by pasting into the %{html_abbreviation} editor and then switching to the %{rte_abbreviation} to make changes. To copy HTML from Scrivener, do the following:'
           edit_menu: Go to the Edit menu
           header: Scrivener
           html_abbreviated: HTML
@@ -1458,20 +1457,20 @@ en:
         header: Comments
       css_basics:
         description:
-          background_color_example_html: "Inside any tags with the id "header", set the background color to purple: %{background_color_css_code}"
-          blink_example_html: "Inside any tags with the class "meta", make the text blink: (we do not advise this) %{blink_css_code}"
+          background_color_example_html: 'Inside any tags with the id "header", set the background color to purple: %{background_color_css_code}'
+          blink_example_html: 'Inside any tags with the class "meta", make the text blink: (we do not advise this) %{blink_css_code}'
           css_getting_started_tutorial: Getting Started (CSS Tutorial) from MDN
           css_intro_tutorial: CSS introduction tutorial
           css_selectors_and_rules_html: The %{selector_bold} is either the name of an HTML tag (like %{body_tag_code} or %{h1_tag_code}), or it can be an id or class that has been set on a tag. The %{property_bold} is what you want to change in the contents of that tag (for instance the font size), and the %{value_bold} is what you want to set it to.
-          css_tutorials: "Some useful CSS tutorials for more information:"
-          example_css: "selector {property: value;}"
-          examples_header: "Examples:"
-          font_size_example_html: "Inside the "body" tag, set the font size slightly larger than the baseline: %{font_size_css_code}"
-          line_of_css_html: "A line of CSS code looks pretty much like this: %{example_css_code}"
+          css_tutorials: 'Some useful CSS tutorials for more information:'
+          example_css: 'selector {property: value;}'
+          examples_header: 'Examples:'
+          font_size_example_html: 'Inside the "body" tag, set the font size slightly larger than the baseline: %{font_size_css_code}'
+          line_of_css_html: 'A line of CSS code looks pretty much like this: %{example_css_code}'
           property: property
           selector: selector
           value: value
-        header: "If you are new to CSS, here are the basics:"
+        header: 'If you are new to CSS, here are the basics:'
       custom_properties:
         description:
           accepting_properties_html: All properties except %{font_family_code} and %{content_code} accept the %{var_code} function as a value. We don't allow fallbacks.
@@ -1490,24 +1489,24 @@ en:
           web_safe_fonts: a set of web-safe fonts with fallbacks
         header: Font and Font Family
       intro:
-        description: "Note that for security reasons, you can only use a limited set of CSS code: all other declarations and comments will be removed!"
+        description: 'Note that for security reasons, you can only use a limited set of CSS code: all other declarations and comments will be removed!'
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
           em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
-          precision_html: "You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}"
+          precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
         header: Numeric Values
       one_declaration_per_ruleset:
-        description_html: "The CSS parser we use retains only one declaration for each property, meaning that rulesets like %{repeated_declarations_css_code} will have all but the last %{background_code} declaration removed (so your gradient would only show up in WebKit browsers). To avoid losing declarations with repeated properties, split each one into its own ruleset, like so:"
+        description_html: 'The CSS parser we use retains only one declaration for each property, meaning that rulesets like %{repeated_declarations_css_code} will have all but the last %{background_code} declaration removed (so your gradient would only show up in WebKit browsers). To avoid losing declarations with repeated properties, split each one into its own ruleset, like so:'
         header: Use only one declaration per property per ruleset
       scale:
         description_html: You can specify scale (for the %{transform_code} property) as %{scale_numeric_value_code} where the numeric value can be specified up to two decimal places.
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
+        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1522,17 +1521,17 @@ en:
         alt: Second Square
         femslash:
           alt: F/F
-          definition: "F/F: female/female relationships"
+          definition: 'F/F: female/female relationships'
         gen:
           alt: Gen
-          definition: "Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work"
+          definition: 'Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work'
         heading: Relationships, pairings, orientations
         het:
           alt: F/M
-          definition: "F/M: female/male relationships"
+          definition: 'F/M: female/male relationships'
         multi:
           alt: Multi
-          definition: "Multi: more than one kind of relationship, or a relationship with multiple partners"
+          definition: 'Multi: more than one kind of relationship, or a relationship with multiple partners'
         none:
           alt: blank square
           definition: The work was not put in any categories
@@ -1541,13 +1540,13 @@ en:
           definition: Other relationships
         slash:
           alt: M/M
-          definition: "M/M: male/male relationships"
+          definition: 'M/M: male/male relationships'
       page_heading: Symbols we use on the Archive
       ratings:
         alt: First Square
         explicit:
           alt: E
-          definition: "Explicit: only suitable for adults"
+          definition: 'Explicit: only suitable for adults'
         general:
           alt: G
           definition: General Audiences
@@ -1588,7 +1587,7 @@ en:
           definition: The work was not marked with any Archive Warnings. Please note that an author may have included other information about their work in the Additional Tags (Genre, Warnings, Other Information) section.
         warning_yes:
           alt: exclamation mark
-          definition_html: "At least one of these warnings applies: graphic depictions of violence, major character death, rape/%{non_con}, underage sex. The specific warnings are shown in the Archive Warnings tags."
+          definition_html: 'At least one of these warnings applies: graphic depictions of violence, major character death, rape/%{non_con}, underage sex. The specific warnings are shown in the Archive Warnings tags.'
           non_con:
             acronym: non-con
             title: non-consensual sex
@@ -1608,7 +1607,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
+        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1620,17 +1619,17 @@ en:
     tags_warnings:
       choose_not_to_use:
         description: Use this if you don't want to warn for anything. You may also choose this option if you don't know what you should warn for; if you don't like warning for certain topics or warnings in general; if you want to avoid some spoilers, but not others; etc.
-        header: "Choose Not To Use Archive Warnings:"
-      description: "The %{app_name} has chosen, for legal and other reasons, to mandate that users either warn for—or explicitly choose not to warn for—a short list of common warnings: Graphic Depictions of Violence, Major Character Death, Rape/Non-Con, and Underage Sex. We understand that creators may wish to not warn for some of these things, or to warn for additional content, and have provided options for them to do so within this framework."
+        header: 'Choose Not To Use Archive Warnings:'
+      description: 'The %{app_name} has chosen, for legal and other reasons, to mandate that users either warn for—or explicitly choose not to warn for—a short list of common warnings: Graphic Depictions of Violence, Major Character Death, Rape/Non-Con, and Underage Sex. We understand that creators may wish to not warn for some of these things, or to warn for additional content, and have provided options for them to do so within this framework.'
       graphic_depictions_of_violence:
         description: This is for gory, graphic, explicitly described violence. Exactly where to draw the line is your call.
-        header: "Graphic Depictions Of Violence:"
+        header: 'Graphic Depictions Of Violence:'
       major_character_death:
         description: Please use your best judgment about who counts as a major character.
-        header: "Major Character Death:"
+        header: 'Major Character Death:'
       no_archive_warnings_apply:
         description: Use this if the Archive warnings don't apply to your content. (In other words, if it contains no graphic depictions of violence, major character death, rape/non-con, or underage sexual activity.)
-        header: "No Archive Warnings Apply:"
+        header: 'No Archive Warnings Apply:'
       other_warnings:
         html: You can also use the "Additional Tags" field to give other or more detailed warnings. Our policies regarding warnings can be found in the %{tos_link} and %{tos_faq_link}.
         tos: Terms of Service
@@ -1638,10 +1637,10 @@ en:
       page_heading: Warning Tags
       rape_non_con:
         description: This is your call. If you think your content may be seen as containing non-consensual sexual activity, but you don't feel like using this warning or you're not sure if you should, you always have the option of using "Choose Not to Use Archive Warnings" instead.
-        header: "Rape/Non-Con:"
+        header: 'Rape/Non-Con:'
       underage_sex:
         description: This is for descriptions or depictions of sexual activity involving characters under the age of eighteen. (This doesn't include dating activity like kissing or vague references with no actual description or depiction.) This warning generally applies to humans; if you are creating a pornographic work about space aliens who only live for a month or thousand-year-old vampires with twelve-year-old bodies, please just use your best judgment. You are always free to specify characters' ages or to use "Choose Not to Use Archive Warnings".
-        header: "Underage Sex:"
+        header: 'Underage Sex:'
     works_languages:
       contact_support: let us know via the Support form
       page_heading: Languages
@@ -1677,14 +1676,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
+        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
         legal_advocacy: Legal Advocacy
-        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
+        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
         open_doors: Open Doors
-        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
-        title: "Our other major projects include:"
+        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
+        title: 'Our other major projects include:'
         twc: Transformative Works and Cultures
-        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
+        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1697,7 +1696,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1706,20 +1705,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
-      effective: "Effective: November 19, 2024"
+      effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
+        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1741,7 +1740,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1754,7 +1753,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1762,7 +1761,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1771,7 +1770,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
+        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1790,13 +1789,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1804,7 +1803,7 @@ en:
         disclosing_personal_data_html: disclosing personal data, including %{special_categories_of_personal_data_link}.
         heading: II.F. Personal Information and Fannish Identities
         linking_fannish_identity: linking someone's fannish identity (such as their AO3 username) to their legal or professional identity (such as their "real life" name);
-        not_allowed: "You may not upload Content that contains seemingly accurate, non-public information about another individual without authorization. This includes:"
+        not_allowed: 'You may not upload Content that contains seemingly accurate, non-public information about another individual without authorization. This includes:'
         orphaned: Orphaned
         revealing_orphaned_creator_html: revealing the identity of the creator of an %{orphaned_link} fanwork;
         right_to_hide_delete: We reserve the right to delete, hide, or otherwise make such Content unavailable.
@@ -1812,14 +1811,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1830,11 +1829,11 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: "(%{tos_faq_link})"
+        tos_faq_in_parens_html: '(%{tos_faq_link})'
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
-      archive_for_you: "No matter your appearance, circumstances, configuration or take on the world: if you enjoy consuming, creating or commenting on fanworks, the Archive is for you."
+      archive_for_you: 'No matter your appearance, circumstances, configuration or take on the world: if you enjoy consuming, creating or commenting on fanworks, the Archive is for you.'
       archive_team: the Archive team
       diversity_statement: Diversity Statement
       dreamwidth: Dreamwidth's
@@ -1886,7 +1885,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: "@status.archiveofourown.org on Bluesky"
+        bluesky: '@status.archiveofourown.org on Bluesky'
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -1897,7 +1896,7 @@ en:
       parent_org_intro_html: The Archive of Our Own (AO3) is a project of the %{parent_org_link}.
     privacy:
       account_termination:
-        backup_copies_html: ""Active records" do not include the backup copies of Content created for legal and/or disaster recovery purposes (refer to the %{general_principles_link})."
+        backup_copies_html: '"Active records" do not include the backup copies of Content created for legal and/or disaster recovery purposes (refer to the %{general_principles_link}).'
         deletion_after_termination_html: If for any reason you %{terminate_your_account_link}, as soon as reasonably possible we will destroy active records containing your Personal Information that are visible to the public or to AO3 users, with the exception of Personal Information entered as Content that you have not deleted. "Reasonably" here means no more than thirty business days from the termination of the account.
         general_principles: General Principles
         heading: III.G. Termination of account
@@ -1923,7 +1922,7 @@ en:
         heading: III.I. Contact us
         html: If you have any questions, concerns, or complaints about this Privacy Policy, or would like to submit a data request, please %{contact_pac_link}.
       content_policy: Content Policy
-      effective: "Effective: November 19, 2024"
+      effective: 'Effective: November 19, 2024'
       information_scope:
         collect_through_use: We may collect your Personal Information (such as your IP address and email address) when you request an AO3 invitation, register for an AO3 account, or otherwise access or use AO3.
         content: Content
@@ -1932,7 +1931,7 @@ en:
         special_categories: Special Categories of Personal Data
       intro:
         answers_common_questions_html: Answers to common questions about the Privacy Policy can be found in the %{tos_faq_link}.
-        ao3_exists_to_host_html: "AO3 exists to host content by and for fans from all over the world. To do so, we process certain data and information, including %{personal_information_link}. This is so that we can:"
+        ao3_exists_to_host_html: 'AO3 exists to host content by and for fans from all over the world. To do so, we process certain data and information, including %{personal_information_link}. This is so that we can:'
         archive_description: The Archive of Our Own (AO3) is a project of the Organization for Transformative Works (OTW), which is committed to fan privacy.
         details_how_and_why_html: This Privacy Policy details how and why we collect and process this information. %{common_questions_bold}
         enable_post_information: Enable you to post comments, kudos, bookmarks, and other information designed to be seen by other users
@@ -1955,28 +1954,28 @@ en:
         sharing_exceptions:
           challenge_signup:
             challenge: Challenge
-            heading_html: "If you sign up for a %{challenge_link}:"
+            heading_html: 'If you sign up for a %{challenge_link}:'
             text: We may share your email address with the maintainers of the Challenge.
           external_processing:
-            heading: "For external processing:"
+            heading: 'For external processing:'
             html: We may use third-party services to store, process, or transmit data, or to perform other technical functions related to operating AO3. For example, we may use third-party email services. A list of third-party services is provided in our %{subprocessor_list_link}. We cannot guarantee other services' technical performance. We or the services we use may store or process your Personal Information in data centers which may be located in the United States or elsewhere.
             subprocessor_list: Subprocessor List
           handle_complaints:
             dmca_notice: Digital Millennium Copyright Act (DMCA) notice
-            heading: "To handle complaints submitted by you about TOS violations:"
+            heading: 'To handle complaints submitted by you about TOS violations:'
             html: If we receive a %{dmca_notice_link}, we reserve the right to disclose the information provided by the copyright owner or their legal representative to the subject of the complaint. If we receive a complaint from you about other matters, that information will be subject to the %{pac_confidentiality_policy_link}.
             pac_confidentiality_policy: Policy & Abuse Confidentiality Policy
-          intro: "We will not share your Personal Information with any third parties without your prior consent, except for the following cases:"
+          intro: 'We will not share your Personal Information with any third parties without your prior consent, except for the following cases:'
           legal_reasons:
             attempt_to_notify: We will attempt to notify you any time we disclose your Personal Information to a third party for legal reasons, unless legally prohibited from doing so or if, in our sole judgment, notification might hinder an ongoing investigation. In some cases, the Personal Information we have, such as an IP address, may be insufficient for us to notify you.
             cooperating_law_enforcement: are cooperating with law enforcement authorities.
             good_faith_comply: have a good-faith belief that such action is necessary to comply with a current judicial proceeding, court order, or legal process served on the OTW; or
-            heading: "For legal reasons:"
-            intro: "We may share Personal Information if we:"
+            heading: 'For legal reasons:'
+            intro: 'We may share Personal Information if we:'
             law_enforcement_cooperation_details: We will cooperate with all investigations conducted by law enforcement authorities within the United States when legally required to do so. Cooperation with law enforcement authorities from other countries and cooperation when it is not legally required are at our sole discretion. Our discretion looks favorably on freedom and justice, and unfavorably on oppression and violence.
             legally_compelled: are legally compelled to do so;
           open_doors_import:
-            heading_html: "If your work is imported via %{open_doors_link}:"
+            heading_html: 'If your work is imported via %{open_doors_link}:'
             open_doors: Open Doors
             text: If the email address associated with your AO3 account matches an email address that you used in connection with a non-AO3 archive that is being imported to AO3 via Open Doors, then we may share your email address with the entity that manages that imported archive.
         third_party_tools: Third parties have developed applications, software, scripts, browser extensions, or other tools for use in connection with AO3. Such third parties may receive Personal Information from you if you use their tools to access AO3. This Privacy Policy does not cover your use of such tools.
@@ -1985,26 +1984,26 @@ en:
         intro: The Privacy Policy is the third part of the AO3 Terms of Service.
       types_of_information:
         cookies:
-          heading: "Cookies:"
+          heading: 'Cookies:'
           text: We and our Subprocessors use cookies to collect and store visitors' preferences; customize web pages' content based on visitors' preferences or other Personal Information that the visitor sends; prevent attacks on our servers; and record activity at AO3 in order to provide better service when visitors return to our site. AO3 has no access to cookies set by other sites. If you block or disable cookies, you may be unable to access or use AO3.
         emails:
           address_usage_html: We will use your email address internally for the purposes of managing AO3 and maintaining site integrity. We may occasionally send emails to you about AO3, your Content and account, or news that we reasonably believe to be of interest to our registered users. We will also send you your invitation to register for AO3 via email. By creating and maintaining an account on AO3, you consent to receiving such emails. We reserve the right to send you notice of complaints raised against you, or alleged violations of the TOS by you, as well as to reply to any email message you send to AO3 and/or its personnel. If you choose to participate in a %{challenge_link}, the Challenge maintainer(s) may have access to your email address for the purposes of communicating with you.
           challenge: Challenge
           collect_process_retain: We collect, process, and retain the email addresses of and from those who communicate with us via email, and any Content or Personal Information included in emails to us. We need this Personal Information so we can respond to you; so we can handle complaints about AO3 and any users who may have violated the TOS or other policies; and for other legal and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
-          heading: "Emails:"
+          heading: 'Emails:'
           unsubscribe: Although it is possible to unsubscribe from some emails (such as kudos updates and responses to comments), you cannot unsubscribe from receiving emails that we, in our sole discretion, deem necessary for legal purposes or to maintain the safety and integrity of your account or our services, including other OTW sites.
         fnok:
-          heading: "Fannish next-of-kin:"
+          heading: 'Fannish next-of-kin:'
           text: We collect the contact information you and/or your fannish next-of-kin provide, and use it only to implement the fannish next-of-kin function.
         heading: III.C. Types of Personal Information we collect and process
         ip_addresses:
-          heading: "IP addresses:"
+          heading: 'IP addresses:'
           text: We and our Subprocessors collect, process, and retain the IP addresses of AO3 visitors, including registered users. IP information may also be collected by our servers for logging purposes and used for limited technical assessments of AO3. We need this Personal Information so we can provide you with the Content that you are requesting; to allow you to submit Content to us; and for other legal, TOS enforcement, and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
         logs:
-          heading: "Logs:"
+          heading: 'Logs:'
           text: We and our Subprocessors collect, process, and retain logs of server interactions. We need this Personal Information for legal, TOS enforcement, and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
         other_information:
-          heading: "Other user-specific information:"
+          heading: 'Other user-specific information:'
           to_maintain_integrity: We and our Subprocessors collect, process, and retain Personal Information about what pages you access or visit, including your interactions with integral AO3 features such as comments, kudos, and bookmarks; referral information (i.e. data about what site you are coming to AO3 from); and whether there are errors in displaying Content to you. We need this Personal Information to maintain the integrity of AO3 and the Content that we host; to provide you with the Content that you are seeking; to prevent spam and abuse; and for other legal and accounting/audit reasons.
           to_make_content_available_html: We and our Subprocessors collect, process, and retain Personal Information about Content that you submit to us. You consent to the collection of your Personal Information (such as your IP address) when you access AO3, including when you are not logged in. We use this Personal Information to make the Content you submit available to people who use AO3. By submitting Content to us, you are requesting that we make it available to those people and consenting to the use of your Content. For explanations of site features that use your Content and/or Personal Information and how they are used, please refer to the %{tos_faq_link}.
           tos_faq: TOS FAQ
@@ -2118,8 +2117,8 @@ en:
         eu_country_html: a European Union country where the processing of %{special_categories_of_personal_data_link} from children of that age requires the consent of a parent or legal guardian, or
         heading: I.H. Age Policy
         individuals_under_13: individuals under the age of thirteen (13), and
-        individuals_under_16: "individuals under the age of sixteen (16) who are not old enough, in their country of residence or citizenship, to consent to the processing of personal data. This includes individuals under the age of sixteen (16) who are residents or citizens of:"
-        intro: "AO3 does not knowingly solicit or collect information from Age-Barred Individuals. Age-Barred Individuals are:"
+        individuals_under_16: 'individuals under the age of sixteen (16) who are not old enough, in their country of residence or citizenship, to consent to the processing of personal data. This includes individuals under the age of sixteen (16) who are residents or citizens of:'
+        intro: 'AO3 does not knowingly solicit or collect information from Age-Barred Individuals. Age-Barred Individuals are:'
         not_permitted_account_upload: not permitted to have an account or upload Content
         special_categories_of_personal_data: Special Categories of Personal Data
       archive_description: The Archive of Our Own (AO3) is a home for fanworks, including fanfiction based on books, movies, TV, comics, other media, and real-person fiction (RPF).
@@ -2137,33 +2136,33 @@ en:
         otw_not_liable: The OTW is not liable to you for any Content to which you are exposed on or because of AO3.
         privacy_policy: Privacy Policy
         third_party_content_html: Some of the Content displayed on or accessible via AO3 is not hosted on AO3 or by the OTW. Such content can include text, image, audio, or video files %{hosted_by_third_party_link} ("User-Embedded Content"). If you access a page that includes User-Embedded Content, the embedded file may share data with the hosted site as if you were on or at the hosted site. Although User-Embedded Content must comply with our %{content_policy_link}, it is not otherwise governed by these Terms of Service (including the AO3 %{privacy_policy_link}), and is instead governed by the terms of use or privacy policy of the service that hosts it. We reserve the right to provide an indicator to users that User-Embedded Content is present on or visible via your Content.
-      effective: "Effective: November 19, 2024"
+      effective: 'Effective: November 19, 2024'
       general_principles_heading: I. General Principles
       general_terms:
         agreement:
-          agreement: "Agreement:"
+          agreement: 'Agreement:'
           any_other_form: any other form of content
           content_policy: Content Policy
-          html: "%{agreement} AO3 hosts and shares content created by fans, for fans. Our %{content_policy_link} and %{privacy_policy_link} are part of these Terms of Service (TOS). By submitting a work; bookmark; comment; tag; link; text, image, audio, or video file; username; fannish next-of-kin; %{personal_information_link} (such as an email address); or %{any_other_form_link} ("Content") to the Archive of Our Own service (hereinafter "Service", "AO3", or "Archive"), or by creating an account and/or accessing Content on AO3, you affirm, confirm, and state that you comply with and assent to the TOS."
+          html: '%{agreement} AO3 hosts and shares content created by fans, for fans. Our %{content_policy_link} and %{privacy_policy_link} are part of these Terms of Service (TOS). By submitting a work; bookmark; comment; tag; link; text, image, audio, or video file; username; fannish next-of-kin; %{personal_information_link} (such as an email address); or %{any_other_form_link} ("Content") to the Archive of Our Own service (hereinafter "Service", "AO3", or "Archive"), or by creating an account and/or accessing Content on AO3, you affirm, confirm, and state that you comply with and assent to the TOS.'
           personal_information: Personal Information
           privacy_policy: Privacy Policy
         entirety_of_agreement:
-          entirety_of_agreement: "Entirety of agreement:"
-          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
+          entirety_of_agreement: 'Entirety of agreement:'
+          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
         heading: I.A. General terms
         jurisdiction:
-          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
-          jurisdiction: "Jurisdiction:"
+          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
+          jurisdiction: 'Jurisdiction:'
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
-          limitation_on_claims: "Limitation on claims:"
+          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
+          limitation_on_claims: 'Limitation on claims:'
         no_assignment:
-          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
-          no_assignment: "No assignment:"
+          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
+          no_assignment: 'No assignment:'
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
-          non_severability: "Non-severability:"
+          non_severability: 'Non-severability:'
       license_html: The AO3 %{terms_of_service_link}, including the %{content_policy_link} and %{privacy_policy_link}, are licensed under the %{cc_attribution_4_0_international_link}.
       page_content_landmark: Main Text
       page_heading: Terms of Service
@@ -2194,7 +2193,7 @@ en:
       updates_to_the_tos:
         content_policy: Content Policy
         heading: I.B. Updates to the Terms of Service
-        html: "You can learn about changes to the TOS by visiting AO3. The TOS, including the %{content_policy_link} and %{privacy_policy_link}, may be modified at any time through the following process: Proposed changes will first be prominently disclosed on AO3 for a public comment period lasting at least two weeks. After the end of the comment period, proposed changes will be voted on by the OTW Board. If the OTW Board votes in favor, the changes will become effective when posted to the relevant Terms page(s). This is the only means by which the TOS may be altered. The TOS cannot be changed by emails or other communications with you."
+        html: 'You can learn about changes to the TOS by visiting AO3. The TOS, including the %{content_policy_link} and %{privacy_policy_link}, may be modified at any time through the following process: Proposed changes will first be prominently disclosed on AO3 for a public comment period lasting at least two weeks. After the end of the comment period, proposed changes will be voted on by the OTW Board. If the OTW Board votes in favor, the changes will become effective when posted to the relevant Terms page(s). This is the only means by which the TOS may be altered. The TOS cannot be changed by emails or other communications with you.'
         privacy_policy: Privacy Policy
       what_we_believe:
         ao3_run_by_html: AO3 is run by the Organization for Transformative Works (OTW). We are committed to %{defending_fanworks_link}. We have legal resources and alliances on which we can draw. However, that is not a guarantee that the OTW can or will fight each battle. The OTW Board will take into account a variety of factors, both legal and otherwise, when responding to a legal challenge. More information is available %{on_the_otw_site_link}.
@@ -2225,7 +2224,7 @@ en:
         some_content_open_doors_html: Some of the Content hosted on AO3 is imported via %{open_doors_link}. Open Doors' agreement with each collection's archivist is separate from AO3's TOS. If a work has been imported via Open Doors and its creator requests that the work be removed from AO3, we will remove it. If an archivist chooses to remove their imported collection, any imported works that have been claimed or Orphaned by their creators will remain on AO3.
         subject_to_moderation: subject to moderation
         tag_wrangling: tag wrangling
-        we_repeat: "We repeat: we do not own your Content."
+        we_repeat: 'We repeat: we do not own your Content.'
         worldwide_royalty_free_nonexclusive_license: worldwide, royalty-free, nonexclusive license
       what_you_cant_do:
         account_if_age_barred_html: to create an account if you are an %{age_barred_individual_link};
@@ -2248,11 +2247,11 @@ en:
         position_on_fanwork_legality: position on fanwork legality
         resident_embargo_country_html: to create an account if you are a resident or national of any country with which the U.S. has prohibited transactions by mandating a %{comprehensive_trade_embargo_link}, as detailed by the Office of Foreign Assets Control; or
         software_viruses: to make available any material that contains software viruses or other computer code, files, or programs designed to interrupt, destroy, or limit the functionality of any computer, hardware, or telecommunications equipment;
-        you_agree_not_to: "You agree not to use AO3 (as well as the email addresses and URLs of OTW sites):"
+        you_agree_not_to: 'You agree not to use AO3 (as well as the email addresses and URLs of OTW sites):'
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: "%{arrow} Top"
+      top: '%{arrow} Top'
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2334,8 +2333,8 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: "%{closed_bold} For more information, please check the %{news_link}."
-        news: ""Invitations" tag on AO3 News"
+        html: '%{closed_bold} For more information, please check the %{news_link}.'
+        news: '"Invitations" tag on AO3 News'
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
         other: There are %{count} people remaining on the waiting list.
@@ -2347,10 +2346,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2377,7 +2376,7 @@ en:
       resend_button: Resend Invitation
       title: Invitation Status for %{email}
     invite_request:
-      date: "At our current rate, you should receive an invitation on or around: %{date}."
+      date: 'At our current rate, you should receive an invitation on or around: %{date}.'
       position_html: You are currently number %{position} on our waiting list!
       title: Invitation Status for %{email}
     no_invitation:
@@ -2387,11 +2386,11 @@ en:
     status:
       frequency:
         one: hour
-        other: "%{count} hours"
+        other: '%{count} hours'
       heading: Invitation Request Status
       invitation_number:
-        one: "%{count} invitation"
-        other: "%{count} invitations"
+        one: '%{count} invitation'
+        other: '%{count} invitations'
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2399,12 +2398,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: "%{count} guest has also left kudos"
-      other: "%{count} guests have also left kudos"
+      one: '%{count} guest has also left kudos'
+      other: '%{count} guests have also left kudos'
     user_links:
       more_link:
-        one: "%{count} more user"
-        other: "%{count} more users"
+        one: '%{count} more user'
+        other: '%{count} more users'
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2417,15 +2416,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: "(%{code})"
+      language_code_format_html: '(%{code})'
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: "%{formatted_count} work"
-        other: "%{formatted_count} works"
+        one: '%{formatted_count} work'
+        other: '%{formatted_count} works'
   layouts:
     banner:
       hide: hide banner
@@ -2451,7 +2450,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: "%{license_link} by the %{otw_link}"
+        license_details_html: '%{license_link} by the %{otw_link}'
         view_license: View License
       landmark: Footer
       otw:
@@ -2470,7 +2469,7 @@ en:
         search: Search
     proxy_notice:
       button: Dismiss Notice
-      faux_heading: "Important message:"
+      faux_heading: 'Important message:'
       point1: You are using a proxy site that is not part of the Archive of Our Own.
       point2: The entity that set up the proxy site can see what you submit, including your IP address. If you log in through the proxy site, it can see your password.
     tos_prompt:
@@ -2524,17 +2523,17 @@ en:
         sure_html: Are you sure you want to %{mute} %{username}?
         title: Mute %{name}
         will:
-          intro: "Muting a user:"
+          intro: 'Muting a user:'
           seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
         will_not:
           hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
-          intro: "Muting a user will not:"
+          intro: 'Muting a user will not:'
           prevent_emails: prevent you from receiving comment or subscription emails from this user
       confirm_unmute:
         button: Yes, Unmute User
         cancel: Cancel
         resume:
-          intro: "Unmuting a user allows you to:"
+          intro: 'Unmuting a user allows you to:'
           see_content: see their works, series, bookmarks, and comments on the site
         sure_html: Are you sure you want to %{unmute} %{username}?
         title: Unmute %{name}
@@ -2555,27 +2554,27 @@ en:
         title: Muted Users
         will:
           intro:
-            one: "You can mute up to %{mute_limit} user. Muting a user:"
-            other: "You can mute up to %{mute_limit} users. Muting a user:"
+            one: 'You can mute up to %{mute_limit} user. Muting a user:'
+            other: 'You can mute up to %{mute_limit} users. Muting a user:'
           seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
         will_not:
           hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
-          intro: "Muting a user will not:"
+          intro: 'Muting a user will not:'
           prevent_emails: prevent you from receiving comment or subscription emails from this user
   orphans:
     orphan_user:
       orphaning_bylines_only_message_html: Orphaning will automatically remove your personal information from <strong>bylines only</strong>. It will <strong>not</strong> automatically remove your personal information from anywhere else in the work(s). Social media accounts, contact information, email addresses, names, and any other personal information posted in the title, summary, notes, tags, work body, or comment text will <strong>not</strong> be automatically removed. Comments posted by other users will also <strong>not</strong> be affected by Orphaning. If you want information removed from these places, you should edit or delete it prior to Orphaning. <strong>Once you Orphan the work(s), you will no longer be able to delete information in these places yourself</strong>.
-      orphaning_works_message_html: "Orphaning will <strong>permanently</strong> remove your username and/or pseud from the bylines of: the following work(s), their chapters, associated series, and any comments you may have left on them while logged into this account."
+      orphaning_works_message_html: 'Orphaning will <strong>permanently</strong> remove your username and/or pseud from the bylines of: the following work(s), their chapters, associated series, and any comments you may have left on them while logged into this account.'
   pagy:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: "← Previous"
+    prev: '← Previous'
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
       generating_matches: The archive is generating potential matches for this challenge. This can take a long time, especially for a large challenge! We'll send an email to the collection maintainers when all potential matches have been generated.
-      generation_progress: "Potential match generation progress:"
+      generation_progress: 'Potential match generation progress:'
       if_progress_doesnt_change: If the progress value below doesn't change when you reload the page after about 10 minutes, there may have been a problem. Please check again after an hour, and then contact archive support.
     index:
       assignments_generating:
@@ -2665,8 +2664,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: "%{count} more pseud"
-        other: "%{count} more pseuds"
+        one: '%{count} more pseud'
+        other: '%{count} more pseuds'
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2698,11 +2697,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: " %{pseud}"
+      delete_landmark_text: ' %{pseud}'
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: " %{pseud}"
+      edit_landmark_text: ' %{pseud}'
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: " by %{pseud}"
+      orphan_landmark_text: ' by %{pseud}'
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2741,16 +2740,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: "(Hidden by Admin)"
+      hidden_by_admin_alt: '(Hidden by Admin)'
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: "(Restricted)"
-      series_by_html: "%{series_title_link} by %{byline}"
+      restricted_alt: '(Restricted)'
+      series_by_html: '%{series_title_link} by %{byline}'
     series_order:
-      draft_work_title: "%{title} (DRAFT)"
+      draft_work_title: '%{title} (DRAFT)'
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2758,7 +2757,7 @@ en:
       css: CSS
       description: Description
       icon: Upload a preview (png, jpeg or gif)
-      load_archive_skin_components: "Load Archive Skin Components:"
+      load_archive_skin_components: 'Load Archive Skin Components:'
       parent_skins: Parent Skins
       public: Apply to make public
       skin_type: Type
@@ -2815,13 +2814,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: "(Series)"
-      work: "(Work)"
+      series: '(Series)'
+      work: '(Work)'
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: "%{type} (%{count} left to review)"
-      paginated: "%{from} - %{to} of %{total} %{type}"
+      left_to_review: '%{type} (%{count} left to review)'
+      paginated: '%{from} - %{to} of %{total} %{type}'
   tag_wranglers:
     index:
       filters:
@@ -2830,42 +2829,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
+      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
+        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
+        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
+        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
-        heading: "General Wrangling Resources:"
+        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
+        heading: 'General Wrangling Resources:'
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
+        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
+        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
+        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
+        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
+        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
+        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
+        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
+        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
+        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
+        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2877,8 +2876,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
-        tw_wranglers_slack: "#tw-wranglers"
+        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
+        tw_wranglers_slack: '#tw-wranglers'
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2896,7 +2895,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: "%{tag_type} (%{count})"
+      tag_type_and_count: '%{tag_type} (%{count})'
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2906,7 +2905,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: "%{use_type} (%{count})"
+      use_type_and_count: '%{use_type} (%{count})'
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2943,13 +2942,13 @@ en:
       canonical_html: It's a %{canonical_tag_link}. You can use it to %{filter_works_link} and to %{filter_bookmarks_link}.
       canonical_tag: canonical tag
       children:
-        heading: "Child tags (displaying the first %{count} of each type):"
+        heading: 'Child tags (displaying the first %{count} of each type):'
         more: and more
       fandom_relationship_tags: Relationship tags in this fandom
       filter_bookmarks: filter bookmarks
       filter_works: filter works
       list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
-      synonyms: "Tags with the same meaning:"
+      synonyms: 'Tags with the same meaning:'
     wrangle:
       manage:
         comments: Comments (%{count})
@@ -2998,7 +2997,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
+        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3024,8 +3023,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: "%{minimum} to %{count} character"
-        other: "%{minimum} to %{count} characters"
+        one: '%{minimum} to %{count} character'
+        other: '%{minimum} to %{count} characters'
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3047,7 +3046,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3072,7 +3071,7 @@ en:
       co_creations:
         legend: Works You Made With Others
         orphan_info: You are not able to delete these as they are shared works, but you can %{orphan_link} them or remove yourself completely as a co-creator.
-        summary: "You have %{work_count} work(s) co-created with the following users: %{co_creators}."
+        summary: 'You have %{work_count} work(s) co-created with the following users: %{co_creators}.'
       confirm: Are you sure? This can't be undone!
       heading: What do you want to do with your works?
       options:
@@ -3083,10 +3082,10 @@ en:
       orphan: orphan
       orphaning: orphaning
       sole_creations:
-        collections_summary: "You have %{collection_count} collection(s) under the following pseuds: %{pseuds}."
+        collections_summary: 'You have %{collection_count} collection(s) under the following pseuds: %{pseuds}.'
         legend: Works and Collections You Made By Yourself
         options_info: You can delete them, but please consider %{orphaning_link} them instead!
-        works_summary: "You have %{work_count} work(s) under the following pseuds: %{pseuds}."
+        works_summary: 'You have %{work_count} work(s) under the following pseuds: %{pseuds}.'
       submit: Save
     edit_header_navigation:
       change_email: Change Email
@@ -3108,8 +3107,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: "%{minimum} to %{count} character"
-          other: "%{minimum} to %{count} characters"
+          one: '%{minimum} to %{count} character'
+          other: '%{minimum} to %{count} characters'
         submit: Submit
       new:
         email_html: Email address
@@ -3139,10 +3138,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: "%{minimum} to %{maximum} characters"
+        password_requirements: '%{minimum} to %{maximum} characters'
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
+        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3185,17 +3184,17 @@ en:
       passwd:
         landmark_submit: Submit
         log_in: Log in
-        password: "Password:"
+        password: 'Password:'
         remember_me: Remember me
-        username_or_email: "Username or email:"
+        username_or_email: 'Username or email:'
       passwd_small:
         create_an_account: Create an Account
         forgot_password: Forgot password?
         get_an_invitation: Get an Invitation
         log_in: Log In
-        password: "Password:"
+        password: 'Password:'
         remember_me: Remember Me
-        username_or_email: "Username or email:"
+        username_or_email: 'Username or email:'
     show:
       login_banner:
         contact_abuse: contact our Policy & Abuse team
@@ -3255,7 +3254,7 @@ en:
       show_co-creator_options: Add co-creators?
     drafts:
       page_heading: Unposted Draft
-      please_note: "Please note:"
+      please_note: 'Please note:'
       unposted_drafts_get_deleted: Unposted drafts are only saved for 30 days from the day they are first created, and then deleted from %{app_name}.
     edit_multiple:
       works_languages_help_title: Languages help
@@ -3264,7 +3263,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: "%{work_link} (Draft)"
+      draft_work_title_html: '%{work_link} (Draft)'
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3273,8 +3272,8 @@ en:
       recent_works_html: These are some of the latest works posted to the Archive. To find more works, %{choose_fandom_link} or %{advanced_search_link}.
     meta:
       original_creators:
-        one: "Original Creator ID:"
-        other: "Original Creator IDs:"
+        one: 'Original Creator ID:'
+        other: 'Original Creator IDs:'
     navigate:
       page_heading_html: Chapter Index for %{work_link} by %{creators}
     new_import:
@@ -3316,13 +3315,13 @@ en:
       a11y_label: Work
       label: Work Search
       submit: Search
-      tooltip_label: "tip:"
+      tooltip_label: 'tip:'
     search_form:
       creator: Creator
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: " (Draft)"
+      draft: ' (Draft)'
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3334,8 +3333,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
-        revealed_html: "%{work_link} by %{creator_link}"
+        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
+        revealed_html: '%{work_link} by %{creator_link}'
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3360,15 +3359,15 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
-        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
+        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
+        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
         more_notes: more notes
         notes: notes
-        related_works_html: "(See the end of the work for %{related_works_link}.)"
+        related_works_html: '(See the end of the work for %{related_works_link}.)'
       translated_to:
-        restricted_html: "Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)"
-        revealed_html: "Translation into %{language} available: %{work_link} by %{creator_link}"
-        unrevealed_html: "Translation into %{language} available: A work in an unrevealed collection"
+        restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
+        revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
+        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection'
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link} (Log in to access.)
         revealed_html: A translation of %{work_link} by %{creator_link}

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -946,8 +946,8 @@ en:
       previous_comment: Previous Comment
     preview:
       anonymous_creator: Anonymous Creator
-      back_to_edit: Back to Edit
       commenting_on_html: 'Commenting on: %{commentable_link}'
+      edit_comment_heading: Edit Comment
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -890,6 +890,7 @@ en:
       legend: Post Comment
       preview_button: Preview
       processing_message: Please wait...
+      cancel_redirect_warning: You will lose any changes you have made. Are you sure?
     commentable:
       actions:
         comment: Comment

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -923,7 +923,6 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
-      commenting_on: "Commenting on: %{commentable_link}"
       page_heading: Preview Comment
       post_comment: Post Comment
     show:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -851,7 +851,6 @@ en:
       error: Sorry, that comment is currently in moderation.
     check_permission_to_edit:
       error:
-        frozen: This comment is frozen.
         has_replies: Comments with replies cannot be edited
     check_permission_to_moderate:
       error: Sorry, you don't have permission to moderate that comment.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -6,7 +6,7 @@ en:
     new:
       do_not_spam:
         delay: it may take several months for us to get to your report
-        paragraph_html: '%{split_bold} Our volunteer team is small, so %{delay_link}.'
+        paragraph_html: "%{split_bold} Our volunteer team is small, so %{delay_link}."
         split: Please only report one user at a time, and do not submit multiple reports about the same user.
       form:
         comment:
@@ -41,7 +41,7 @@ en:
         page_title: Policy Questions & Abuse Reports
       include:
         evidence_html: links to any relevant %{sources_link} or screenshots
-        intro: 'What to include in your report description:'
+        intro: "What to include in your report description:"
         other_content: links to any of their other content that you would like to report
         quote: a quote from or summary of the content that violates the Terms of Service
         reported_username: username of the person you are reporting
@@ -69,7 +69,7 @@ en:
         email: an email explaining why
         hack: You believe that your AO3 account was hacked.
         harassment: You have experienced or witnessed harassment taking place on AO3.
-        intro_html: 'Potential reasons to submit a report to the %{pac_link} team:'
+        intro_html: "Potential reasons to submit a report to the %{pac_link} team:"
         pac: Policy & Abuse
         suspended_html: You have been suspended or your work has been removed, and you have not received %{email_link}.
         tos: Terms of Service
@@ -185,7 +185,7 @@ en:
           creations: Creations
         no_creations: This user has no works or comments.
         page_heading: Works and Comments by %{user} (%{id})
-        page_title: '%{login} - User Creations'
+        page_title: "%{login} - User Creations"
       history:
         heading: User History
         table:
@@ -201,7 +201,7 @@ en:
             current:
               action: Most Recent Login
               no_details: No login recorded
-            details: 'IP Address: %{ip}'
+            details: "IP Address: %{ip}"
             last:
               action: Previous Login
               no_details: No previous login recorded
@@ -219,20 +219,20 @@ en:
             submit: Update Fannish Next of Kin
           heading: Fannish Next of Kin
         info:
-          email: 'Email:'
+          email: "Email:"
           heading: User Information
-          invitation: 'Invitation:'
+          invitation: "Invitation:"
           no_invitation: Created without invitation
           no_role: No roles
           past_emails:
-            one: 'Past email:'
-            other: 'Past emails:'
+            one: "Past email:"
+            other: "Past emails:"
           past_logins:
-            one: 'Past username:'
-            other: 'Past usernames:'
+            one: "Past username:"
+            other: "Past usernames:"
           role:
-            one: 'Role:'
-            other: 'Roles:'
+            one: "Role:"
+            other: "Roles:"
         navigation:
           activate: Activate
           creations: Creations
@@ -243,16 +243,16 @@ en:
           roles: Manage Roles
           troubleshoot: Troubleshoot
         note: To fix common errors with this user's Subscriptions and Stats pages, and to reindex the user and their works and bookmarks, choose "Troubleshoot."
-        page_heading: 'User: %{login} (%{id})'
-        page_title: '%{login} - User Administration'
+        page_heading: "User: %{login} (%{id})"
+        page_title: "%{login} - User Administration"
         status:
           form:
             admin_action:
               ban: Suspend permanently (ban user)
               legend: Warnings and Suspensions
               note: Record note
-              spamban: 'Spammer: ban and delete all creations'
-              suspend: 'Suspend: enter a whole number of days'
+              spamban: "Spammer: ban and delete all creations"
+              suspend: "Suspend: enter a whole number of days"
               unban: Lift permanent suspension, effective immediately.
               unsuspend: Lift temporary suspension, effective immediately.
               warn: Record warning
@@ -303,7 +303,7 @@ en:
     blacklist:
       emails_found:
         one: one email found
-        other: '%{count} emails found'
+        other: "%{count} emails found"
     blacklisted_emails:
       create:
         browser_title: Create Banned Email
@@ -360,7 +360,7 @@ en:
     passwords:
       edit:
         describedby:
-          password_length: '%{minimum} to %{maximum} characters'
+          password_length: "%{minimum} to %{maximum} characters"
         label:
           confirmation: Confirm new password
           password: New password
@@ -418,8 +418,8 @@ en:
           disable_support_form: Turn Off Support Form
           performance_and_misc: Performance and Misc
         queue_status:
-          one: '%{count} person is scheduled to be sent an invitation at %{time}.'
-          other: '%{count} people are scheduled to be sent invitations at %{time}.'
+          one: "%{count} person is scheduled to be sent an invitation at %{time}."
+          other: "%{count} people are scheduled to be sent invitations at %{time}."
         queue_status_help: "(The automatic task that invites people from the queue runs at most every hour. Don't be alarmed if the time you see is within the last hour. Do be alarmed if the time you see is more than one hour in the past and the queue is supposed to be active.)"
         update: Update
       update:
@@ -484,13 +484,13 @@ en:
           general_info: Two-step verification, also called two-factor authentication, helps prevent other people from accessing your account even if they know your password. All you need to set it up is an authenticator app such as 1Password, Google Authenticator, or Twilio Authy.
           heading: About Two-Step Verification
         app_setup:
-          heading: 'Step 1: Set up your authenticator app'
+          heading: "Step 1: Set up your authenticator app"
           instructions: Use your authenticator app to scan the QR code or enter the manual setup key. The app will give you a 6-digit code, which you'll use in the next step.
           key:
             format_note: Spaces and capitalization don't matter
             heading: Setup Key
         enter_code:
-          heading: 'Step 2: Enter your 6-digit code'
+          heading: "Step 2: Enter your 6-digit code"
           instructions: Enter the 6-digit code from your app to enable two-step verification
           label: 6-digit code
           please_wait: Please wait...
@@ -501,7 +501,7 @@ en:
         copy_to_clipboard: Copy Backup Codes to Clipboard
         finish: Finish
         page_heading: Two-Step Verification Backup Codes
-        write_codes_down: 'Keep these backup codes in a safe and secure place in case you lose access to your authenticator app:'
+        write_codes_down: "Keep these backup codes in a safe and secure place in case you lose access to your authenticator app:"
     user_creations:
       confirm_remove_pseud:
         caution: Are you sure you want to remove the creator's pseud from this work?
@@ -569,7 +569,7 @@ en:
       elasticsearch_update_notice_html: Our search engine has recently been updated, and this FAQ is based on our old version. We're working on bringing you more up-to-date information, but in the meantime, you can find out more in our %{elasticsearch_news_link}!
       no_category_entries: We're sorry, there are currently no entries in this category.
       page_heading: Archive FAQ
-      screencast: 'Screencast:'
+      screencast: "Screencast:"
   blocked:
     block: Block
     unblock: Unblock
@@ -585,20 +585,20 @@ en:
         will:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
-          intro: 'Blocking a user prevents them from:'
+          intro: "Blocking a user prevents them from:"
           replying: replying to your comments anywhere on the site
         will_not:
           comments_elsewhere: hide their comments elsewhere on the site
           comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
           hide_works: hide their works or bookmarks from you
-          intro: 'Blocking a user will not:'
+          intro: "Blocking a user will not:"
       confirm_unblock:
         button: Yes, Unblock User
         cancel: Cancel
         resume:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
-          intro: 'Unblocking a user allows them to resume:'
+          intro: "Unblocking a user allows them to resume:"
           replying: replying to your comments anywhere on the site
         sure_html: Are you sure you want to %{unblock} %{username}?
         title: Unblock %{name}
@@ -619,14 +619,14 @@ en:
           commenting: commenting or leaving kudos on your works
           gifting: giving you gift works outside of challenge assignments and claimed prompts
           intro:
-            one: 'You can block up to %{block_limit} user. Blocking a user prevents them from:'
-            other: 'You can block up to %{block_limit} users. Blocking a user prevents them from:'
+            one: "You can block up to %{block_limit} user. Blocking a user prevents them from:"
+            other: "You can block up to %{block_limit} users. Blocking a user prevents them from:"
           replying: replying to your comments anywhere on the site
         will_not:
           comments_elsewhere: hide their comments elsewhere on the site
           comments_on_works: delete or hide comments they previously left on your works; you can delete these individually
           hide_works: hide their works or bookmarks from you
-          intro: 'Blocking a user will not:'
+          intro: "Blocking a user will not:"
   bookmarks:
     bookmark_blurb:
       deleted: This has been deleted, sorry!
@@ -682,14 +682,14 @@ en:
         fandom: Fandom %{allowed_fandom_count}
   challenge_assignments:
     assignment_blurb:
-      header_draft_html: '%{title_link} (Draft)'
+      header_draft_html: "%{title_link} (Draft)"
       stats:
         creation:
-          posted: 'Posted:'
-          unposted: 'Created:'
+          posted: "Posted:"
+          unposted: "Created:"
         status:
           fulfilled: Complete!
-          header: 'Status:'
+          header: "Status:"
           unapproved: Unapproved
           unposted: Unposted
     to_default:
@@ -768,32 +768,32 @@ en:
   collection_profile:
     show:
       meta:
-        collection_tags: 'Collection tags:'
+        collection_tags: "Collection tags:"
   collections:
     collection_blurb:
-      collection_tags: 'Collection Tags:'
-      signups_close_at: 'Sign-ups close at:'
+      collection_tags: "Collection Tags:"
+      signups_close_at: "Sign-ups close at:"
       summary: Summary
     filters:
       clear_filters: Clear Filters
       closed:
-        exclude: 'No'
+        exclude: "No"
         include: Either
         label: Closed
-        only: 'Yes'
+        only: "Yes"
       landmark: Filters
       leave_filters: Top of Collections Index
-      legend: 'Filter collections:'
+      legend: "Filter collections:"
       moderated:
-        exclude: 'No'
+        exclude: "No"
         include: Either
         label: Moderated
-        only: 'Yes'
+        only: "Yes"
       multifandom:
-        exclude: 'No'
+        exclude: "No"
         include: Either
         label: Multifandom
-        only: 'Yes'
+        only: "Yes"
       sort:
         column: Sort by
         direction:
@@ -912,7 +912,7 @@ en:
           draft: Sorry, you can't comment on a draft.
           hidden: Sorry, you can't add or edit comments on a hidden work.
           unrevealed: Sorry, you can't add or edit comments on an unrevealed work.
-      previous_chapter_html: '%{back_arrow_html} Previous Chapter'
+      previous_chapter_html: "%{back_arrow_html} Previous Chapter"
     confirm_delete:
       confirm_button: Yes, delete!
       delete_confirmation: Are you sure you want to delete this comment?
@@ -923,7 +923,7 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
-      commenting_on_html: 'Commenting on: %{commentable_link}'
+      commenting_on_html: "Commenting on: %{commentable_link}"
       missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
@@ -944,8 +944,8 @@ en:
       comment: drop by the Archive and comment
       end_notes: End Notes
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link}'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link}"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
       please_comment_html: Please %{comment_link} to let the creator know if you enjoyed their work!
@@ -955,42 +955,42 @@ en:
       chapter_end_notes_without_chapter_notes: notes
       chapter_notes: Chapter Notes
       chapter_summary: Chapter Summary
-      full_chapter_title_with_title: 'Chapter %{chapter_number}: %{title}'
+      full_chapter_title_with_title: "Chapter %{chapter_number}: %{title}"
       full_chapter_title_without_title: Chapter %{chapter_number}
       section_chapter_end_notes: Chapter End Notes
       see_chapter_end_notes_html: See the end of the chapter for %{chapter_end_notes_link}
     download_preface:
       byline_html: by %{byline_names_link}
-      chapters: 'Chapters: %{chapter_total_display}'
-      collections: 'Collections:'
-      completed: 'Completed: %{date}'
+      chapters: "Chapters: %{chapter_total_display}"
+      collections: "Collections:"
+      completed: "Completed: %{date}"
       end_notes_with_work_notes: more notes
       end_notes_without_work_notes: notes
       inspired_by:
         restricted_html: Inspired by [Restricted Work] by %{creator_link}
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
-      language: 'Language:'
+      language: "Language:"
       notes: Notes
       originally_posted_html: Posted originally on the %{archive_link} at %{work_url}.
       preface: Preface
-      published: 'Published: %{date}'
+      published: "Published: %{date}"
       see_end_notes_html: See the end of the work for %{end_notes_link}
-      series: 'Series:'
+      series: "Series:"
       series_list_html: Part %{position} of %{series_link}
-      stats: 'Stats:'
+      stats: "Stats:"
       summary: Summary
-      tag_type: '%{tag_type}:'
+      tag_type: "%{tag_type}:"
       translated_to:
-        restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link}'
-        revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
-        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection'
+        restricted_html: "Translation into %{language} available: [Restricted Work] by %{creator_link}"
+        revealed_html: "Translation into %{language} available: %{work_link} by %{creator_link}"
+        unrevealed_html: "Translation into %{language} available: A work in an unrevealed collection"
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link}
         revealed_html: A translation of %{work_link} by %{creator_link}
         unrevealed: A translation of a work in an unrevealed collection
-      updated: 'Updated: %{date}'
-      words: 'Words: %{count_with_delimiters}'
+      updated: "Updated: %{date}"
+      words: "Words: %{count_with_delimiters}"
   errors:
     '429':
       browse_more_slowly: If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
@@ -1036,7 +1036,7 @@ en:
         other: Claim your works as %{current_user}. If you would like to claim these works under a different account (or create a new account to claim them with), log out and reload this page first.
       contact_open_doors: contact Open Doors
       dashboard: dashboard
-      import_without_email: 'Important: If you tick "Do not email me in future" but do not tick "Do not import works", works may be imported without you being told. If that''s not what you want, turn off importing as well as emails.'
+      import_without_email: "Important: If you tick "Do not email me in future" but do not tick "Do not import works", works may be imported without you being told. If that''s not what you want, turn off importing as well as emails."
       invitation_to_create_account:
         one: We invite you to create an account on %{app_name}! The work will automatically be added to your account and you will have full control over it.
         other: We invite you to create an account on %{app_name}! The works will automatically be added to your account and you will have full control over them.
@@ -1092,7 +1092,7 @@ en:
       abuse:
         contact: contact our Policy and Abuse team
         reports_html: For reports of violations of the Terms of Service such as harassment, spam, or plagiarism, or if you believe your account has been hacked, please %{contact_link} instead. We cannot act on these reports or provide information about Policy and Abuse cases.
-      do_not_spam_html: '<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer.'
+      do_not_spam_html: "<strong>We respond to every report we receive, but we are a small volunteer team.</strong> For this reason, we ask you to not submit multiple reports regarding any one issue, or encourage other people to report the same issue, unless there is additional information to offer."
       form:
         comment:
           description: Please be as specific as possible, including error messages and/or links
@@ -1119,7 +1119,7 @@ en:
         landmark:
           reference: Reference Links
         page_title: Support and Feedback
-      languages_html: '<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English.'
+      languages_html: "<strong>We can answer Support inquiries in %{list_html}.</strong> Please allow for additional delay for responses in any language other than English."
       navigation:
         faqs: FAQs & Tutorials
         known_issues: Known Issues
@@ -1130,7 +1130,7 @@ en:
         fnok:
           concerning_html: Setting up, changing, or activating your %{fnok_link}
           fnok: Fannish Next of Kin
-        intro: 'Some issues you can contact Support about include:'
+        intro: "Some issues you can contact Support about include:"
         lost_access: Lost password or email preventing access to your account
         new_features: Feature requests for future development
         orphaned_works: Questions about orphaned works
@@ -1139,7 +1139,7 @@ en:
         tag_changes: Requests to canonize or change tags
         work_problems: Works labeled with the wrong language or duplicate works
       status:
-        bluesky: '@status.archiveofourown.org'
+        bluesky: "@status.archiveofourown.org"
         current_html: For current updates on AO3 performance or downtime, please check our %{status_page_link} and follow %{bluesky_link} on Bluesky or %{tumblr_link} on Tumblr.
         status_page: status page
         tumblr: ao3org
@@ -1187,11 +1187,11 @@ en:
         html: To open the Post New Work page, just select the %{post_new_link} link from the menu of the Post tab located at the top right of the page in the default browser skin. Visit the %{posting_editing_faq_link} or check out our %{tutorial_link} for more information.
         post_new: Post New
         posting_editing_faq: Posting and Editing FAQ
-        tutorial: 'Tutorial: Posting a Work on AO3'
+        tutorial: "Tutorial: Posting a Work on AO3"
       preferences:
         edit_my_profile: Edit My Profile
         header: Preferences
-        html: '"%{set_my_preferences_link}" is located next to the "%{edit_my_profile_link}" button, and allows you to adjust certain settings to personalize your experience on the site. The Preferences area controls both the Archive''s behavior (such as whether your history is saved) and the Archive''s appearance. Go to the %{preferences_faq_link} for more details.'
+        html: ""%{set_my_preferences_link}" is located next to the "%{edit_my_profile_link}" button, and allows you to adjust certain settings to personalize your experience on the site. The Preferences area controls both the Archive''s behavior (such as whether your history is saved) and the Archive''s appearance. Go to the %{preferences_faq_link} for more details."
         preferences_faq: Preferences FAQ
         set_my_preferences: Set My Preferences
         skins_detail_html: For more information on how to customize the skins and interface of the Archive, refer to the %{skins_faq_link} and %{tutorials_list_link}.
@@ -1226,7 +1226,7 @@ en:
         tos_faq: Terms of Service FAQ
       warnings:
         archive_specific_warnings: Archive-specific warnings
-        description_html: 'The Archive defines four "primary" %{archive_specific_warnings_link}: "Graphic Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and "Underage Sex". When posting a work, you have the option to explicitly select warnings for this content, deny the presence of such content ("No Archive Warnings Apply"), or choose not to apply warnings regardless of whether or not these warnings are applicable ("Creator Chose Not To Use Archive Warnings"). Remember, "No Archive Warnings Apply" only refers to the listed primary warnings.'
+        description_html: "The Archive defines four "primary" %{archive_specific_warnings_link}: "Graphic Depictions Of Violence", "Major Character Death", "Rape/Non-Con", and "Underage Sex". When posting a work, you have the option to explicitly select warnings for this content, deny the presence of such content ("No Archive Warnings Apply"), or choose not to apply warnings regardless of whether or not these warnings are applicable ("Creator Chose Not To Use Archive Warnings"). Remember, "No Archive Warnings Apply" only refers to the listed primary warnings."
         header: Warnings
         symbols_html: When browsing the Archive, warnings will be displayed in the blurb of each work. Official warning tags are displayed in bold. A four square grid in the top left corner of each work's blurb indicates the work's rating, completion status, pairing category, and any Archive warnings that apply to it. Refer to the %{symbols_key_chart_link} for more information.
         symbols_key_chart: Symbols Key Chart
@@ -1237,43 +1237,43 @@ en:
       formatting:
         a_blank_line: If you leave a blank line between two paragraphs, we will put paragraph tags in for you around the two paragraphs.
         after_first_put_note: When you edit your HTML after you first put it in, you will see the results of our formatting work, so you can correct any mistakes our formatter might have made. Please note that the best way to get good results is to put in good HTML -- that is how you can be sure your story will look right across various browsers, screen readers, mobile devices, and downloads.
-        description: 'When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:'
+        description: "When you enter HTML into the archive, we do some cleanup on it to make sure that it is safe (so spammers and hackers cannot upload badness) and try and do some basic formatting both for your convenience and for accessibility reasons. Here are the formatting steps we take:"
         example:
           blockquote:
-            description_html: '&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;'
+            description_html: "&lt;blockquote&gt;%{text_blockquote}&lt;/blockquote&gt;"
             text: To quote a block of text
-          chapter_title: '<h3>Chapter title<h3>'
+          chapter_title: "<h3>Chapter title<h3>"
           cite:
             description_html: Try cite to cite &lt;cite&gt;%{phrase_or_title_cite}&lt;/cite&gt;
             phrase_or_title: a phrase or title
           em:
-            description_html: '&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay'
+            description_html: "&lt;em&gt;%{rodney_italic}&lt;/em&gt; McKay"
             rodney: Rodney
-          footnote_title: '<h6>Footnote title<h6>'
+          footnote_title: "<h6>Footnote title<h6>"
           inline_quote:
             description_html: Use q to &lt;q&gt;%{phrase_inline_quote}&lt;/q&gt;
             phrase: To quote a phrase
-          scene_title: '<h4>Scene title<h4>'
+          scene_title: "<h4>Scene title<h4>"
           strong:
             description_html: I will &lt;strong&gt;%{never_bold}&lt;/strong&gt; understand you!
             never: never
-          subtitle_h2: '<h2>Subtitle<h2>'
-          subtitle_h5: '<h5>Subtitle<h5>'
-          title: '<h1>Title<h1>'
+          subtitle_h2: "<h2>Subtitle<h2>"
+          subtitle_h5: "<h5>Subtitle<h5>"
+          title: "<h1>Title<h1>"
         forgotten_open_tags: If you have forgotten to close a formatting tag, it will be closed at the end of the paragraph for you.
         good_html_note_html: Good HTML means HTML that labels what the text is supposed to be -- so if you have paragraphs, they should be inside paragraph tags, not just separated with break tags. If you have emphasized text, it should be inside em tags. If you have a list of items, each item should be inside list tags. If you %{negation_italic} have a list of items, you shouldn't have list tags. :) (We are putting together a set of more detailed helpful references about this, but this is the basic idea.)
         header: How Do We Format Your HTML?
         misnested_tags:
           corrected_text: text!
-          description_html: 'If you have mis-nested tags like this: &lt;em&gt;&lt;strong&gt;%{text_bold_italic}&lt;/em&gt;&lt;/strong&gt; we will fix the mis-nesting (so it would become &lt;em&gt;&lt;strong&gt;%{corrected_text_bold_italic}&lt;/strong&gt;&lt;/em&gt;).'
+          description_html: "If you have mis-nested tags like this: &lt;em&gt;&lt;strong&gt;%{text_bold_italic}&lt;/em&gt;&lt;/strong&gt; we will fix the mis-nesting (so it would become &lt;em&gt;&lt;strong&gt;%{corrected_text_bold_italic}&lt;/strong&gt;&lt;/em&gt;)."
           text: text!
         negation: don't
         not_satisfied_note: If you find yourself putting in HTML that doesn't mean the right thing, in order to get a particular visual effect, please resist! The work skin feature allows you to apply custom CSS to works, and that lets you make them look just about any way you want them to (and is easier if you are starting from good HTML).
         recommendations:
           emphasis_html: For emphasis, use emphasis tags %{emphasis_tags_code}
-          headings_html: 'For headings, use heading tags: %{heading_tags_code}'
-          lead_in: 'Some specific recommendations:'
-          quote_html: 'To quote poetry, phrases or titles use quote tags: %{quote_tags_code}'
+          headings_html: "For headings, use heading tags: %{heading_tags_code}"
+          lead_in: "Some specific recommendations:"
+          quote_html: "To quote poetry, phrases or titles use quote tags: %{quote_tags_code}"
         single_carriage_return: If you have a single carriage return between two lines of text, we will put in a break tag for you.
         tags_spanning_paragraphs: If you open a formatting tag in one paragraph and close it several paragraphs later, we will reopen/close it within each paragraph.
         two_blank_lines: If you have two blank lines in a row between paragraphs, we will add extra whitespace in for you (with <p>&nbsp;</p>)
@@ -1370,7 +1370,7 @@ en:
       page_heading: Privacy Preferences
       preferences_faq: Preferences FAQ
     preferences_work_title_format:
-      description: 'Specify how the page title looks in your browser when you are reading a story. Some examples:'
+      description: "Specify how the page title looks in your browser when you are reading a story. Some examples:"
       example:
         default: This is the default format.
         no_fandom: Don't include the fandom.
@@ -1379,7 +1379,7 @@ en:
     rte:
       description_html: "The exact behavior of the Rich Text Editor (%{rte_abbreviation}) depends on your device, browser, and operating system as well as the source you're pasting from. However, starting with a well-formatted document will help you get the most out of the %{rte_abbreviation_no_title}. Here are some general tips to ensure that as much of your formatting as possible will be retained:"
       enter_once:
-        description_html: '%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags.'
+        description_html: "%{intro_sentence_bold_html} Pressing %{enter_for_twice_key} twice will insert a blank paragraph, creating additional, and likely unwanted, space between paragraphs when you paste into the %{rte_abbreviation}. The Archive uses top and bottom margins to create the appearance of a blank line between paragraphs; you can use the paragraph formatting options in your text editor to create a similar effect without adding extra %{p_tag_code} tags."
         enter_for_once: Enter
         enter_for_twice: Enter
         intro_sentence_html: Press %{enter_for_once_key} %{once_italic} between paragraphs.
@@ -1425,7 +1425,7 @@ en:
         scrivener:
           copy_as: Select either "Copy as HTML" or "Copy as HTML (Basic, using <p> and <span>)"
           copy_special: Choose Copy Special
-          description_html: 'Scrivener users will typically get better results by pasting into the %{html_abbreviation} editor and then switching to the %{rte_abbreviation} to make changes. To copy HTML from Scrivener, do the following:'
+          description_html: "Scrivener users will typically get better results by pasting into the %{html_abbreviation} editor and then switching to the %{rte_abbreviation} to make changes. To copy HTML from Scrivener, do the following:"
           edit_menu: Go to the Edit menu
           header: Scrivener
           html_abbreviated: HTML
@@ -1458,20 +1458,20 @@ en:
         header: Comments
       css_basics:
         description:
-          background_color_example_html: 'Inside any tags with the id "header", set the background color to purple: %{background_color_css_code}'
-          blink_example_html: 'Inside any tags with the class "meta", make the text blink: (we do not advise this) %{blink_css_code}'
+          background_color_example_html: "Inside any tags with the id "header", set the background color to purple: %{background_color_css_code}"
+          blink_example_html: "Inside any tags with the class "meta", make the text blink: (we do not advise this) %{blink_css_code}"
           css_getting_started_tutorial: Getting Started (CSS Tutorial) from MDN
           css_intro_tutorial: CSS introduction tutorial
           css_selectors_and_rules_html: The %{selector_bold} is either the name of an HTML tag (like %{body_tag_code} or %{h1_tag_code}), or it can be an id or class that has been set on a tag. The %{property_bold} is what you want to change in the contents of that tag (for instance the font size), and the %{value_bold} is what you want to set it to.
-          css_tutorials: 'Some useful CSS tutorials for more information:'
-          example_css: 'selector {property: value;}'
-          examples_header: 'Examples:'
-          font_size_example_html: 'Inside the "body" tag, set the font size slightly larger than the baseline: %{font_size_css_code}'
-          line_of_css_html: 'A line of CSS code looks pretty much like this: %{example_css_code}'
+          css_tutorials: "Some useful CSS tutorials for more information:"
+          example_css: "selector {property: value;}"
+          examples_header: "Examples:"
+          font_size_example_html: "Inside the "body" tag, set the font size slightly larger than the baseline: %{font_size_css_code}"
+          line_of_css_html: "A line of CSS code looks pretty much like this: %{example_css_code}"
           property: property
           selector: selector
           value: value
-        header: 'If you are new to CSS, here are the basics:'
+        header: "If you are new to CSS, here are the basics:"
       custom_properties:
         description:
           accepting_properties_html: All properties except %{font_family_code} and %{content_code} accept the %{var_code} function as a value. We don't allow fallbacks.
@@ -1490,24 +1490,24 @@ en:
           web_safe_fonts: a set of web-safe fonts with fallbacks
         header: Font and Font Family
       intro:
-        description: 'Note that for security reasons, you can only use a limited set of CSS code: all other declarations and comments will be removed!'
+        description: "Note that for security reasons, you can only use a limited set of CSS code: all other declarations and comments will be removed!"
         header: You can create new skins for the Archive using our wizard, or by writing your own CSS (cascading style sheets) code
       numeric_values:
         description:
           em_unit_html: "PS: we highly encourage learning about and using %{em_code}, which lets you set things relative to the viewer's current font size! It will make your layouts much more flexible and responsive to different browser/font settings."
-          precision_html: 'You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}'
+          precision_html: "You can specify numeric values up to two decimal places, either as percentages or in %{various_units_link}: %{units_list_code}"
           units_list: cm, em, ex, in, mm, pc, pt, px
           various_units: various units
         header: Numeric Values
       one_declaration_per_ruleset:
-        description_html: 'The CSS parser we use retains only one declaration for each property, meaning that rulesets like %{repeated_declarations_css_code} will have all but the last %{background_code} declaration removed (so your gradient would only show up in WebKit browsers). To avoid losing declarations with repeated properties, split each one into its own ruleset, like so:'
+        description_html: "The CSS parser we use retains only one declaration for each property, meaning that rulesets like %{repeated_declarations_css_code} will have all but the last %{background_code} declaration removed (so your gradient would only show up in WebKit browsers). To avoid losing declarations with repeated properties, split each one into its own ruleset, like so:"
         header: Use only one declaration per property per ruleset
       scale:
         description_html: You can specify scale (for the %{transform_code} property) as %{scale_numeric_value_code} where the numeric value can be specified up to two decimal places.
         header: Scale
         numeric_value: numeric value
       skin_examples:
-        description_html: '%{public_skins_link} are visible and you can read their code and copy them to edit for your own use.'
+        description_html: "%{public_skins_link} are visible and you can read their code and copy them to edit for your own use."
         header: Look at other public skins for examples
         public_skins: All approved public skins
     skins_parents:
@@ -1522,17 +1522,17 @@ en:
         alt: Second Square
         femslash:
           alt: F/F
-          definition: 'F/F: female/female relationships'
+          definition: "F/F: female/female relationships"
         gen:
           alt: Gen
-          definition: 'Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work'
+          definition: "Gen: no romantic or sexual relationships, or relationships which are not the main focus of the work"
         heading: Relationships, pairings, orientations
         het:
           alt: F/M
-          definition: 'F/M: female/male relationships'
+          definition: "F/M: female/male relationships"
         multi:
           alt: Multi
-          definition: 'Multi: more than one kind of relationship, or a relationship with multiple partners'
+          definition: "Multi: more than one kind of relationship, or a relationship with multiple partners"
         none:
           alt: blank square
           definition: The work was not put in any categories
@@ -1541,13 +1541,13 @@ en:
           definition: Other relationships
         slash:
           alt: M/M
-          definition: 'M/M: male/male relationships'
+          definition: "M/M: male/male relationships"
       page_heading: Symbols we use on the Archive
       ratings:
         alt: First Square
         explicit:
           alt: E
-          definition: 'Explicit: only suitable for adults'
+          definition: "Explicit: only suitable for adults"
         general:
           alt: G
           definition: General Audiences
@@ -1588,7 +1588,7 @@ en:
           definition: The work was not marked with any Archive Warnings. Please note that an author may have included other information about their work in the Additional Tags (Genre, Warnings, Other Information) section.
         warning_yes:
           alt: exclamation mark
-          definition_html: 'At least one of these warnings applies: graphic depictions of violence, major character death, rape/%{non_con}, underage sex. The specific warnings are shown in the Archive Warnings tags.'
+          definition_html: "At least one of these warnings applies: graphic depictions of violence, major character death, rape/%{non_con}, underage sex. The specific warnings are shown in the Archive Warnings tags."
           non_con:
             acronym: non-con
             title: non-consensual sex
@@ -1608,7 +1608,7 @@ en:
         description: This is for content with adult themes (sex, violence, etc.) that isn't as graphic as explicit-rated content.
         header: Mature (Adult!)
       more_info:
-        html: '(For more information, see the %{ratings_and_warnings_tos_section_link}.)'
+        html: "(For more information, see the %{ratings_and_warnings_tos_section_link}.)"
         ratings_and_warnings_tos_section: Ratings and Warnings section of the %{app_name} Terms of Service
       not_rated:
         description: For searching, screening, and other Archive functions, this may get treated the same way as explicit-rated content.  In reality, it could be anything from porn to completely family-friendly stuff.  Choose this rating if you prefer not to rate your content (because you don't like ratings, because you're trying to avoid spoilers, etc.).
@@ -1620,17 +1620,17 @@ en:
     tags_warnings:
       choose_not_to_use:
         description: Use this if you don't want to warn for anything. You may also choose this option if you don't know what you should warn for; if you don't like warning for certain topics or warnings in general; if you want to avoid some spoilers, but not others; etc.
-        header: 'Choose Not To Use Archive Warnings:'
-      description: 'The %{app_name} has chosen, for legal and other reasons, to mandate that users either warn for—or explicitly choose not to warn for—a short list of common warnings: Graphic Depictions of Violence, Major Character Death, Rape/Non-Con, and Underage Sex. We understand that creators may wish to not warn for some of these things, or to warn for additional content, and have provided options for them to do so within this framework.'
+        header: "Choose Not To Use Archive Warnings:"
+      description: "The %{app_name} has chosen, for legal and other reasons, to mandate that users either warn for—or explicitly choose not to warn for—a short list of common warnings: Graphic Depictions of Violence, Major Character Death, Rape/Non-Con, and Underage Sex. We understand that creators may wish to not warn for some of these things, or to warn for additional content, and have provided options for them to do so within this framework."
       graphic_depictions_of_violence:
         description: This is for gory, graphic, explicitly described violence. Exactly where to draw the line is your call.
-        header: 'Graphic Depictions Of Violence:'
+        header: "Graphic Depictions Of Violence:"
       major_character_death:
         description: Please use your best judgment about who counts as a major character.
-        header: 'Major Character Death:'
+        header: "Major Character Death:"
       no_archive_warnings_apply:
         description: Use this if the Archive warnings don't apply to your content. (In other words, if it contains no graphic depictions of violence, major character death, rape/non-con, or underage sexual activity.)
-        header: 'No Archive Warnings Apply:'
+        header: "No Archive Warnings Apply:"
       other_warnings:
         html: You can also use the "Additional Tags" field to give other or more detailed warnings. Our policies regarding warnings can be found in the %{tos_link} and %{tos_faq_link}.
         tos: Terms of Service
@@ -1638,10 +1638,10 @@ en:
       page_heading: Warning Tags
       rape_non_con:
         description: This is your call. If you think your content may be seen as containing non-consensual sexual activity, but you don't feel like using this warning or you're not sure if you should, you always have the option of using "Choose Not to Use Archive Warnings" instead.
-        header: 'Rape/Non-Con:'
+        header: "Rape/Non-Con:"
       underage_sex:
         description: This is for descriptions or depictions of sexual activity involving characters under the age of eighteen. (This doesn't include dating activity like kissing or vague references with no actual description or depiction.) This warning generally applies to humans; if you are creating a pornographic work about space aliens who only live for a month or thousand-year-old vampires with twelve-year-old bodies, please just use your best judgment. You are always free to specify characters' ages or to use "Choose Not to Use Archive Warnings".
-        header: 'Underage Sex:'
+        header: "Underage Sex:"
     works_languages:
       contact_support: let us know via the Support form
       page_heading: Languages
@@ -1677,14 +1677,14 @@ en:
         otw_long: Organization for Transformative Works
       major_projects:
         fanlore: Fanlore
-        fanlore_details_html: '%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen.'
+        fanlore_details_html: "%{fanlore_link}, a fandom wiki devoted to preserving the history of transformative fanworks and the fandoms from which they have arisen."
         legal_advocacy: Legal Advocacy
-        legal_details_html: '%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge.'
+        legal_details_html: "%{legal_advocacy_link} committed to protecting and defending fanworks from commercial exploitation and legal challenge."
         open_doors: Open Doors
-        open_doors_details_html: '%{open_doors_link}, which offers shelter to at-risk fannish projects.'
-        title: 'Our other major projects include:'
+        open_doors_details_html: "%{open_doors_link}, which offers shelter to at-risk fannish projects."
+        title: "Our other major projects include:"
         twc: Transformative Works and Cultures
-        twc_details_html: '%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices.'
+        twc_details_html: "%{twc_link}, a peer-reviewed academic journal that seeks to promote scholarship on fanworks and practices."
       more_info:
         communications_team: Communications team
         faq_page: FAQ page
@@ -1697,7 +1697,7 @@ en:
         heading: II.C. Commercial Promotion
         not_allowed: Promotion, solicitation, and advertisement of commercial products or activities are not allowed.
         tos_faq: FAQ for Section II.C
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Commercial Promotion FAQ
       content_policy: Content Policy
       content_policy_heading: II. Content Policy
@@ -1706,20 +1706,20 @@ en:
         heading: II.D. Copyright Infringement
         not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
         tos_faq: FAQ for Section II.D
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
         transformative_fanworks: transformative fanworks
         transformative_works_legal_html: We believe that %{transformative_fanworks_link} are legal. Complaints about the mere existence of fanworks that mention trademarks or are based on copyrighted material will not be pursued.
-      effective: 'Effective: November 19, 2024'
+      effective: "Effective: November 19, 2024"
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
+        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.
         non_fanwork_content: non-fanwork Content
         tos_faq: FAQ for Section II.B
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fanworks and Non-Fanwork Content FAQ
       harassment:
         advocating_harm:
@@ -1741,7 +1741,7 @@ en:
           text: Creating RPF never constitutes harassment in and of itself. Posting works where someone dies, is subjected to slurs, or is otherwise harmed as part of the plot is usually not a violation of the Harassment Policy. However, deliberately posting such Content in a manner designed to be seen by the subject of the work, such as by gifting them the work, may result in a judgment of harassment.
         threatening_versus_annoying_html: In general, threatening Content will be considered harassment, while Content that is merely rude or annoying will be allowed. Not everyone agrees about what is offensive and unacceptable. Users are encouraged to use tools such as %{blocking_link}, %{muting_link}, and %{filtering_link} to control their own environment on AO3.
         tos_faq: FAQ for Section II.H
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Harassment FAQ
       illegal_inappropriate_content:
         automated_spam_check_html: We may use automated means to filter out spam. If you submit Content that is erroneously caught in a spam filter, please %{contact_ao3_administrators_link}.
@@ -1754,7 +1754,7 @@ en:
         spamming_behavior: Spamming behavior is prohibited. Repeated identical or nearly identical posts in multiple places may be considered spam regardless of commercial content.
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
@@ -1762,7 +1762,7 @@ en:
         heading: II.G. Impersonation
         html: You may not impersonate or misrepresent your affiliation with any person, entity, or %{function_link}. Fiction clearly marked as such is not considered impersonation.
         tos_faq: FAQ for Section II.G
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       intro:
         all_content_must_comply_html: All %{content_link} on AO3 must comply with our Content Policy.
@@ -1771,7 +1771,7 @@ en:
         maximum_inclusiveness: maximum inclusiveness of fanwork content
         our_goal_html: Our goal is %{maximum_inclusiveness_link}. We want to provide a safe and permanent home for fanworks, including works that might be at risk on other sites due to being deemed immoral, explicit, or otherwise objectionable. Users should always observe and heed the ratings and warnings provided before accessing works on AO3.
         report_it_to_us: report it to us
-        review_before_posting_html: '%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}.'
+        review_before_posting_html: "%{all_content_must_comply_bold} Please review this page carefully before you begin posting. Answers to common questions about the Content Policy can be found in the %{tos_faq_link}."
         tos_faq: TOS FAQ
         we_do_not_prescreen: We do not prescreen content on AO3.
         you_can_report_html: If you encounter content that you believe violates our Content Policy, you can %{report_it_to_us_link}. %{we_do_not_prescreen_bold}
@@ -1790,13 +1790,13 @@ en:
         tags_applied_automatically_html: Some tags may be automatically applied to Works. In addition, AO3 administrators may determine that tags in a mandatory tag field on a Work are inaccurate or insufficient. In such cases, AO3 administrators may remove inaccurate tags; add non-specific tags to the Work; add specific tags to the Work in fields where non-specific tags are %{not_available_link}; require the creator to appropriately adjust the Work's tags; hide the Work; or take other appropriate action to address the matter. Refer to the %{tos_faq_link} for details about when AO3 administrators may enforce the presence or removal of tags in mandatory fields.
         tos_faq: TOS FAQ
         tos_faq_endnote: FAQ for Section II.J
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Ratings and Archive Warnings FAQ
       offensive_content:
         heading: II.A. Offensive Content
         removal_not_just_offensiveness: Unless it violates some other policy, we will not remove Content for offensiveness.
         tos_faq: FAQ for Section II.A
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Offensive Content vs Illegal Content FAQ
       page_content_landmark: Main Text
       page_heading: Content Policy
@@ -1804,7 +1804,7 @@ en:
         disclosing_personal_data_html: disclosing personal data, including %{special_categories_of_personal_data_link}.
         heading: II.F. Personal Information and Fannish Identities
         linking_fannish_identity: linking someone's fannish identity (such as their AO3 username) to their legal or professional identity (such as their "real life" name);
-        not_allowed: 'You may not upload Content that contains seemingly accurate, non-public information about another individual without authorization. This includes:'
+        not_allowed: "You may not upload Content that contains seemingly accurate, non-public information about another individual without authorization. This includes:"
         orphaned: Orphaned
         revealing_orphaned_creator_html: revealing the identity of the creator of an %{orphaned_link} fanwork;
         right_to_hide_delete: We reserve the right to delete, hide, or otherwise make such Content unavailable.
@@ -1812,14 +1812,14 @@ en:
         sharing_sufficient_information: sharing information sufficient to identify someone else's legal or professional identity or their physical location (e.g. phone numbers, email addresses, residential addresses, or hotel room numbers); and
         special_categories_of_personal_data: Special Categories of Personal Data
         tos_faq: FAQ for Section II.F
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Fannish Identities and Impersonation FAQ
       plagiarism:
         heading: II.E. Plagiarism
         html: Plagiarism is the use of someone else's words, or %{their_expressions_of_their_ideas_link}, without attribution. Minor alterations (such as replacing names, substituting synonyms, or rearranging a few words) are insufficient to make a work your own. Plagiarism is not allowed. Deliberately creating a work using the same general idea as another work is not plagiarism, but citation may be appropriate.
         their_expressions_of_their_ideas: their expressions of their ideas
         tos_faq: FAQ for Section II.E
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ
       privacy_policy: Privacy Policy
       terms_of_service: Terms of Service
@@ -1830,11 +1830,11 @@ en:
         heading: II.I. User Icons
         text: User icons must be appropriate for general audiences. They must not depict genital nudity, explicit sexual activity, hate symbols, or imagery that promotes, advocates, or causes harm.
         tos_faq: FAQ for Section II.I
-        tos_faq_in_parens_html: '(%{tos_faq_link})'
+        tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Usernames, Icons, and Profiles FAQ
     diversity_statement:
       archive_description_html: This archive is a permanent, panfandom place for fanworks, built by fans for fans. Whichever way you use the Archive, you're part of this, powering it, shaping it through your use and %{your_feedback_link}.
-      archive_for_you: 'No matter your appearance, circumstances, configuration or take on the world: if you enjoy consuming, creating or commenting on fanworks, the Archive is for you.'
+      archive_for_you: "No matter your appearance, circumstances, configuration or take on the world: if you enjoy consuming, creating or commenting on fanworks, the Archive is for you."
       archive_team: the Archive team
       diversity_statement: Diversity Statement
       dreamwidth: Dreamwidth's
@@ -1886,7 +1886,7 @@ en:
           title: Is it later already?
         note: Some works you've marked for later.
       social:
-        bluesky: '@status.archiveofourown.org on Bluesky'
+        bluesky: "@status.archiveofourown.org on Bluesky"
         heading: Follow us
         note_html: Follow AO3 on Bluesky or Tumblr for status updates, and don't forget to check out the %{other_outlets_link} for updates on our other projects!
         other_outlets: Organization for Transformative Works' news outlets
@@ -1897,7 +1897,7 @@ en:
       parent_org_intro_html: The Archive of Our Own (AO3) is a project of the %{parent_org_link}.
     privacy:
       account_termination:
-        backup_copies_html: '"Active records" do not include the backup copies of Content created for legal and/or disaster recovery purposes (refer to the %{general_principles_link}).'
+        backup_copies_html: ""Active records" do not include the backup copies of Content created for legal and/or disaster recovery purposes (refer to the %{general_principles_link})."
         deletion_after_termination_html: If for any reason you %{terminate_your_account_link}, as soon as reasonably possible we will destroy active records containing your Personal Information that are visible to the public or to AO3 users, with the exception of Personal Information entered as Content that you have not deleted. "Reasonably" here means no more than thirty business days from the termination of the account.
         general_principles: General Principles
         heading: III.G. Termination of account
@@ -1923,7 +1923,7 @@ en:
         heading: III.I. Contact us
         html: If you have any questions, concerns, or complaints about this Privacy Policy, or would like to submit a data request, please %{contact_pac_link}.
       content_policy: Content Policy
-      effective: 'Effective: November 19, 2024'
+      effective: "Effective: November 19, 2024"
       information_scope:
         collect_through_use: We may collect your Personal Information (such as your IP address and email address) when you request an AO3 invitation, register for an AO3 account, or otherwise access or use AO3.
         content: Content
@@ -1932,7 +1932,7 @@ en:
         special_categories: Special Categories of Personal Data
       intro:
         answers_common_questions_html: Answers to common questions about the Privacy Policy can be found in the %{tos_faq_link}.
-        ao3_exists_to_host_html: 'AO3 exists to host content by and for fans from all over the world. To do so, we process certain data and information, including %{personal_information_link}. This is so that we can:'
+        ao3_exists_to_host_html: "AO3 exists to host content by and for fans from all over the world. To do so, we process certain data and information, including %{personal_information_link}. This is so that we can:"
         archive_description: The Archive of Our Own (AO3) is a project of the Organization for Transformative Works (OTW), which is committed to fan privacy.
         details_how_and_why_html: This Privacy Policy details how and why we collect and process this information. %{common_questions_bold}
         enable_post_information: Enable you to post comments, kudos, bookmarks, and other information designed to be seen by other users
@@ -1955,28 +1955,28 @@ en:
         sharing_exceptions:
           challenge_signup:
             challenge: Challenge
-            heading_html: 'If you sign up for a %{challenge_link}:'
+            heading_html: "If you sign up for a %{challenge_link}:"
             text: We may share your email address with the maintainers of the Challenge.
           external_processing:
-            heading: 'For external processing:'
+            heading: "For external processing:"
             html: We may use third-party services to store, process, or transmit data, or to perform other technical functions related to operating AO3. For example, we may use third-party email services. A list of third-party services is provided in our %{subprocessor_list_link}. We cannot guarantee other services' technical performance. We or the services we use may store or process your Personal Information in data centers which may be located in the United States or elsewhere.
             subprocessor_list: Subprocessor List
           handle_complaints:
             dmca_notice: Digital Millennium Copyright Act (DMCA) notice
-            heading: 'To handle complaints submitted by you about TOS violations:'
+            heading: "To handle complaints submitted by you about TOS violations:"
             html: If we receive a %{dmca_notice_link}, we reserve the right to disclose the information provided by the copyright owner or their legal representative to the subject of the complaint. If we receive a complaint from you about other matters, that information will be subject to the %{pac_confidentiality_policy_link}.
             pac_confidentiality_policy: Policy & Abuse Confidentiality Policy
-          intro: 'We will not share your Personal Information with any third parties without your prior consent, except for the following cases:'
+          intro: "We will not share your Personal Information with any third parties without your prior consent, except for the following cases:"
           legal_reasons:
             attempt_to_notify: We will attempt to notify you any time we disclose your Personal Information to a third party for legal reasons, unless legally prohibited from doing so or if, in our sole judgment, notification might hinder an ongoing investigation. In some cases, the Personal Information we have, such as an IP address, may be insufficient for us to notify you.
             cooperating_law_enforcement: are cooperating with law enforcement authorities.
             good_faith_comply: have a good-faith belief that such action is necessary to comply with a current judicial proceeding, court order, or legal process served on the OTW; or
-            heading: 'For legal reasons:'
-            intro: 'We may share Personal Information if we:'
+            heading: "For legal reasons:"
+            intro: "We may share Personal Information if we:"
             law_enforcement_cooperation_details: We will cooperate with all investigations conducted by law enforcement authorities within the United States when legally required to do so. Cooperation with law enforcement authorities from other countries and cooperation when it is not legally required are at our sole discretion. Our discretion looks favorably on freedom and justice, and unfavorably on oppression and violence.
             legally_compelled: are legally compelled to do so;
           open_doors_import:
-            heading_html: 'If your work is imported via %{open_doors_link}:'
+            heading_html: "If your work is imported via %{open_doors_link}:"
             open_doors: Open Doors
             text: If the email address associated with your AO3 account matches an email address that you used in connection with a non-AO3 archive that is being imported to AO3 via Open Doors, then we may share your email address with the entity that manages that imported archive.
         third_party_tools: Third parties have developed applications, software, scripts, browser extensions, or other tools for use in connection with AO3. Such third parties may receive Personal Information from you if you use their tools to access AO3. This Privacy Policy does not cover your use of such tools.
@@ -1985,26 +1985,26 @@ en:
         intro: The Privacy Policy is the third part of the AO3 Terms of Service.
       types_of_information:
         cookies:
-          heading: 'Cookies:'
+          heading: "Cookies:"
           text: We and our Subprocessors use cookies to collect and store visitors' preferences; customize web pages' content based on visitors' preferences or other Personal Information that the visitor sends; prevent attacks on our servers; and record activity at AO3 in order to provide better service when visitors return to our site. AO3 has no access to cookies set by other sites. If you block or disable cookies, you may be unable to access or use AO3.
         emails:
           address_usage_html: We will use your email address internally for the purposes of managing AO3 and maintaining site integrity. We may occasionally send emails to you about AO3, your Content and account, or news that we reasonably believe to be of interest to our registered users. We will also send you your invitation to register for AO3 via email. By creating and maintaining an account on AO3, you consent to receiving such emails. We reserve the right to send you notice of complaints raised against you, or alleged violations of the TOS by you, as well as to reply to any email message you send to AO3 and/or its personnel. If you choose to participate in a %{challenge_link}, the Challenge maintainer(s) may have access to your email address for the purposes of communicating with you.
           challenge: Challenge
           collect_process_retain: We collect, process, and retain the email addresses of and from those who communicate with us via email, and any Content or Personal Information included in emails to us. We need this Personal Information so we can respond to you; so we can handle complaints about AO3 and any users who may have violated the TOS or other policies; and for other legal and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
-          heading: 'Emails:'
+          heading: "Emails:"
           unsubscribe: Although it is possible to unsubscribe from some emails (such as kudos updates and responses to comments), you cannot unsubscribe from receiving emails that we, in our sole discretion, deem necessary for legal purposes or to maintain the safety and integrity of your account or our services, including other OTW sites.
         fnok:
-          heading: 'Fannish next-of-kin:'
+          heading: "Fannish next-of-kin:"
           text: We collect the contact information you and/or your fannish next-of-kin provide, and use it only to implement the fannish next-of-kin function.
         heading: III.C. Types of Personal Information we collect and process
         ip_addresses:
-          heading: 'IP addresses:'
+          heading: "IP addresses:"
           text: We and our Subprocessors collect, process, and retain the IP addresses of AO3 visitors, including registered users. IP information may also be collected by our servers for logging purposes and used for limited technical assessments of AO3. We need this Personal Information so we can provide you with the Content that you are requesting; to allow you to submit Content to us; and for other legal, TOS enforcement, and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
         logs:
-          heading: 'Logs:'
+          heading: "Logs:"
           text: We and our Subprocessors collect, process, and retain logs of server interactions. We need this Personal Information for legal, TOS enforcement, and accounting/audit reasons, including maintaining the integrity of AO3 and the Content that we host.
         other_information:
-          heading: 'Other user-specific information:'
+          heading: "Other user-specific information:"
           to_maintain_integrity: We and our Subprocessors collect, process, and retain Personal Information about what pages you access or visit, including your interactions with integral AO3 features such as comments, kudos, and bookmarks; referral information (i.e. data about what site you are coming to AO3 from); and whether there are errors in displaying Content to you. We need this Personal Information to maintain the integrity of AO3 and the Content that we host; to provide you with the Content that you are seeking; to prevent spam and abuse; and for other legal and accounting/audit reasons.
           to_make_content_available_html: We and our Subprocessors collect, process, and retain Personal Information about Content that you submit to us. You consent to the collection of your Personal Information (such as your IP address) when you access AO3, including when you are not logged in. We use this Personal Information to make the Content you submit available to people who use AO3. By submitting Content to us, you are requesting that we make it available to those people and consenting to the use of your Content. For explanations of site features that use your Content and/or Personal Information and how they are used, please refer to the %{tos_faq_link}.
           tos_faq: TOS FAQ
@@ -2118,8 +2118,8 @@ en:
         eu_country_html: a European Union country where the processing of %{special_categories_of_personal_data_link} from children of that age requires the consent of a parent or legal guardian, or
         heading: I.H. Age Policy
         individuals_under_13: individuals under the age of thirteen (13), and
-        individuals_under_16: 'individuals under the age of sixteen (16) who are not old enough, in their country of residence or citizenship, to consent to the processing of personal data. This includes individuals under the age of sixteen (16) who are residents or citizens of:'
-        intro: 'AO3 does not knowingly solicit or collect information from Age-Barred Individuals. Age-Barred Individuals are:'
+        individuals_under_16: "individuals under the age of sixteen (16) who are not old enough, in their country of residence or citizenship, to consent to the processing of personal data. This includes individuals under the age of sixteen (16) who are residents or citizens of:"
+        intro: "AO3 does not knowingly solicit or collect information from Age-Barred Individuals. Age-Barred Individuals are:"
         not_permitted_account_upload: not permitted to have an account or upload Content
         special_categories_of_personal_data: Special Categories of Personal Data
       archive_description: The Archive of Our Own (AO3) is a home for fanworks, including fanfiction based on books, movies, TV, comics, other media, and real-person fiction (RPF).
@@ -2137,33 +2137,33 @@ en:
         otw_not_liable: The OTW is not liable to you for any Content to which you are exposed on or because of AO3.
         privacy_policy: Privacy Policy
         third_party_content_html: Some of the Content displayed on or accessible via AO3 is not hosted on AO3 or by the OTW. Such content can include text, image, audio, or video files %{hosted_by_third_party_link} ("User-Embedded Content"). If you access a page that includes User-Embedded Content, the embedded file may share data with the hosted site as if you were on or at the hosted site. Although User-Embedded Content must comply with our %{content_policy_link}, it is not otherwise governed by these Terms of Service (including the AO3 %{privacy_policy_link}), and is instead governed by the terms of use or privacy policy of the service that hosts it. We reserve the right to provide an indicator to users that User-Embedded Content is present on or visible via your Content.
-      effective: 'Effective: November 19, 2024'
+      effective: "Effective: November 19, 2024"
       general_principles_heading: I. General Principles
       general_terms:
         agreement:
-          agreement: 'Agreement:'
+          agreement: "Agreement:"
           any_other_form: any other form of content
           content_policy: Content Policy
-          html: '%{agreement} AO3 hosts and shares content created by fans, for fans. Our %{content_policy_link} and %{privacy_policy_link} are part of these Terms of Service (TOS). By submitting a work; bookmark; comment; tag; link; text, image, audio, or video file; username; fannish next-of-kin; %{personal_information_link} (such as an email address); or %{any_other_form_link} ("Content") to the Archive of Our Own service (hereinafter "Service", "AO3", or "Archive"), or by creating an account and/or accessing Content on AO3, you affirm, confirm, and state that you comply with and assent to the TOS.'
+          html: "%{agreement} AO3 hosts and shares content created by fans, for fans. Our %{content_policy_link} and %{privacy_policy_link} are part of these Terms of Service (TOS). By submitting a work; bookmark; comment; tag; link; text, image, audio, or video file; username; fannish next-of-kin; %{personal_information_link} (such as an email address); or %{any_other_form_link} ("Content") to the Archive of Our Own service (hereinafter "Service", "AO3", or "Archive"), or by creating an account and/or accessing Content on AO3, you affirm, confirm, and state that you comply with and assent to the TOS."
           personal_information: Personal Information
           privacy_policy: Privacy Policy
         entirety_of_agreement:
-          entirety_of_agreement: 'Entirety of agreement:'
-          html: '%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements.'
+          entirety_of_agreement: "Entirety of agreement:"
+          html: "%{entirety_of_agreement} These Terms of Service constitute the entire agreement between you and the Organization for Transformative Works (OTW) and govern your use of AO3. They replace all prior agreements between you and the OTW concerning your use of AO3. They do not govern your use of any other OTW sites and/or projects, all of which are covered under separate agreements."
         heading: I.A. General terms
         jurisdiction:
-          html: '%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.'
-          jurisdiction: 'Jurisdiction:'
+          html: "%{jurisdiction} The AO3 TOS, the relationship between you and the OTW, and all disputes arising out of or related to them shall be governed by the laws of the United States and specifically %{the_state_of_new_york_link}, without regard to any conflict-of-law provisions. You and the OTW agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there."
+          jurisdiction: "Jurisdiction:"
           the_state_of_new_york: the State of New York
         limitation_on_claims:
-          html: '%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred.'
-          limitation_on_claims: 'Limitation on claims:'
+          html: "%{limitation_on_claims} You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to any use of AO3 or its TOS must be filed within one (1) year after such claim or cause of action arose or be forever barred."
+          limitation_on_claims: "Limitation on claims:"
         no_assignment:
-          html: '%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void.'
-          no_assignment: 'No assignment:'
+          html: "%{no_assignment} These TOS are personal to you. You may not assign or transfer your rights or obligations under these TOS to any other person or entity, and any attempted assignment or transfer is void."
+          no_assignment: "No assignment:"
         non_severability:
           html: "%{non_severability} The OTW's failure to enforce any part of the TOS will not waive the OTW's ability to enforce it. Any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the TOS, even with regard to the same user. If any provision of the TOS is found by a court of competent jurisdiction to be invalid, you agree that the court should give effect to the party's intentions as reflected in the provision, and that all other provisions of the TOS remain in full force and effect."
-          non_severability: 'Non-severability:'
+          non_severability: "Non-severability:"
       license_html: The AO3 %{terms_of_service_link}, including the %{content_policy_link} and %{privacy_policy_link}, are licensed under the %{cc_attribution_4_0_international_link}.
       page_content_landmark: Main Text
       page_heading: Terms of Service
@@ -2194,7 +2194,7 @@ en:
       updates_to_the_tos:
         content_policy: Content Policy
         heading: I.B. Updates to the Terms of Service
-        html: 'You can learn about changes to the TOS by visiting AO3. The TOS, including the %{content_policy_link} and %{privacy_policy_link}, may be modified at any time through the following process: Proposed changes will first be prominently disclosed on AO3 for a public comment period lasting at least two weeks. After the end of the comment period, proposed changes will be voted on by the OTW Board. If the OTW Board votes in favor, the changes will become effective when posted to the relevant Terms page(s). This is the only means by which the TOS may be altered. The TOS cannot be changed by emails or other communications with you.'
+        html: "You can learn about changes to the TOS by visiting AO3. The TOS, including the %{content_policy_link} and %{privacy_policy_link}, may be modified at any time through the following process: Proposed changes will first be prominently disclosed on AO3 for a public comment period lasting at least two weeks. After the end of the comment period, proposed changes will be voted on by the OTW Board. If the OTW Board votes in favor, the changes will become effective when posted to the relevant Terms page(s). This is the only means by which the TOS may be altered. The TOS cannot be changed by emails or other communications with you."
         privacy_policy: Privacy Policy
       what_we_believe:
         ao3_run_by_html: AO3 is run by the Organization for Transformative Works (OTW). We are committed to %{defending_fanworks_link}. We have legal resources and alliances on which we can draw. However, that is not a guarantee that the OTW can or will fight each battle. The OTW Board will take into account a variety of factors, both legal and otherwise, when responding to a legal challenge. More information is available %{on_the_otw_site_link}.
@@ -2225,7 +2225,7 @@ en:
         some_content_open_doors_html: Some of the Content hosted on AO3 is imported via %{open_doors_link}. Open Doors' agreement with each collection's archivist is separate from AO3's TOS. If a work has been imported via Open Doors and its creator requests that the work be removed from AO3, we will remove it. If an archivist chooses to remove their imported collection, any imported works that have been claimed or Orphaned by their creators will remain on AO3.
         subject_to_moderation: subject to moderation
         tag_wrangling: tag wrangling
-        we_repeat: 'We repeat: we do not own your Content.'
+        we_repeat: "We repeat: we do not own your Content."
         worldwide_royalty_free_nonexclusive_license: worldwide, royalty-free, nonexclusive license
       what_you_cant_do:
         account_if_age_barred_html: to create an account if you are an %{age_barred_individual_link};
@@ -2248,11 +2248,11 @@ en:
         position_on_fanwork_legality: position on fanwork legality
         resident_embargo_country_html: to create an account if you are a resident or national of any country with which the U.S. has prohibited transactions by mandating a %{comprehensive_trade_embargo_link}, as detailed by the Office of Foreign Assets Control; or
         software_viruses: to make available any material that contains software viruses or other computer code, files, or programs designed to interrupt, destroy, or limit the functionality of any computer, hardware, or telecommunications equipment;
-        you_agree_not_to: 'You agree not to use AO3 (as well as the email addresses and URLs of OTW sites):'
+        you_agree_not_to: "You agree not to use AO3 (as well as the email addresses and URLs of OTW sites):"
     tos_navigation:
       content: Content Policy
       privacy: Privacy Policy
-      top: '%{arrow} Top'
+      top: "%{arrow} Top"
       tos: Terms of Service
       tos_faq: TOS FAQ
     tos_toc:
@@ -2334,8 +2334,8 @@ en:
       page_heading: Invitation Requests
       queue_disabled:
         closed: New invitation requests are currently closed.
-        html: '%{closed_bold} For more information, please check the %{news_link}.'
-        news: '"Invitations" tag on AO3 News'
+        html: "%{closed_bold} For more information, please check the %{news_link}."
+        news: ""Invitations" tag on AO3 News"
       waiting_list_count:
         one: There is %{count} person remaining on the waiting list.
         other: There are %{count} people remaining on the waiting list.
@@ -2347,10 +2347,10 @@ en:
       details_html: To get a free Archive of Our Own account, you need an Invitation. By submitting your email address to our invitation queue, you confirm that you are at least 13 years old, and if you're in a country whose residents/citizens have to be of an age older than 13 to consent, you are old enough to consent to the processing of your personal data without our obtaining written permission from a parent or legal guardian. We will use the email address you submit only to send you an Invitation and to process/manage your account activation. Please don't request an Invitation unless you've read our %{tos_link}, including the %{content_policy_link} and %{privacy_policy_link}, and agree to abide by those Terms.
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       page_heading: Invitation Requests
       privacy_policy: Privacy Policy
@@ -2377,7 +2377,7 @@ en:
       resend_button: Resend Invitation
       title: Invitation Status for %{email}
     invite_request:
-      date: 'At our current rate, you should receive an invitation on or around: %{date}.'
+      date: "At our current rate, you should receive an invitation on or around: %{date}."
       position_html: You are currently number %{position} on our waiting list!
       title: Invitation Status for %{email}
     no_invitation:
@@ -2387,11 +2387,11 @@ en:
     status:
       frequency:
         one: hour
-        other: '%{count} hours'
+        other: "%{count} hours"
       heading: Invitation Request Status
       invitation_number:
-        one: '%{count} invitation'
-        other: '%{count} invitations'
+        one: "%{count} invitation"
+        other: "%{count} invitations"
       invitation_send_rate: We are sending out %{queue_invitation_number} every %{queue_frequency}.
       search: Look me up
       waiting_list:
@@ -2399,12 +2399,12 @@ en:
         other: There are currently %{count} people on the waiting list.
   kudos:
     guest_header:
-      one: '%{count} guest has also left kudos'
-      other: '%{count} guests have also left kudos'
+      one: "%{count} guest has also left kudos"
+      other: "%{count} guests have also left kudos"
     user_links:
       more_link:
-        one: '%{count} more user'
-        other: '%{count} more users'
+        one: "%{count} more user"
+        other: "%{count} more users"
   languages:
     form:
       abuse_support_available: Abuse support available
@@ -2417,15 +2417,15 @@ en:
         update: Update Language
       support_available: Support available
     index:
-      language_code_format_html: '(%{code})'
+      language_code_format_html: "(%{code})"
       navigation:
         add: Add a Language
         edit: Edit
         suggest: Suggest a Language
       page_heading: Work Languages
       works_count:
-        one: '%{formatted_count} work'
-        other: '%{formatted_count} works'
+        one: "%{formatted_count} work"
+        other: "%{formatted_count} works"
   layouts:
     banner:
       hide: hide banner
@@ -2451,7 +2451,7 @@ en:
         gpl_2_0_or_later: GPL-2.0-or-later
         header: Development
         known_issues: Known Issues
-        license_details_html: '%{license_link} by the %{otw_link}'
+        license_details_html: "%{license_link} by the %{otw_link}"
         view_license: View License
       landmark: Footer
       otw:
@@ -2470,7 +2470,7 @@ en:
         search: Search
     proxy_notice:
       button: Dismiss Notice
-      faux_heading: 'Important message:'
+      faux_heading: "Important message:"
       point1: You are using a proxy site that is not part of the Archive of Our Own.
       point2: The entity that set up the proxy site can see what you submit, including your IP address. If you log in through the proxy site, it can see your password.
     tos_prompt:
@@ -2524,17 +2524,17 @@ en:
         sure_html: Are you sure you want to %{mute} %{username}?
         title: Mute %{name}
         will:
-          intro: 'Muting a user:'
+          intro: "Muting a user:"
           seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
         will_not:
           hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
-          intro: 'Muting a user will not:'
+          intro: "Muting a user will not:"
           prevent_emails: prevent you from receiving comment or subscription emails from this user
       confirm_unmute:
         button: Yes, Unmute User
         cancel: Cancel
         resume:
-          intro: 'Unmuting a user allows you to:'
+          intro: "Unmuting a user allows you to:"
           see_content: see their works, series, bookmarks, and comments on the site
         sure_html: Are you sure you want to %{unmute} %{username}?
         title: Unmute %{name}
@@ -2555,27 +2555,27 @@ en:
         title: Muted Users
         will:
           intro:
-            one: 'You can mute up to %{mute_limit} user. Muting a user:'
-            other: 'You can mute up to %{mute_limit} users. Muting a user:'
+            one: "You can mute up to %{mute_limit} user. Muting a user:"
+            other: "You can mute up to %{mute_limit} users. Muting a user:"
           seeing_content: completely hides their works, series, bookmarks, and comments from you; there will be no empty space, placeholder text, or other indication something has been removed
         will_not:
           hide_content_for_others: hide their works, series, bookmarks, and comments from anyone else
-          intro: 'Muting a user will not:'
+          intro: "Muting a user will not:"
           prevent_emails: prevent you from receiving comment or subscription emails from this user
   orphans:
     orphan_user:
       orphaning_bylines_only_message_html: Orphaning will automatically remove your personal information from <strong>bylines only</strong>. It will <strong>not</strong> automatically remove your personal information from anywhere else in the work(s). Social media accounts, contact information, email addresses, names, and any other personal information posted in the title, summary, notes, tags, work body, or comment text will <strong>not</strong> be automatically removed. Comments posted by other users will also <strong>not</strong> be affected by Orphaning. If you want information removed from these places, you should edit or delete it prior to Orphaning. <strong>Once you Orphan the work(s), you will no longer be able to delete information in these places yourself</strong>.
-      orphaning_works_message_html: 'Orphaning will <strong>permanently</strong> remove your username and/or pseud from the bylines of: the following work(s), their chapters, associated series, and any comments you may have left on them while logged into this account.'
+      orphaning_works_message_html: "Orphaning will <strong>permanently</strong> remove your username and/or pseud from the bylines of: the following work(s), their chapters, associated series, and any comments you may have left on them while logged into this account."
   pagy:
     aria_label:
       nav: Pagination
     next: Next →
-    prev: '← Previous'
+    prev: "← Previous"
   potential_matches:
     in_progress:
       cancel: Cancel Potential Match Generation
       generating_matches: The archive is generating potential matches for this challenge. This can take a long time, especially for a large challenge! We'll send an email to the collection maintainers when all potential matches have been generated.
-      generation_progress: 'Potential match generation progress:'
+      generation_progress: "Potential match generation progress:"
       if_progress_doesnt_change: If the progress value below doesn't change when you reload the page after about 10 minutes, there may have been a problem. Please check again after an hour, and then contact archive support.
     index:
       assignments_generating:
@@ -2665,8 +2665,8 @@ en:
       update: Update
     pseud_list:
       more_pseuds:
-        one: '%{count} more pseud'
-        other: '%{count} more pseuds'
+        one: "%{count} more pseud"
+        other: "%{count} more pseuds"
     show:
       delete_account_confirmation: This will permanently delete your account and cannot be undone. Are you sure?
       delete_my_account: Delete My Account
@@ -2698,11 +2698,11 @@ en:
       confirm_delete: Are you sure?
       default_pseud: Default Pseud
       delete_html: Delete%{landmark_span}
-      delete_landmark_text: ' %{pseud}'
+      delete_landmark_text: " %{pseud}"
       edit_html: Edit%{landmark_span}
-      edit_landmark_text: ' %{pseud}'
+      edit_landmark_text: " %{pseud}"
       orphan_html: Orphan Works%{landmark_span}
-      orphan_landmark_text: ' by %{pseud}'
+      orphan_landmark_text: " by %{pseud}"
       user_actions: User Actions
     pseuds_form:
       cannot_change_matching_pseud_html: You cannot change the pseud that matches your username. However, you can %{change_username_link} instead.
@@ -2741,16 +2741,16 @@ en:
       page_heading: "%{login}'s Related Works"
   series:
     series_module:
-      hidden_by_admin_alt: '(Hidden by Admin)'
+      hidden_by_admin_alt: "(Hidden by Admin)"
       hidden_by_administrator: Hidden by Administrator
       landmark:
         fandom: Fandom
         summary: Summary
       restricted: Restricted
-      restricted_alt: '(Restricted)'
-      series_by_html: '%{series_title_link} by %{byline}'
+      restricted_alt: "(Restricted)"
+      series_by_html: "%{series_title_link} by %{byline}"
     series_order:
-      draft_work_title: '%{title} (DRAFT)'
+      draft_work_title: "%{title} (DRAFT)"
   skins:
     confirm_delete:
       confirm_html: Are you sure you want to <strong><em>delete</em></strong> the skin "%{skin_title}"?
@@ -2758,7 +2758,7 @@ en:
       css: CSS
       description: Description
       icon: Upload a preview (png, jpeg or gif)
-      load_archive_skin_components: 'Load Archive Skin Components:'
+      load_archive_skin_components: "Load Archive Skin Components:"
       parent_skins: Parent Skins
       public: Apply to make public
       skin_type: Type
@@ -2815,13 +2815,13 @@ en:
         series: My Series Subscriptions
         users: My User Subscriptions
         works: My Work Subscriptions
-      series: '(Series)'
-      work: '(Work)'
+      series: "(Series)"
+      work: "(Work)"
   tag_sets:
     nomination_review_heading:
       already_approved_fandoms: Already Approved Fandoms
-      left_to_review: '%{type} (%{count} left to review)'
-      paginated: '%{from} - %{to} of %{total} %{type}'
+      left_to_review: "%{type} (%{count} left to review)"
+      paginated: "%{from} - %{to} of %{total} %{type}"
   tag_wranglers:
     index:
       filters:
@@ -2830,42 +2830,42 @@ en:
         only_media: Only media
         only_wrangler: Only wrangler
     show:
-      last_wrangled_html: '%{wrangler_login} last wrangled at %{time}.'
+      last_wrangled_html: "%{wrangler_login} last wrangled at %{time}."
       tags_wrangled_csv: Tags Wrangled (CSV)
   tag_wranglings:
     index:
       general_resources:
         ao3_catch_and_release: AO3_Catch_and_Release
-        ao3_catch_and_release_html: '%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}'
+        ao3_catch_and_release_html: "%{ao3_catch_and_release_link} - For more information, please see the %{ao3_wrangling_project_faq_link}"
         ao3_wrangling_project_faq: Tag Wrangling AO3 Project FAQ
         current_wrangling_limitations: Current Wrangling Limitations
-        current_wrangling_limitations_html: '%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies'
+        current_wrangling_limitations_html: "%{current_wrangling_limitations_link} - Details about current wrangling limitations and policies"
         fandom_and_megafandom_directory: Directory of Fandom & Megafandom Wiki Pages
-        fandom_and_megafandom_directory_html: '%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages'
+        fandom_and_megafandom_directory_html: "%{fandom_and_megafandom_directory_link} - All currently available fandom & megafandom wiki pages"
         fandoms_in_need_of_cowranglers: Fandoms in need of Cowranglers
-        fandoms_in_need_of_cowranglers_html: '%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?'
-        heading: 'General Wrangling Resources:'
+        fandoms_in_need_of_cowranglers_html: "%{fandoms_in_need_of_cowranglers_link} - Interested in helping out a fandom in need?"
+        heading: "General Wrangling Resources:"
         otw_slack_chat: OTW Slack Chat
-        otw_slack_chat_html: '%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}'
+        otw_slack_chat_html: "%{otw_slack_chat_link} - For more information please see the %{tag_wrangling_slack_tutorial_link}"
         tag_wranglers_mailing_list: Tag Wranglers Mailing List Conversations
-        tag_wranglers_mailing_list_html: '%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List'
+        tag_wranglers_mailing_list_html: "%{tag_wranglers_mailing_list_link} - Message Archive for the Tagwranglers Mailing List"
         tag_wrangling_bugs: Tag Wrangling Bugs & Troubleshooting
-        tag_wrangling_bugs_html: '%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!'
+        tag_wrangling_bugs_html: "%{tag_wrangling_bugs_link} - Having technical issues while wrangling? Check here for solutions!"
         tag_wrangling_committee: Tag Wrangling Committee
-        tag_wrangling_committee_html: '%{tag_wrangling_committee_link} - Full collection of wiki links & policies'
+        tag_wrangling_committee_html: "%{tag_wrangling_committee_link} - Full collection of wiki links & policies"
         tag_wrangling_communication_policy: Tag Wrangling Communication Policy
-        tag_wrangling_communication_policy_html: '%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules'
+        tag_wrangling_communication_policy_html: "%{tag_wrangling_communication_policy_link} - Includes instructions for leaving tag comments and chat rules"
         tag_wrangling_faq: Tag Wrangling FAQ
-        tag_wrangling_faq_html: '%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions'
+        tag_wrangling_faq_html: "%{tag_wrangling_faq_link} - Check here to find answers to frequently asked questions"
         tag_wrangling_moodle: Tag Wrangling Moodle
-        tag_wrangling_moodle_html: '%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers'
+        tag_wrangling_moodle_html: "%{tag_wrangling_moodle_link} - Additional modular training and support for all wranglers"
         tag_wrangling_slack_tutorial: Tag Wrangling Slack Tutorial
         tag_wrangling_training: Tag Wrangling Training
-        tag_wrangling_training_html: '%{tag_wrangling_training_link} - New wranglers, start here!'
+        tag_wrangling_training_html: "%{tag_wrangling_training_link} - New wranglers, start here!"
         unassigned_fandoms: Unassigned Fandoms
-        unassigned_fandoms_html: '%{unassigned_fandoms_link} - A list of all current unassigned fandoms'
+        unassigned_fandoms_html: "%{unassigned_fandoms_link} - A list of all current unassigned fandoms"
         vacations_and_retiring: Vacation and Retiring from Wrangling
-        vacations_and_retiring_html: '%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!'
+        vacations_and_retiring_html: "%{vacations_and_retiring_link} - Unable to wrangle for more than 2 weeks? Read about options for taking a break from wrangling!"
       manage:
         comments: Comments (%{count})
         edit: Edit
@@ -2877,8 +2877,8 @@ en:
         landmark: Notes
         question_for_chair: Question for a Chair!
         question_for_supervisor: Question for a Supervisor!
-        tw_wranglers_quietroom_slack: '#tw-wranglers-quietroom'
-        tw_wranglers_slack: '#tw-wranglers'
+        tw_wranglers_quietroom_slack: "#tw-wranglers-quietroom"
+        tw_wranglers_slack: "#tw-wranglers"
         wrangle_to_guidelines_html: Wrangle tags in accordance with the %{wrangling_guidelines_link}.
         wrangling_guidelines: wrangling guidelines
       page_heading: Tag Wrangling
@@ -2896,7 +2896,7 @@ en:
         merger: Mergers
         relationship: Relationships
         subtag: SubTags
-      tag_type_and_count: '%{tag_type} (%{count})'
+      tag_type_and_count: "%{tag_type} (%{count})"
       unsorted_tags: Unsorted Tags (%{count})
       use_type:
         bookmarks: Bookmarks
@@ -2906,7 +2906,7 @@ en:
         private_bookmarks: Private Bookmarks
         taggings_count: Taggings Count
         works: Works
-      use_type_and_count: '%{use_type} (%{count})'
+      use_type_and_count: "%{use_type} (%{count})"
       wranglers: Wranglers
       wrangling_home: Wrangling Home
       wrangling_tools: Wrangling Tools
@@ -2943,13 +2943,13 @@ en:
       canonical_html: It's a %{canonical_tag_link}. You can use it to %{filter_works_link} and to %{filter_bookmarks_link}.
       canonical_tag: canonical tag
       children:
-        heading: 'Child tags (displaying the first %{count} of each type):'
+        heading: "Child tags (displaying the first %{count} of each type):"
         more: and more
       fandom_relationship_tags: Relationship tags in this fandom
       filter_bookmarks: filter bookmarks
       filter_works: filter works
       list_fandom_tags_html: You can also access a list of %{fandom_relationship_tags_link}.
-      synonyms: 'Tags with the same meaning:'
+      synonyms: "Tags with the same meaning:"
     wrangle:
       manage:
         comments: Comments (%{count})
@@ -2998,7 +2998,7 @@ en:
       ticket_id: Ticket ID
     change_email:
       caution:
-        check_spam_html: '%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email.'
+        check_spam_html: "%{must_confirm_bold} Please check your spam folder or %{contact_support_link} if you do not receive the confirmation email."
         confirm_by: If you don't confirm your request by %{date}, your email address will not be changed.
         contact_support: contact Support
         must_confirm: You must use the link in the confirmation email in order to finish confirming your email change.
@@ -3024,8 +3024,8 @@ en:
       old_password: Old password
       page_heading: Change Password
       password_length:
-        one: '%{minimum} to %{count} character'
-        other: '%{minimum} to %{count} characters'
+        one: "%{minimum} to %{count} character"
+        other: "%{minimum} to %{count} characters"
       submit: Submit
     change_username:
       account_faq: Account FAQ
@@ -3047,7 +3047,7 @@ en:
       password: Password
       submit: Change Username
       submit_landmark: Submit
-      username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+      username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
     confirm_change_email:
       are_you_sure_html: Are you sure you want to change your email address to %{unconfirmed_email}? A confirmation email will be sent to this address.
       cancel: Cancel
@@ -3072,7 +3072,7 @@ en:
       co_creations:
         legend: Works You Made With Others
         orphan_info: You are not able to delete these as they are shared works, but you can %{orphan_link} them or remove yourself completely as a co-creator.
-        summary: 'You have %{work_count} work(s) co-created with the following users: %{co_creators}.'
+        summary: "You have %{work_count} work(s) co-created with the following users: %{co_creators}."
       confirm: Are you sure? This can't be undone!
       heading: What do you want to do with your works?
       options:
@@ -3083,10 +3083,10 @@ en:
       orphan: orphan
       orphaning: orphaning
       sole_creations:
-        collections_summary: 'You have %{collection_count} collection(s) under the following pseuds: %{pseuds}.'
+        collections_summary: "You have %{collection_count} collection(s) under the following pseuds: %{pseuds}."
         legend: Works and Collections You Made By Yourself
         options_info: You can delete them, but please consider %{orphaning_link} them instead!
-        works_summary: 'You have %{work_count} work(s) under the following pseuds: %{pseuds}.'
+        works_summary: "You have %{work_count} work(s) under the following pseuds: %{pseuds}."
       submit: Save
     edit_header_navigation:
       change_email: Change Email
@@ -3108,8 +3108,8 @@ en:
         new_password: New password
         page_heading: Change Password
         password_length:
-          one: '%{minimum} to %{count} character'
-          other: '%{minimum} to %{count} characters'
+          one: "%{minimum} to %{count} character"
+          other: "%{minimum} to %{count} characters"
         submit: Submit
       new:
         email_html: Email address
@@ -3139,10 +3139,10 @@ en:
         confirm_password: Confirm password
         confirm_password_validation: Please enter the same password in both fields.
         password: Password
-        password_requirements: '%{minimum} to %{maximum} characters'
+        password_requirements: "%{minimum} to %{maximum} characters"
         password_validation: Please enter a password! (At least %{minimum} characters long, please.)
         username: Username
-        username_requirements: '%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)'
+        username_requirements: "%{minimum} to %{maximum} characters (A-Z, a-z, _, 0-9 only), no spaces, cannot begin or end with underscore (_)"
         username_validation: You need a username! (At least %{minimum} letters long, please.)
         valid_email: Valid email
     sessions:
@@ -3185,17 +3185,17 @@ en:
       passwd:
         landmark_submit: Submit
         log_in: Log in
-        password: 'Password:'
+        password: "Password:"
         remember_me: Remember me
-        username_or_email: 'Username or email:'
+        username_or_email: "Username or email:"
       passwd_small:
         create_an_account: Create an Account
         forgot_password: Forgot password?
         get_an_invitation: Get an Invitation
         log_in: Log In
-        password: 'Password:'
+        password: "Password:"
         remember_me: Remember Me
-        username_or_email: 'Username or email:'
+        username_or_email: "Username or email:"
     show:
       login_banner:
         contact_abuse: contact our Policy & Abuse team
@@ -3255,7 +3255,7 @@ en:
       show_co-creator_options: Add co-creators?
     drafts:
       page_heading: Unposted Draft
-      please_note: 'Please note:'
+      please_note: "Please note:"
       unposted_drafts_get_deleted: Unposted drafts are only saved for 30 days from the day they are first created, and then deleted from %{app_name}.
     edit_multiple:
       works_languages_help_title: Languages help
@@ -3264,7 +3264,7 @@ en:
         edit_tags_and_language_html: Edit Work Tags and Language for %{title}
         edit_tags_html: Edit Work Tags for %{title}
     import:
-      draft_work_title_html: '%{work_link} (Draft)'
+      draft_work_title_html: "%{work_link} (Draft)"
       page_heading: Imported Works
       success: We were able to successfully upload the following works.
     index:
@@ -3273,8 +3273,8 @@ en:
       recent_works_html: These are some of the latest works posted to the Archive. To find more works, %{choose_fandom_link} or %{advanced_search_link}.
     meta:
       original_creators:
-        one: 'Original Creator ID:'
-        other: 'Original Creator IDs:'
+        one: "Original Creator ID:"
+        other: "Original Creator IDs:"
     navigate:
       page_heading_html: Chapter Index for %{work_link} by %{creators}
     new_import:
@@ -3316,13 +3316,13 @@ en:
       a11y_label: Work
       label: Work Search
       submit: Search
-      tooltip_label: 'tip:'
+      tooltip_label: "tip:"
     search_form:
       creator: Creator
     show:
       unposted_deletion_notice_html: This work is a draft and has not been posted. The draft will be <strong>scheduled for deletion</strong> on %{deletion_date}.
     show_multiple:
-      draft: ' (Draft)'
+      draft: " (Draft)"
       no_works: You have no works or drafts to edit.
     skin:
       select: Select work skin
@@ -3334,8 +3334,8 @@ en:
       works_translation_link_help_title: Translation link
     work_approved_children:
       inspired_by:
-        restricted_html: '[Restricted Work] by %{creator_link} (Log in to access.)'
-        revealed_html: '%{work_link} by %{creator_link}'
+        restricted_html: "[Restricted Work] by %{creator_link} (Log in to access.)"
+        revealed_html: "%{work_link} by %{creator_link}"
         title: Works inspired by this one
         unrevealed: A work in an unrevealed collection
     work_form_associations_language:
@@ -3360,15 +3360,15 @@ en:
         revealed_html: Inspired by %{work_link} by %{creator_link}
         unrevealed: Inspired by a work in an unrevealed collection
       jump:
-        endnotes_and_related_works_html: '(See the end of the work for %{endnotes_link} and %{related_works_link}.)'
-        endnotes_html: '(See the end of the work for %{endnotes_link}.)'
+        endnotes_and_related_works_html: "(See the end of the work for %{endnotes_link} and %{related_works_link}.)"
+        endnotes_html: "(See the end of the work for %{endnotes_link}.)"
         more_notes: more notes
         notes: notes
-        related_works_html: '(See the end of the work for %{related_works_link}.)'
+        related_works_html: "(See the end of the work for %{related_works_link}.)"
       translated_to:
-        restricted_html: 'Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)'
-        revealed_html: 'Translation into %{language} available: %{work_link} by %{creator_link}'
-        unrevealed_html: 'Translation into %{language} available: A work in an unrevealed collection'
+        restricted_html: "Translation into %{language} available: [Restricted Work] by %{creator_link} (Log in to access.)"
+        revealed_html: "Translation into %{language} available: %{work_link} by %{creator_link}"
+        unrevealed_html: "Translation into %{language} available: A work in an unrevealed collection"
       translation_of:
         restricted_html: A translation of [Restricted Work] by %{creator_link} (Log in to access.)
         revealed_html: A translation of %{work_link} by %{creator_link}

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -923,7 +923,8 @@ en:
       update: Update
     preview:
       back_to_edit: Back to Edit
-      commenting_on: 'Commenting on: %{commentable_link}'
+      commenting_on_html: 'Commenting on: %{commentable_link}'
+      missing_commentable: What did you want to comment on?
       page_heading: Preview Comment
       post_comment: Post Comment
     show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,7 +579,7 @@ Rails.application.routes.draw do
     end
     collection do
       post :preview
-      post :back_to_edit
+      post "preview/edit"
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,7 +579,6 @@ Rails.application.routes.draw do
     end
     collection do
       post :preview
-      post :draft
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,7 +579,7 @@ Rails.application.routes.draw do
     end
     collection do
       post :preview
-      post :new
+      post :draft
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -578,6 +578,7 @@ Rails.application.routes.draw do
       put :unhide
     end
     collection do
+      post :preview
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,7 +579,7 @@ Rails.application.routes.draw do
     end
     collection do
       post :preview
-      post "preview/edit"
+      post :new
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,6 +579,7 @@ Rails.application.routes.draw do
     end
     collection do
       post :preview
+      post :back_to_edit
       get :hide_comments
       get :show_comments
       get :add_comment_reply

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -464,12 +464,11 @@ Scenario: Comment preview
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "This is my test comment with <b>bold text</b>"
     And I press "Preview"
-  Then I should see "Preview Comment"
-    And I should see "Commenting on: The One Where Neal is Awesome"
+  Then I should see "Comment on The One Where Neal is Awesome"
     And I should see "This is my test comment with bold text"
     And I should see "commenter" in the comment byline
     And I should see "Cancel"
-    And I should see a button "Post Comment"
+    And I should see a button "Comment"
 
 Scenario: Comment preview persists content when going back to edit
   Given the work "The One Where Neal is Awesome"
@@ -477,7 +476,7 @@ Scenario: Comment preview persists content when going back to edit
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "Initial comment content"
     And I press "Preview"
-  Then I should see "Preview Comment"
+  Then I should see "Comment on The One Where Neal is Awesome"
   When I fill in "Comment" with "Initial comment content with more text"
     And I press "Preview"
   Then I should see "Initial comment content with more text"
@@ -489,9 +488,9 @@ Scenario: Comment preview and post
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "I really enjoyed this!"
     And I press "Preview"
-  Then I should see "Preview Comment"
+  Then I should see "Comment on The One Where Neal is Awesome"
     And I should see "I really enjoyed this!"
-  When I press "Post Comment"
+  When I press "Comment"
   Then I should see "Comment created!"
     And I should see "I really enjoyed this!" within ".odd"
 
@@ -501,7 +500,7 @@ Scenario: Comment preview shows sanitized HTML
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "Safe HTML: <b>bold</b>, <i>italic</i>, <p>paragraph</p>"
     And I press "Preview"
-  Then I should see "Preview Comment"
+  Then I should see "Comment on The One Where Neal is Awesome"
     And I should see "bold"
     And I should see "italic"
     And I should see "paragraph"
@@ -513,7 +512,7 @@ Scenario: Guest comment preview
     And I fill in "Guest email" with "guest@example.com"
     And I fill in "Comment" with "Great work!"
     And I press "Preview"
-  Then I should see "Preview Comment"
+  Then I should see "Comment on The One Where Neal is Awesome"
     And I should see "Guest User" in the comment byline
     And I should see "Great work!"
     And I should see "Cancel"
@@ -526,6 +525,6 @@ Scenario: Comment preview for anonymous work
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "Anonymous work comment"
     And I press "Preview"
-  Then I should see "Preview Comment"
+  Then I should see "Comment on The One Where Neal is Awesome"
     And I should see "Anonymous Creator" in the comment byline
     And I should see "Anonymous work comment"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -520,7 +520,7 @@ Scenario: Guest comment preview
   Then I should see "Preview Comment"
     And I should see "Guest User" in the comment byline
     And I should see "Great work!"
-    And I should see "Back to Edit"
+    And I should see a button "Back to Edit"
   When I press "Back to Edit"
   Then I should see "Great work!" in the comment field
     And I should see "Guest User" in the guest name field

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -468,7 +468,7 @@ Scenario: Comment preview
     And I should see "Commenting on: The One Where Neal is Awesome"
     And I should see "This is my test comment with bold text"
     And I should see "commenter" in the comment byline
-    And I should see a link "Back to Edit"
+    And I should see a button "Back to Edit"
     And I should see a button "Post Comment"
 
 Scenario: Comment preview persists content when going back to edit
@@ -478,13 +478,13 @@ Scenario: Comment preview persists content when going back to edit
     And I fill in "Comment" with "Initial comment content"
     And I press "Preview"
   Then I should see "Preview Comment"
-  When I follow "Back to Edit"
+  When I press "Back to Edit"
   Then I should see "Initial comment content" in the comment field
     And I should see the "Preview" button
   When I fill in "Comment" with "Initial comment content with more text"
     And I press "Preview"
   Then I should see "Initial comment content with more text"
-  When I follow "Back to Edit"
+  When I press "Back to Edit"
   Then I should see "Initial comment content with more text" in the comment field
 
 Scenario: Comment preview and post
@@ -521,13 +521,13 @@ Scenario: Guest comment preview
     And I should see "Guest User" in the comment byline
     And I should see "Great work!"
     And I should see "Back to Edit"
-  When I follow "Back to Edit"
+  When I press "Back to Edit"
   Then I should see "Great work!" in the comment field
     And I should see "Guest User" in the guest name field
 
 Scenario: Comment preview for anonymous work
-  Given the anonymous work "The One Where Neal is Awesome"
-  When I am logged in as "commenter"
+  Given there is a work "The One Where Neal is Awesome" in an anonymous collection "Anonymous Hugs"
+  When I am logged in as the author of "The One Where Neal is Awesome"
     And I view the work "The One Where Neal is Awesome"
     And I fill in "Comment" with "Anonymous work comment"
     And I press "Preview"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -457,3 +457,80 @@ Scenario: Guest comments with an email from a banned or suspended user should be
       And the email to "creator" should contain "edited their reply to your comment on"
       And the email to "creator" should contain "Go to the thread starting from this comment"
       And the email to "creator" should be translated
+
+Scenario: Comment preview
+  Given the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "This is my test comment with <b>bold text</b>"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+    And I should see "Commenting on: The One Where Neal is Awesome"
+    And I should see "This is my test comment with bold text"
+    And I should see "commenter" in the comment byline
+    And I should see a link "Back to Edit"
+    And I should see a button "Post Comment"
+
+Scenario: Comment preview persists content when going back to edit
+  Given the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "Initial comment content"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+  When I follow "Back to Edit"
+  Then I should see "Initial comment content" in the comment field
+    And I should see the "Preview" button
+  When I fill in "Comment" with "Initial comment content with more text"
+    And I press "Preview"
+  Then I should see "Initial comment content with more text"
+  When I follow "Back to Edit"
+  Then I should see "Initial comment content with more text" in the comment field
+
+Scenario: Comment preview and post
+  Given the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "I really enjoyed this!"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+    And I should see "I really enjoyed this!"
+  When I press "Post Comment"
+  Then I should see "Comment created!"
+    And I should see "I really enjoyed this!" within ".odd"
+
+Scenario: Comment preview shows sanitized HTML
+  Given the work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "Safe HTML: <b>bold</b>, <i>italic</i>, <p>paragraph</p>"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+    And I should see "bold"
+    And I should see "italic"
+    And I should see "paragraph"
+
+Scenario: Guest comment preview
+  Given the work "The One Where Neal is Awesome" by "creator" with guest comments enabled
+  When I view the work "The One Where Neal is Awesome"
+    And I fill in "Guest name" with "Guest User"
+    And I fill in "Guest email" with "guest@example.com"
+    And I fill in "Comment" with "Great work!"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+    And I should see "Guest User" in the comment byline
+    And I should see "Great work!"
+    And I should see "Back to Edit"
+  When I follow "Back to Edit"
+  Then I should see "Great work!" in the comment field
+    And I should see "Guest User" in the guest name field
+
+Scenario: Comment preview for anonymous work
+  Given the anonymous work "The One Where Neal is Awesome"
+  When I am logged in as "commenter"
+    And I view the work "The One Where Neal is Awesome"
+    And I fill in "Comment" with "Anonymous work comment"
+    And I press "Preview"
+  Then I should see "Preview Comment"
+    And I should see "Anonymous Creator" in the comment byline
+    And I should see "Anonymous work comment"

--- a/features/comments_and_kudos/add_comment.feature
+++ b/features/comments_and_kudos/add_comment.feature
@@ -468,7 +468,7 @@ Scenario: Comment preview
     And I should see "Commenting on: The One Where Neal is Awesome"
     And I should see "This is my test comment with bold text"
     And I should see "commenter" in the comment byline
-    And I should see a button "Back to Edit"
+    And I should see "Cancel"
     And I should see a button "Post Comment"
 
 Scenario: Comment preview persists content when going back to edit
@@ -478,14 +478,10 @@ Scenario: Comment preview persists content when going back to edit
     And I fill in "Comment" with "Initial comment content"
     And I press "Preview"
   Then I should see "Preview Comment"
-  When I press "Back to Edit"
-  Then I should see "Initial comment content" in the comment field
-    And I should see the "Preview" button
   When I fill in "Comment" with "Initial comment content with more text"
     And I press "Preview"
   Then I should see "Initial comment content with more text"
-  When I press "Back to Edit"
-  Then I should see "Initial comment content with more text" in the comment field
+    And I should see "Initial comment content with more text" in the comment field
 
 Scenario: Comment preview and post
   Given the work "The One Where Neal is Awesome"
@@ -520,9 +516,8 @@ Scenario: Guest comment preview
   Then I should see "Preview Comment"
     And I should see "Guest User" in the comment byline
     And I should see "Great work!"
-    And I should see a button "Back to Edit"
-  When I press "Back to Edit"
-  Then I should see "Great work!" in the comment field
+    And I should see "Cancel"
+    And I should see "Great work!" in the comment field
     And I should see "Guest User" in the guest name field
 
 Scenario: Comment preview for anonymous work

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -430,4 +430,3 @@ end
 Then "I should see {string} in the guest name field" do |text|
   expect(find('input[name="comment[name]"]').value).to eq(text)
 end
-

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -410,3 +410,31 @@ end
 When "I reply on a new page" do
   visit find(:link, "Reply")["href"]
 end
+
+Then 'I should see {string} in the comment byline' do |text|
+  step %{I should see "#{text}" within ".byline"}
+end
+
+Then 'I should see a button {string}' do |text|
+  expect(page).to have_button(text)
+end
+
+Then 'I should see a link {string}' do |text|
+  expect(page).to have_link(text)
+end
+
+Then 'I should see {string} in the comment field' do |text|
+  expect(find('textarea[name="comment[comment_content]"]').value).to include(text)
+end
+
+Then 'I should see the {string} button' do |text|
+  expect(page).to have_button(text)
+end
+
+Then 'I should see {string} in the guest name field' do |text|
+  expect(find('input[name="comment[name]"]').value).to eq(text)
+end
+
+Given 'the anonymous work {string}' do |title|
+  FactoryBot.create(:no_authors, title: title)
+end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -431,6 +431,3 @@ Then "I should see {string} in the guest name field" do |text|
   expect(find('input[name="comment[name]"]').value).to eq(text)
 end
 
-Given "the anonymous work {string}" do |title|
-  FactoryBot.create(:no_authors, title: title)
-end

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -411,30 +411,26 @@ When "I reply on a new page" do
   visit find(:link, "Reply")["href"]
 end
 
-Then 'I should see {string} in the comment byline' do |text|
+Then "I should see {string} in the comment byline" do |text|
   step %{I should see "#{text}" within ".byline"}
 end
 
-Then 'I should see a button {string}' do |text|
+Then "I should see a button {string}" do |text|
   expect(page).to have_button(text)
 end
 
-Then 'I should see a link {string}' do |text|
-  expect(page).to have_link(text)
-end
-
-Then 'I should see {string} in the comment field' do |text|
+Then "I should see {string} in the comment field" do |text|
   expect(find('textarea[name="comment[comment_content]"]').value).to include(text)
 end
 
-Then 'I should see the {string} button' do |text|
+Then "I should see the {string} button" do |text|
   expect(page).to have_button(text)
 end
 
-Then 'I should see {string} in the guest name field' do |text|
+Then "I should see {string} in the guest name field" do |text|
   expect(find('input[name="comment[name]"]').value).to eq(text)
 end
 
-Given 'the anonymous work {string}' do |title|
+Given "the anonymous work {string}" do |title|
   FactoryBot.create(:no_authors, title: title)
 end

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -60,7 +60,7 @@ input[type="submit"] {
   white-space: normal;
 }
 
-p.submit, input.submit, dd.submit {
+p.submit, input.submit, dd.submit, div.actions.right {
   text-align: right;
 }
 

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -60,7 +60,7 @@ input[type="submit"] {
   white-space: normal;
 }
 
-p.submit, input.submit, dd.submit, ul.actions.right {
+p.submit, input.submit, dd.submit {
   text-align: right;
 }
 

--- a/public/stylesheets/site/2.0/08-actions.css
+++ b/public/stylesheets/site/2.0/08-actions.css
@@ -60,7 +60,7 @@ input[type="submit"] {
   white-space: normal;
 }
 
-p.submit, input.submit, dd.submit, div.actions.right {
+p.submit, input.submit, dd.submit, ul.actions.right {
   text-align: right;
 }
 

--- a/public/stylesheets/site/2.0/15-group-comments.css
+++ b/public/stylesheets/site/2.0/15-group-comments.css
@@ -116,4 +116,8 @@ fieldset.comments, .comment .userstuff {
   padding-left: 83px;
 }
 
+#edit_comment_on_preview {
+  margin-top: 2.5em;
+}
+
 /* END == */


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-1173

## Purpose
EDIT: this description is out of date and will be rewritten once features and design are locked in

This change adds a JavaScript-free "comment preview" (similar to work previews) for the commenting system. It should display the parsed HTML in a similar template to how the comment would actually be displayed. It preserves the body/info of the comment, as well as the user info between pages, allowing a user to edit the details until it looks right.

I would like some feedback on a few things:
- The implementation: I'm a bit wary about sending the data in the URL params, but as mentioned in the comments of the Jira ticket, `sessionStorage` and its ilk are out of the question, and I'm not sure we want to implement any comment draft system on the backend.
- The template: I think if we want to emulate the current comment appearance in the preview, then it might be best to have a shared template for comments so that any style changes will be consistent in the preview without needing to edit both places. I wasn't sure whether this would be welcome or warranted, and, if so, what best practices would apply to this codebase when creating the template.
- The style rule for `text-align: right`. I hate how this rule looks, but I'm not sure if we have any better practices for the naming/style rule conventions I can take advantage of here.

# Testing Instructions

I will update the Jira ticket once this code looks close to being ready to merge; until then I want to wait until the flow is solidified and approved.

## Credit

calm (they/them)