### PR TITLE
AO3-7470 Always use first-party JQuery & JQuery UI

### DIFF
--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -2,15 +2,8 @@
 <% if allow_tinymce?(controller) %>
   <%= yield :tinymce %>
 <% end %>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-<!-- if user has googleapis blocked for some reason we need a fallback -->
-<script type="text/javascript">
-  if (typeof jQuery == 'undefined') {
-    document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-    document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-  }
-</script>
+<script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+<script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
 
 <% if Rails.env.test? %>
   <!--

--- a/public/400.html
+++ b/public/400.html
@@ -138,16 +138,8 @@
   </div>
   <!-- END footer -->
 </div>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-<!-- if user has googleapis blocked for some reason we need a fallback -->
-<script type="text/javascript">
-  if (typeof jQuery == 'undefined')
-  {
-    document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-    document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-  }
-</script>
+<script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+<script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
 <script type="text/javascript">$j = jQuery.noConflict();</script>
 <script src="/javascripts/application.js" type="text/javascript"></script>
 <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/403.html
+++ b/public/403.html
@@ -138,16 +138,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/404.html
+++ b/public/404.html
@@ -138,16 +138,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/406-unsupported-browser.html
+++ b/public/406-unsupported-browser.html
@@ -137,16 +137,8 @@
   </div>
   <!-- END footer -->
 </div>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-<!-- if user has googleapis blocked for some reason we need a fallback -->
-<script type="text/javascript">
-  if (typeof jQuery == 'undefined')
-  {
-    document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-    document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-  }
-</script>
+<script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+<script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
 <script type="text/javascript">$j = jQuery.noConflict();</script>
 <script src="/javascripts/application.js" type="text/javascript"></script>
 <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/445.html
+++ b/public/445.html
@@ -137,16 +137,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/500.html
+++ b/public/500.html
@@ -138,16 +138,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/502.html
+++ b/public/502.html
@@ -139,16 +139,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/503.html
+++ b/public/503.html
@@ -138,16 +138,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/507.html
+++ b/public/507.html
@@ -139,16 +139,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/nomaintenance.html
+++ b/public/nomaintenance.html
@@ -139,16 +139,8 @@
       </div>
       <!-- END footer -->
     </div>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined')
-      {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>

--- a/public/status/index.html
+++ b/public/status/index.html
@@ -150,15 +150,8 @@
       </ul>
     </div>
     <!-- END footer -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js" type="text/javascript"></script>
-    <!-- if user has googleapis blocked for some reason we need a fallback -->
-    <script type="text/javascript">
-      if (typeof jQuery == 'undefined') {
-        document.write(unescape("%3Cscript src='/javascripts/jquery.min.js' type='text/javascript'%3E%3C/script%3E"));
-        document.write(unescape("%3Cscript src='/javascripts/jquery-ui.min.js' type='text/javascript'%3E%3C/script%3E"));
-      }
-    </script>
+    <script src="/javascripts/jquery.min.js" type="text/javascript"></script>
+    <script src="/javascripts/jquery-ui.min.js" type="text/javascript"></script>
     <script type="text/javascript">$j = jQuery.noConflict();</script>
     <script src="/javascripts/application.js" type="text/javascript"></script>
     <script src="/javascripts/bootstrap/bootstrap-dropdown.js" type="text/javascript"></script>


### PR DESCRIPTION
## Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)? (no new tests are needed here I believe)
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

[AO3-7470: Move JQuery/JQuery UI to first party hosting](https://otwarchive.atlassian.net/browse/AO3-7470)

## Purpose

Makes it so the site always serves its own JQuery JavaScript files (which were previously a fallback) instead of getting them from Google.

## Notes

While the JS in our `jquery.js`, `jquery.min.js` and `jquery-ui.js` files is exactly identical to Google's, `jquery-ui.min.js` looks different for some reason. Things seem to work the same for me, and the automated tests should show if anything breaks there, I'm guessing that a different minifier just happened to get used at some point, but I'm also open to replacing the file if anyone feels it'd be safer to make it exactly identical to Google's.

Also I have no idea why the error pages are loading any javascript at all...

## Credit

slavalamp
