### PR TITLE
AO3-6765 Use ul in skin preview msg again

### DIFF
--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -135,13 +135,12 @@ class SkinsController < ApplicationController
     end
 
     flash[:notice] = [
-      helpers.content_tag(
-        :ul,
-        helpers.content_tag(:li, t(".skin_title", title: @skin.title)) +
-        helpers.content_tag(:li, t(".remove_skin")) +
-        helpers.content_tag(:li, t(".tip", site_skin_id: @skin.id))
+      helpers.tag.ul(
+        helpers.tag.li(t(".skin_title", title: @skin.title)) +
+        helpers.tag.li(t(".remove_skin")) +
+        helpers.tag.li(t(".tip", site_skin_id: @skin.id))
       ),
-      helpers.content_tag(:p, helpers.link_to(t(".return_to_skin"), skin_path(@skin), class: "action"))
+      helpers.tag.p(helpers.link_to(t(".return_to_skin"), skin_path(@skin), class: "action"))
     ].join("\n")
     redirect_to "#{ArchiveConfig.SKIN_PREVIEW_URL}?site_skin=#{@skin.id}"
   end

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -135,7 +135,8 @@ class SkinsController < ApplicationController
     end
 
     flash[:notice] = [
-      helpers.content_tag(:ul,
+      helpers.content_tag(
+        :ul,
         helpers.content_tag(:li, t(".skin_title", title: @skin.title)) +
         helpers.content_tag(:li, t(".remove_skin")) +
         helpers.content_tag(:li, t(".tip", site_skin_id: @skin.id))

--- a/app/controllers/skins_controller.rb
+++ b/app/controllers/skins_controller.rb
@@ -135,11 +135,13 @@ class SkinsController < ApplicationController
     end
 
     flash[:notice] = [
-      t(".skin_title", title: @skin.title),
-      t(".remove_skin"),
-      t(".tip", site_skin_id: @skin.id),
-      helpers.link_to(t(".return_to_skin"), skin_path(@skin), class: "action")
-    ].join("<br />")
+      helpers.content_tag(:ul,
+        helpers.content_tag(:li, t(".skin_title", title: @skin.title)) +
+        helpers.content_tag(:li, t(".remove_skin")) +
+        helpers.content_tag(:li, t(".tip", site_skin_id: @skin.id))
+      ),
+      helpers.content_tag(:p, helpers.link_to(t(".return_to_skin"), skin_path(@skin), class: "action"))
+    ].join("\n")
     redirect_to "#{ArchiveConfig.SKIN_PREVIEW_URL}?site_skin=#{@skin.id}"
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6765

## Purpose

[Feedback from testing](https://otwarchive.atlassian.net/browse/AO3-6765?focusedCommentId=383546) on changes in #5744 

The message is made up of 3 parts and then a button.

Before all 4 items were part of the list due to how notices are formed, which was replaced in favour of just separating by br.

Change this so the first 3 parts are in a ul and the button is separated from them and wrapped in a p:

<img width="1267" height="236" alt="image" src="https://github.com/user-attachments/assets/2c3c8277-2bb7-4156-9135-c12693c3ec1b" />

Renders to:
```
<ul><li>You are previewing the skin Some Skin.</li><li>Go back or follow any link to remove the skin.</li><li>Tip: You can preview any archive page you want by adding "?site_skin=35" to the end of the URL.</li></ul>
<p><a class="action" href="/skins/35">Return to Skin to Use</a></p>
```

## References

https://github.com/otwcode/otwarchive/pull/4934
https://github.com/otwcode/otwarchive/pull/5744

## Credit

nicolacleary (she/her)