### PR TITLE
AO3-7493 Rate limit commenting based on users's comment count

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -68,7 +68,7 @@ class CommentsController < ApplicationController
 
     return false unless logged_in? # Guest comment rate limits are not handled here
 
-    return false unless current_user.should_spam_check_comments?
+    return false unless current_user.should_rate_limit_comments?
 
     parent = find_parent
     return false if parent.is_a?(Tag)

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -45,7 +45,7 @@ class AdminSetting < ApplicationRecord
   end
 
   def self.current
-    Rails.cache.fetch("admin_settings-v3", race_condition_ttl: 10.seconds) { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
+    Rails.cache.fetch("admin_settings-v4", race_condition_ttl: 10.seconds) { AdminSetting.first } || OpenStruct.new(DEFAULT_SETTINGS)
   end
 
   class << self
@@ -79,7 +79,7 @@ class AdminSetting < ApplicationRecord
     self.reload
 
     # However, we only cache it if the transaction is successful.
-    after_commit { Rails.cache.write("admin_settings-v3", self) }
+    after_commit { Rails.cache.write("admin_settings-v4", self) }
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -435,6 +435,12 @@ class User < ApplicationRecord
     (Time.current - created_at).seconds.in_days.to_i < AdminSetting.current.account_age_threshold_for_comment_spam_check
   end
 
+  def should_rate_limit_comments?
+    # When comment_count_threshold_for_comment_rate_limit is 0, no users should be rate limited based on comment count, so don't count the comments at all
+    based_on_comments_count = AdminSetting.current.comment_count_threshold_for_comment_rate_limit.zero? ? false : comments.count < AdminSetting.current.comment_count_threshold_for_comment_rate_limit
+    should_spam_check_comments? || based_on_comments_count
+  end
+
   # Creates log item tracking changes to user
   def create_log_item(options = {})
     options.reverse_merge! note: "System Generated", user_id: self.id

--- a/app/policies/admin_setting_policy.rb
+++ b/app/policies/admin_setting_policy.rb
@@ -10,6 +10,7 @@ class AdminSettingPolicy < ApplicationPolicy
       invite_from_queue_number
       request_invite_enabled
       account_age_threshold_for_comment_spam_check
+      comment_count_threshold_for_comment_rate_limit
     ],
     "superadmin" => %i[
       account_creation_enabled
@@ -23,6 +24,7 @@ class AdminSettingPolicy < ApplicationPolicy
       hide_spam
       guest_comments_off
       account_age_threshold_for_comment_spam_check
+      comment_count_threshold_for_comment_rate_limit
       invite_from_queue_enabled
       invite_from_queue_frequency
       invite_from_queue_number

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -81,6 +81,12 @@
         <%= admin_setting_text_field(f, :account_age_threshold_for_comment_spam_check, size: "3", "aria-describedby": "account-age-threshold-for-comment-spam-check-note") %>
         <p id="account-age-threshold-for-comment-spam-check-note" class="footnote"><%= t(".fields.account_age_threshold_for_comment_spam_check_note") %></p>
       </dd>
+
+      <dt><%= f.label :comment_count_threshold_for_comment_rate_limit, t(".fields.comment_count_threshold_for_comment_rate_limit") %></dt>
+      <dd>
+        <%= admin_setting_text_field(f, :comment_count_threshold_for_comment_rate_limit, size: "3", "aria-describedby": "comment-count-threshold-for-comment-rate-limit-note") %>
+        <p id="comment-count-threshold-for-comment-rate-limit-note" class="footnote"><%= t(".fields.comment_count_threshold_for_comment_rate_limit_note") %></p>
+      </dd>
     </dl>
   </fieldset>
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -393,7 +393,7 @@ en:
         fields:
           account_age_threshold_for_comment_spam_check: How old (in days) accounts should be before we stop checking comments for spam
           account_age_threshold_for_comment_spam_check_note: Enter 0 to turn off comment spam checks for all logged in users.
-          comment_count_threshold_for_comment_rate_limit: How many comments accounts should have before we stop rate limiting them like new accounts
+          comment_count_threshold_for_comment_rate_limit: How many comments older accounts should have before we stop rate limiting them
           comment_count_threshold_for_comment_rate_limit_note: Enter 0 to turn off additional comment rate limits based on comment count.
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -393,10 +393,10 @@ en:
         fields:
           account_age_threshold_for_comment_spam_check: How old (in days) accounts should be before we stop checking comments for spam
           account_age_threshold_for_comment_spam_check_note: Enter 0 to turn off comment spam checks for all logged in users.
-          comment_count_threshold_for_comment_rate_limit: How many comments older accounts should have before we stop rate limiting them
-          comment_count_threshold_for_comment_rate_limit_note: Enter 0 to turn off additional comment rate limits based on comment count.
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching
+          comment_count_threshold_for_comment_rate_limit: How many comments older accounts should have before we stop rate limiting them
+          comment_count_threshold_for_comment_rate_limit_note: Enter 0 to turn off additional comment rate limits based on comment count.
           creation_requires_invite: Account creation requires invitation
           days_to_purge_unactivated: How many weeks you have to activate your account before we purge it
           disable_support_form: Turn off support form

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -393,6 +393,8 @@ en:
         fields:
           account_age_threshold_for_comment_spam_check: How old (in days) accounts should be before we stop checking comments for spam
           account_age_threshold_for_comment_spam_check_note: Enter 0 to turn off comment spam checks for all logged in users.
+          comment_count_threshold_for_comment_rate_limit: How many comments accounts should have before we stop rate limiting them like new accounts
+          comment_count_threshold_for_comment_rate_limit_note: Enter 0 to turn off additional comment rate limits based on comment count.
           account_creation_enabled: Account creation enabled
           cache_expiration: How often (in minutes) should we refresh caching
           creation_requires_invite: Account creation requires invitation

--- a/db/migrate/20260604175237_add_comment_count_threshold_for_comment_rate_limit_to_admin_settings.rb
+++ b/db/migrate/20260604175237_add_comment_count_threshold_for_comment_rate_limit_to_admin_settings.rb
@@ -1,0 +1,5 @@
+class AddCommentCountThresholdForCommentRateLimitToAdminSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :admin_settings, :comment_count_threshold_for_comment_rate_limit, :integer, default: 0, null: false
+  end
+end

--- a/features/comments_and_kudos/comments_rate_limit.feature
+++ b/features/comments_and_kudos/comments_rate_limit.feature
@@ -3,6 +3,7 @@ Feature: Granular comment rate limiting
 
   Scenario: Guest commenter is not affected by rate limits
     Given account age threshold for comment spam check is set to 5 days
+      And comment count threshold for comment rate limit is set to 5
       And the work "Spam target" by "joe" with guest comments enabled
       And I am logged out
     When I view the work "Spam target"
@@ -15,6 +16,7 @@ Feature: Granular comment rate limiting
 
   Scenario: Work creator is not affected by rate limits
     Given account age threshold for comment spam check is set to 5 days
+      And comment count threshold for comment rate limit is set to 5
       And the work "Spam target" by "joe" with guest comments enabled
     When I am logged in as a new user "joe"
       And I post the comment "Hello!" on the work "Spam target"
@@ -26,6 +28,7 @@ Feature: Granular comment rate limiting
 
   Scenario: Tag comments are not affected by rate limits
     Given account age threshold for comment spam check is set to 5 days
+      And comment count threshold for comment rate limit is set to 5
       And a canonical fandom "Stargate SG-1"
       And I am logged in as a tag wrangler
       And I view the tag "Stargate SG-1" with comments
@@ -132,6 +135,65 @@ Feature: Granular comment rate limiting
   Scenario Outline: New users' comments should not be rate limited when the admin setting is disabled
     Given <commentable>
       And account age threshold for comment spam check is set to 0 days
+    When I am logged in as a new user "naughty"
+      And I view <commentable> with comments
+      And I post the comment "One comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Two comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Three comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Four comment" on <commentable>
+    Then I should see "Comments (4)"
+      But I should not see "Error 429"
+
+    Examples:
+      | commentable |
+      | the work "Generic Work"  |
+      | the admin post "Generic Post" |
+
+  Scenario Outline: Low comment count users' comments should be rate limited when the comment count admin setting is enabled
+    Given <commentable>
+      And comment count threshold for comment rate limit is set to 5
+    When I am logged in as a new user "naughty"
+      And I view <commentable> with comments
+      And I post the comment "One comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Two comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Three comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Four comment" on <commentable>
+    Then I should see "Error 429"
+
+    Examples:
+      | commentable |
+      | the work "Generic Work"  |
+      | the admin post "Generic Post" |
+
+  Scenario Outline: High comment count users' comments should not be rate limited when the comment count admin setting is enabled
+    Given <commentable>
+      And comment count threshold for comment rate limit is set to 2
+    When I am logged in as a new user "naughty"
+      And I view <commentable> with comments
+      And I post the comment "One comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Two comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Three comment" on <commentable>
+    Then I should see "Comment created!"
+      And I post the comment "Four comment" on <commentable>
+    Then I should see "Comments (4)"
+      But I should not see "Error 429"
+
+    Examples:
+      | commentable |
+      | the work "Generic Work"  |
+      | the admin post "Generic Post" |
+
+  Scenario Outline: Low comment count users' comments should not be rate limited when the comment count admin setting is disabled
+    Given <commentable>
+      And comment count threshold for comment rate limit is set to 0
     When I am logged in as a new user "naughty"
       And I view <commentable> with comments
       And I post the comment "One comment" on <commentable>

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -125,6 +125,13 @@ Given "account age threshold for comment spam check is set to {int} days" do |da
   click_button("Update")
 end
 
+Given "comment count threshold for comment rate limit is set to {int}" do |count|
+  step("I am logged in as a super admin")
+  visit(admin_settings_path)
+  fill_in("admin_setting_comment_count_threshold_for_comment_rate_limit", with: count)
+  click_button("Update")
+end
+
 Given "I have posted known issues" do
   step %{I am logged in as a super admin}
   step %{I follow "Admin Posts"}

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -66,7 +66,8 @@ describe Admin::SettingsController do
               cache_expiration: "10",
               hide_spam: "1",
               guest_comments_off: "1",
-              account_age_threshold_for_comment_spam_check: "7"
+              account_age_threshold_for_comment_spam_check: "7",
+              comment_count_threshold_for_comment_rate_limit: "10"
             }
           }
 
