### PR TITLE
AO3-7435 Fix bug where saving changes on unsorted canonical tag gives 500 error.

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -224,16 +224,14 @@ class TagsController < ApplicationController
 
     # update everything except for the synonym,
     # so that the associations are there to move when the synonym is created
-    syn_string = params[:tag].delete(:syn_string)
-    new_tag_type = params[:tag].delete(:type)
+    syn_string = params[:tag]&.delete(:syn_string)
+    new_tag_type = params[:tag]&.delete(:type)
 
     # Limiting the conditions under which you can update the tag type
     types = logged_in_as_admin? ? (Tag::USER_DEFINED + %w[Media]) : Tag::USER_DEFINED
     @tag = @tag.recategorize(new_tag_type) if @tag.can_change_type? && (types + %w[UnsortedTag]).include?(new_tag_type)
 
-    unless params[:tag].empty?
-      @tag.attributes = tag_params
-    end
+    @tag.attributes = tag_params if params[:tag].present?
 
     @tag.syn_string = syn_string if @tag.errors.empty? && @tag.save
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -411,6 +411,18 @@ describe TagsController do
       include_examples "set last wrangling activity"
     end
 
+    context "when no tag parameters are submitted" do
+      let(:unsorted_tag) { create(:unsorted_tag, canonical: true) }
+
+      it "does not raise and redirects to success message" do
+        expect do
+          put :update, params: { id: unsorted_tag, commit: "Save changes" }
+        end.not_to raise_error
+
+        it_redirects_to_with_notice(edit_tag_path(unsorted_tag), "Tag was updated.")
+      end
+    end
+
     context "when making a canonical tag into a synonym" do
       let(:tag) { create(:freeform, canonical: true) }
       let(:synonym) { create(:freeform, canonical: true) }

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -415,9 +415,7 @@ describe TagsController do
       let(:unsorted_tag) { create(:unsorted_tag, canonical: true) }
 
       it "does not raise and redirects to success message" do
-        expect do
-          put :update, params: { id: unsorted_tag, commit: "Save changes" }
-        end.not_to raise_error
+        put :update, params: { id: unsorted_tag, commit: "Save changes" }
 
         it_redirects_to_with_notice(edit_tag_path(unsorted_tag), "Tag was updated.")
       end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7435

## Purpose

Ignores missing tag hash which occurs when an empty update happens on an unsorted canonical tag, fixes undefined call on nil. 

## References

Should unblock [AO3-7436](https://otwarchive.atlassian.net/browse/AO3-7436)



[AO3-7436]: https://otwarchive.atlassian.net/browse/AO3-7436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