### PR TITLE
AO3-7488 Prevent deleted and spam comments from being resubmitted to Akismet

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -510,6 +510,8 @@ class Comment < ApplicationRecord
   end
 
   def submit_spam
+    return unless approved && !is_deleted
+
     AkismetClient.submit_spam(akismet_attributes)
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -937,9 +937,7 @@ describe Comment do
     end
 
     context "when the comment is already marked as spam" do
-      let(:comment) { build(:comment, approved: false, spam: true) }
-
-      before { comment.save!(validate: false) }
+      let(:comment) { create_invalid(:comment, approved: false, spam: true) }
 
       it "flags the comment as spam" do
         comment.mark_as_spam!
@@ -967,9 +965,7 @@ describe Comment do
   end
 
   describe "#mark_as_ham!" do
-    let(:comment) { build(:comment, approved: false, spam: true) }
-
-    before { comment.save!(validate: false) }
+    let(:comment) { create_invalid(:comment, approved: false, spam: true) }
 
     it "flags the comment as legitimate" do
       comment.mark_as_ham!

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -928,10 +928,18 @@ describe Comment do
         expect(comment.approved).to be_falsey
         expect(comment.spam).to be_truthy
       end
+
+      it "submits the comment to Akismet" do
+        expect(AkismetClient).to receive(:submit_spam)
+
+        comment.mark_as_spam!
+      end
     end
 
     context "when the comment is already marked as spam" do
-      let(:comment) { create(:comment, approved: false, spam: false) }
+      let(:comment) { build(:comment, approved: false, spam: true) }
+
+      before { comment.save!(validate: false) }
 
       it "flags the comment as spam" do
         comment.mark_as_spam!
@@ -939,11 +947,29 @@ describe Comment do
         expect(comment.approved).to be_falsey
         expect(comment.spam).to be_truthy
       end
+
+      it "does not resubmit the comment to Akismet" do
+        expect(AkismetClient).not_to receive(:submit_spam)
+
+        comment.mark_as_spam!
+      end
+    end
+
+    context "when the comment is deleted" do
+      let(:comment) { create(:comment, approved: true, spam: false, is_deleted: true) }
+
+      it "does not submit the comment to akismet" do
+        expect(AkismetClient).not_to receive(:submit_spam)
+
+        comment.mark_as_spam!
+      end
     end
   end
 
   describe "#mark_as_ham!" do
-    let(:comment) { create(:comment, approved: false, spam: true) }
+    let(:comment) { build(:comment, approved: false, spam: true) }
+
+    before { comment.save!(validate: false) }
 
     it "flags the comment as legitimate" do
       comment.mark_as_ham!


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7488

## Purpose

Restores the check that prevented comments that were deleted or already marked as spam from being submitted to Akismet

Plus a fix to the `#mark_as_ham!` test where the comment would already be marked as legitimate due to the spam status being updated in the validations.

## Testing Instructions

Automated tests only. There isn’t an easy way to tell if a comment was actually sent to Akismet or not.

## Credit

marcus8448 (he/him)