### PR TITLE
AO3-6789 Return 404 when accessing challenge on nonexistent collection

### DIFF
--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -17,6 +17,10 @@ class ChallengeSignupsController < ApplicationController
   before_action :check_signup_in_collection, only: [:show, :edit, :update, :destroy, :confirm_delete]
 
   def load_challenge
+    unless @collection
+      raise ActiveRecord::RecordNotFound, "Couldn't find collection named '#{params[:collection_id]}'" 
+    end
+    
     @challenge = @collection.challenge
     no_challenge and return unless @challenge
   end

--- a/app/controllers/challenge_signups_controller.rb
+++ b/app/controllers/challenge_signups_controller.rb
@@ -17,10 +17,8 @@ class ChallengeSignupsController < ApplicationController
   before_action :check_signup_in_collection, only: [:show, :edit, :update, :destroy, :confirm_delete]
 
   def load_challenge
-    unless @collection
-      raise ActiveRecord::RecordNotFound, "Couldn't find collection named '#{params[:collection_id]}'" 
-    end
-    
+    raise ActiveRecord::RecordNotFound, "Couldn't find collection named '#{params[:collection_id]}'" unless @collection
+
     @challenge = @collection.challenge
     no_challenge and return unless @challenge
   end

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -46,6 +46,25 @@ describe ChallengeSignupsController do
                                    "What challenge did you want to sign up for?")
       end
     end
+
+    context "when collection does not exist" do
+      it "raises a RecordNotFound error" do
+        fake_login
+        expect do
+          get :new, params: { collection_id: "nonexistent_collection" }
+        end.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "summary" do
+    context "when collection does not exist" do
+      it "raises a RecordNotFound error" do
+        expect do
+          get :summary, params: { collection_id: "nonexistent_collection" }
+        end.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6789

## Purpose

Return 404 when trying to signup to a challenge on nonexistent collection

## Testing Instructions

1. Log in

2. Try to go to the sign-up page for a challenge in a nonexistent collection, e.g. https://test.archiveofourown.org/collections/FakeCollectionPlaceholderName/signups/new
3. 404 should be returned


## Credit

JIRA name: gemmie
