### PR TITLE
AO3-7446 Removing the outdated and unecessary link from "Archive Warnings:"

### DIFF
--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -9,10 +9,7 @@
       <% tags = tag_group[type] %>
         <% unless tags.blank? %>
           <dt class="<%= tag_type_css_class(type) %> tags">
-
-            <% if type == "ArchiveWarning" %>
-              <%= link_to( tags.size == 1 ? type.constantize::NAME : type.constantize::NAME.pluralize, tos_faq_path(:anchor => "tags") ) %>:
-            <% elsif type.constantize::NAME == ArchiveConfig.FREEFORM_CATEGORY_NAME %>
+            <% if type.constantize::NAME == ArchiveConfig.FREEFORM_CATEGORY_NAME %>
               <%= type.constantize::NAME %>:
             <% else %>
               <%= tags.size == 1 ? type.constantize::NAME : type.constantize::NAME.pluralize %>:


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7446

## Purpose

At the top of a work, the text “Archive Warning” used to link to https://test.archiveofourown.org/tos_faq#tags which no longer exists. This PR removes it.

## Testing Instructions

1. View any work.
2. Confirm that there is no hyperlink on the words "Archive Warnings:" in the work meta. 

## Credit

FlyingFalcon they/them
