### PR TITLE
AO3-7490 Add invite queue frequency permission to PAC admins.

### DIFF
--- a/app/policies/admin_setting_policy.rb
+++ b/app/policies/admin_setting_policy.rb
@@ -7,6 +7,7 @@ class AdminSettingPolicy < ApplicationPolicy
     "policy_and_abuse" => %i[
       hide_spam
       invite_from_queue_enabled
+      invite_from_queue_frequency
       invite_from_queue_number
       request_invite_enabled
       account_age_threshold_for_comment_spam_check

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -95,6 +95,7 @@ describe Admin::SettingsController do
           hide_spam: 1,
           invite_from_queue_enabled: 0,
           invite_from_queue_number: 11,
+          invite_from_queue_frequency: 5,
           request_invite_enabled: 1
         }.each_pair do |field, value|
           it "allows admins with policy_and_abuse role to update #{field}" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7490

## Purpose

Adds ability for PAC admins to adjust invite queue frequency.