@@ -92,6 +93,7 @@ describe Admin::SettingsController do
 
         {
           account_age_threshold_for_comment_spam_check: 10,
+          comment_count_threshold_for_comment_rate_limit: 3,
           hide_spam: 1,
           invite_from_queue_enabled: 0,
           invite_from_queue_number: 11,
@@ -113,7 +115,8 @@ describe Admin::SettingsController do
           hide_spam: true,
           guest_comments_off: true,
           tag_wrangling_off: true,
-          account_age_threshold_for_comment_spam_check: 10
+          account_age_threshold_for_comment_spam_check: 10,
+          comment_count_threshold_for_comment_rate_limit: 3
         }.each_pair do |field, value|
           it "prevents admins with support role from updating #{field}" do
             expect do
@@ -145,7 +148,8 @@ describe Admin::SettingsController do
           downloads_enabled: false,
           hide_spam: true,
           guest_comments_off: true,
-          account_age_threshold_for_comment_spam_check: 10
+          account_age_threshold_for_comment_spam_check: 10,
+          comment_count_threshold_for_comment_rate_limit: 3
         }.each_pair do |field, value|
           it "prevents admins with tag_wrangling role from updating #{field}" do
             expect do

--- a/test/fixtures/admin_settings.yml
+++ b/test/fixtures/admin_settings.yml
@@ -21,3 +21,4 @@ admin_setting_3:
   hide_spam: false
   guest_comments_off: false
   account_age_threshold_for_comment_spam_check: 0
+  comment_count_threshold_for_comment_rate_limit: 0


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7493

## Purpose

Rate limit comment creation based on existing comment count as well as account age. All restrictions like not for guests, not on tags etc still apply. Done with a new admin setting. Setting the setting to 0 (the default) disable the comment count based check.

## Credit

Bilka
