### PR TITLE
AO3-6084 Improve error behavior for Add Prompt form (prompt memes) BOT

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -126,11 +126,11 @@ class PromptsController < ApplicationController
       flash[:notice] = ts("Prompt was successfully added.")
       redirect_to collection_signup_path(@collection, @challenge_signup)
     else
-      if params[:prompt_type] == "offer"
-        @index = @challenge_signup.offers.count
-      else
-        @index = @challenge_signup.requests.count
-      end
+      @index = if params[:prompt_type] == "offer"
+                 @challenge_signup.offers.count
+               else
+                 @challenge_signup.requests.count
+               end
       render action: :new
     end
   end

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -126,6 +126,11 @@ class PromptsController < ApplicationController
       flash[:notice] = ts("Prompt was successfully added.")
       redirect_to collection_signup_path(@collection, @challenge_signup)
     else
+      if params[:prompt_type] == "offer"
+        @index = @challenge_signup.offers.count
+      else
+        @index = @challenge_signup.requests.count
+      end
       render action: :new
     end
   end


### PR DESCRIPTION

## Issue

https://otwarchive.atlassian.net/browse/AO3-6084

## Purpose

Addresses an bug where after the Add Prompt form reloads with an error message, the request number title returns to Request 1 even if it was originally something else

## References

#5706 

## Credit

Ling-Yi (any pronouns)