### PR TITLE
AO3-7416 Disallow using parent-only site skin

### DIFF
--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -28,10 +28,15 @@ class Preference < ApplicationRecord
   end
 
   def can_use_skin
-    return if skin_id == AdminSetting.default_skin_id ||
-              (skin.is_a?(Skin) && skin.approved_or_owned_by?(user))
+    return if skin_id == AdminSetting.default_skin_id
+    
+    if !skin.is_a?(Skin) || !skin.approved_or_owned_by?(user)
+      errors.add(:base, :no_permission_for_skin)
+    end
 
-    errors.add(:base, "You don't have permission to use that skin!")
+    if skin.unusable?
+      errors.add(:base, :unusable_skin)
+    end
   end
 
   def locale

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -30,13 +30,10 @@ class Preference < ApplicationRecord
   def can_use_skin
     return if skin_id == AdminSetting.default_skin_id
     
-    if !skin.is_a?(Skin) || !skin.approved_or_owned_by?(user)
-      errors.add(:base, :no_permission_for_skin)
-    end
-
-    if skin.unusable?
-      errors.add(:base, :unusable_skin)
-    end
+    errors.add(:base, :no_permission_for_skin) if !skin.is_a?(Skin) || !skin.approved_or_owned_by?(user)
+    
+    return unless skin.unusable?
+    errors.add(:base, :unusable_skin)
   end
 
   def locale

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -33,6 +33,7 @@ class Preference < ApplicationRecord
     errors.add(:base, :no_permission_for_skin) if !skin.is_a?(Skin) || !skin.approved_or_owned_by?(user)
     
     return unless skin.unusable?
+
     errors.add(:base, :unusable_skin)
   end
 

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -174,6 +174,9 @@ en:
           format: "%{message}"
         prompt:
           tags_not_in_fandom: "^These %{tag_label} tags in your %{prompt_type} are not in the selected fandom(s), %{fandom}: %{taglist} (Your moderator may be able to fix this.)"
+        preference:
+          no_permission_for_skin: "You don't have permission to use that skin!"
+          unusable_skin: "This skin can only be used as a parent."
         related_work:
           attributes:
             parent:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -172,11 +172,11 @@ en:
             muted_id:
               taken: You have already muted that user.
           format: "%{message}"
+        preference:
+          no_permission_for_skin: You don't have permission to use that skin!
+          unusable_skin: This skin can only be used as a parent.
         prompt:
           tags_not_in_fandom: "^These %{tag_label} tags in your %{prompt_type} are not in the selected fandom(s), %{fandom}: %{taglist} (Your moderator may be able to fix this.)"
-        preference:
-          no_permission_for_skin: "You don't have permission to use that skin!"
-          unusable_skin: "This skin can only be used as a parent."
         related_work:
           attributes:
             parent:

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -132,6 +132,15 @@ describe PreferencesController do
         expect(response).to render_template(:index)
         expect(flash[:error]).to eq("Sorry, something went wrong. Please try that again.")
       end
+
+      it "disallows setting a parent-only site skin" do
+        skin.update!(unusable: true)
+
+        put :update, params: {user_id: user.login, id: user.preference.id, preference: preference_params}
+
+        expect(response).to render_template(:index)
+        expect(flash[:error]).to eq("Sorry, something went wrong. Please try that again.")
+      end
     end
 
     context "as a guest" do

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -136,7 +136,7 @@ describe PreferencesController do
       it "disallows setting a parent-only site skin" do
         skin.update!(unusable: true)
 
-        put :update, params: {user_id: user.login, id: user.preference.id, preference: preference_params}
+        put :update, params: { user_id: user.login, id: user.preference.id, preference: preference_params }
 
         expect(response).to render_template(:index)
         expect(flash[:error]).to eq("Sorry, something went wrong. Please try that again.")


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7416

## Purpose

Redirects to the preferences page with the error "This skin can only be used as a parent." if the user tries to update their preferences with a parent-only site skin.

## Credit

zrei (she/they)
