### PR TITLE
AO3-7478 Disallow enabling a locale for the interface if it can't be used for emails

### DIFF
--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -3,8 +3,13 @@ class Locale < ApplicationRecord
   validates_presence_of :iso
   validates :iso, uniqueness: true
   validates_presence_of :name
+  validate :interface_enabled_only_if_email_enabled
 
   scope :default_order, -> { order(:iso) }
+
+  def interface_enabled_only_if_email_enabled
+    errors.add(:interface_enabled, :only_if_email_enabled) if interface_enabled && !email_enabled
+  end
 
   def to_param
     iso

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -40,6 +40,8 @@ en:
         requests_num_required: Number of requests required per sign-up
       language:
         short: Abbreviation
+      locale:
+        interface_enabled: Use for interface
       meta_tagging:
         meta_tag: Metatag
         meta_tag_id: Metatag
@@ -162,6 +164,10 @@ en:
               official: Please log out of your official account!
           format: "%{message}"
           taken: You have already left kudos here. :)
+        locale:
+          attributes:
+            interface_enabled:
+              only_if_email_enabled: can only be enabled if use for emails is also enabled.
         mute:
           attributes:
             muted:

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -201,6 +201,15 @@ describe LocalesController do
           expect(assigns(:locale)).to eq(locale)
           expect(assigns(:languages)).to eq(Language.default_order)
         end
+
+        it "errors if use for interface is enabled but use for emails isn't" do
+          fake_login_admin(admin)
+          params = { name: "Tiếng Việt", email_enabled: false, interface_enabled: true }
+
+          put :update, params: { id: locale.iso, locale: params }
+          expect(response).to render_template("edit")
+          expect(assigns[:locale].errors[:interface_enabled]).to include("can only be enabled if use for emails is also enabled.")
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7478

## Purpose

Add a validation so that interface_enabled can only be set to true on a locale if email_enabled is also set to true.

## Credit

Bilka