### PR TITLE
AO3-6811 Fix tag nomination parented bug

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1247,17 +1247,8 @@ class Tag < ApplicationRecord
       exists: true
     )
 
-    if canonical?
-      # Calculate the parents associated with this tag, because we'll set any
-      # TagNominations with a matching parent_tagname to have parented: true.
-      parent_names = parents.pluck(:name)
-
-      # If this tag has any parents at all, we also want to count it as parented
-      # for nominations with a blank parent_tagname. See the set_parented
-      # function in TagNominations for the calculation that we're trying to mimic
-      # here.
-      parent_names.push("", nil) if parent_names.present?
-
+    if canonical? && parents.exists?
+      parent_names = parents.where(type: "Fandom").pluck(:name).push("", nil)
       TagNomination.where(tagname: name, parent_tagname: parent_names).update_all(parented: true)
     end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1248,15 +1248,15 @@ class Tag < ApplicationRecord
     )
 
     if canonical?
-      # Calculate the fandoms associated with this tag, because we'll set any
+      # Calculate the parents associated with this tag, because we'll set any
       # TagNominations with a matching parent_tagname to have parented: true.
-      parent_names = parents.where(type: "Fandom").pluck(:name)
+      parent_names = parents.pluck(:name)
 
-      # If this tag has any fandoms at all, we also want to count it as parented
+      # If this tag has any parents at all, we also want to count it as parented
       # for nominations with a blank parent_tagname. See the set_parented
       # function in TagNominations for the calculation that we're trying to mimic
       # here.
-      parent_names << "" if parent_names.present?
+      parent_names.push("", nil) if parent_names.present?
 
       TagNomination.where(tagname: name, parent_tagname: parent_names).update_all(parented: true)
     end

--- a/spec/models/tagset_models/tag_nomination_spec.rb
+++ b/spec/models/tagset_models/tag_nomination_spec.rb
@@ -62,5 +62,26 @@ describe TagNomination do
         end
       end
     end
+
+    context "when the nominated tag is a canonical fandom with a media parent" do
+      let(:media) { create(:media) }
+      let(:fandom) { create(:canonical_fandom) }
+
+      before do
+        create(:common_tagging, filterable: media, common_tag: fandom)
+      end
+
+      let(:nomination) { create(:tag_nomination, tagname: fandom.name, type: "FandomNomination") }
+
+      it "sets parented to true" do
+        expect(nomination.parented).to be(true)
+      end
+
+      it "keeps parented true after the tag is re-saved" do
+        nomination
+        fandom.save!
+        expect(nomination.reload.parented).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6811

## Purpose

When a canonical tag is saved, `Tag#update_tag_nominations` sets `parented: true` on matching `TagNomination` records.
However, it only checked for `Fandom`-type parents and only matched nominations with a blank `parent_tagname` (empty string).
This caused nominations to be incorrectly marked as `parented: false` when:

- The tag's parent was a non-Fandom type (e.g., a Media parent on a Fandom tag).
- The nomination had a `nil` `parent_tagname` instead of an empty string.

This PR fixes both issues by:

1. Checking all parent types instead of only Fandoms.
2. Including both `""` and `nil` in the `parent_names` list so nominations with either blank value are matched.

## Testing Instructions

1. Create a canonical fandom tag with a Media parent (but no Fandom parent).
2. Create a tag nomination for that fandom in a tag set.
3. Save the fandom tag.
4. Verify the nomination's `parented` field is `true`.

## Credit

Pablo Monfort (he/him)