### PR TITLE
AO3-6246 Fix nomination limit bypass via concurrent update

### DIFF
--- a/app/models/tagset_models/tag_set_nomination.rb
+++ b/app/models/tagset_models/tag_set_nomination.rb
@@ -34,17 +34,17 @@ class TagSetNomination < ApplicationRecord
   
   validate :nomination_limits
   def nomination_limits
-    TagSet::TAG_TYPES_INITIALIZABLE.each do |tag_type|    
+    TagSet::TAG_TYPES_INITIALIZABLE.each do |tag_type|
       limit = self.owned_tag_set.send("#{tag_type}_nomination_limit")
       if count_by_fandom?(tag_type)
-        if self.fandom_nominations.any? {|fandom_nom| fandom_nom.send("#{tag_type}_nominations").try(:count) > limit}
+        if active_fandom_nominations.any? { |fandom_nom| active_nominations(fandom_nom, tag_type).size > limit }
           errors.add(:base, ts("You can only nominate %{limit} #{tag_type} tags per fandom.", limit: limit))
         end
       else
-        count = self.send("#{tag_type}_nominations").count
+        count = active_nominations(self, tag_type).size
         errors.add(:base, ts("You can only nominate %{limit} #{tag_type} tags", limit: limit)) if count > limit
       end
-    end 
+    end
   end
 
   # This makes sure a single user doesn't nominate the same tagname twice
@@ -105,5 +105,18 @@ class TagSetNomination < ApplicationRecord
        self.send("#{tag_type}_nominations")
     end
   end
-  
+
+  private
+
+  def discarded_nomination?(nomination)
+    nomination.marked_for_destruction? || nomination.tagname.blank?
+  end
+
+  def active_fandom_nominations
+    fandom_nominations.reject { |n| discarded_nomination?(n) }
+  end
+
+  def active_nominations(owner, tag_type)
+    owner.send("#{tag_type}_nominations").reject { |n| discarded_nomination?(n) }
+  end
 end

--- a/app/models/tagset_models/tag_set_nomination.rb
+++ b/app/models/tagset_models/tag_set_nomination.rb
@@ -37,9 +37,10 @@ class TagSetNomination < ApplicationRecord
     TagSet::TAG_TYPES_INITIALIZABLE.each do |tag_type|
       limit = self.owned_tag_set.send("#{tag_type}_nomination_limit")
       if count_by_fandom?(tag_type)
-        if active_fandom_nominations.any? { |fandom_nom| active_nominations(fandom_nom, tag_type).size > limit }
-          errors.add(:base, ts("You can only nominate %{limit} #{tag_type} tags per fandom.", limit: limit))
+        over_fandom_limit = active_fandom_nominations.any? do |fandom_nom|
+          active_nominations(fandom_nom, tag_type).size > limit
         end
+        errors.add(:base, "too_many_#{tag_type}_nominations_per_fandom".to_sym, limit: limit) if over_fandom_limit
       else
         count = active_nominations(self, tag_type).size
         errors.add(:base, ts("You can only nominate %{limit} #{tag_type} tags", limit: limit)) if count > limit

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -242,6 +242,8 @@ en:
           attributes:
             base:
               taken_by_user: You have already submitted nominations for that tag set. Try editing them instead.
+              too_many_character_nominations_per_fandom: You can only nominate %{limit} character tags per fandom.
+              too_many_relationship_nominations_per_fandom: You can only nominate %{limit} relationship tags per fandom.
         user:
           attributes:
             age_over_13:

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1267,6 +1267,42 @@ describe TagSetNominationsController do
     end
   end
 
+  describe "PUT update - concurrent nomination limit bypass" do
+    let(:owned_tag_set) { create(:owned_tag_set) }
+    let(:nomination) { create(:tag_set_nomination, owned_tag_set: owned_tag_set, pseud: random_user.default_pseud) }
+
+    before do
+      fake_login_known_user(random_user)
+    end
+
+    context "when another tab already saved a fandom at the limit" do
+      before do
+        owned_tag_set.update_column(:fandom_nomination_limit, 2)
+      end
+
+      it "does not save the extra fandom" do
+        fandom_a = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom A")
+        FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom B")
+
+        put :update, params: {
+          tag_set_id: owned_tag_set.id,
+          id: nomination.id,
+          tag_set_nomination: {
+            pseud_id: random_user.default_pseud.id,
+            fandom_nominations_attributes: {
+              '0': { tagname: "Fandom A", id: fandom_a.id },
+              '1': { tagname: "Fandom C" }
+            }
+          }
+        }
+
+        expect(nomination.reload.fandom_nominations.count).to eq(2)
+        expect(response).to render_template("edit")
+      end
+    end
+
+  end
+
   describe 'DELETE destroy' do
     context 'user is not logged in' do
       it 'redirects and returns an error message' do

--- a/spec/controllers/tag_set_nominations_controller_spec.rb
+++ b/spec/controllers/tag_set_nominations_controller_spec.rb
@@ -1290,8 +1290,8 @@ describe TagSetNominationsController do
           tag_set_nomination: {
             pseud_id: random_user.default_pseud.id,
             fandom_nominations_attributes: {
-              '0': { tagname: "Fandom A", id: fandom_a.id },
-              '1': { tagname: "Fandom C" }
+              "0": { tagname: "Fandom A", id: fandom_a.id },
+              "1": { tagname: "Fandom C" }
             }
           }
         }
@@ -1300,7 +1300,6 @@ describe TagSetNominationsController do
         expect(response).to render_template("edit")
       end
     end
-
   end
 
   describe 'DELETE destroy' do

--- a/spec/models/tag_set_nomination_spec.rb
+++ b/spec/models/tag_set_nomination_spec.rb
@@ -93,6 +93,5 @@ describe TagSetNomination do
         expect(nomination.errors[:base]).to include("You can only nominate 2 fandom tags")
       end
     end
-
   end
 end

--- a/spec/models/tag_set_nomination_spec.rb
+++ b/spec/models/tag_set_nomination_spec.rb
@@ -94,36 +94,5 @@ describe TagSetNomination do
       end
     end
 
-    context "when a concurrent update adds a character beyond the limit" do
-      before do
-        owned_tag_set.update_column(:fandom_nomination_limit, 1)
-        owned_tag_set.update_column(:character_nomination_limit, 2)
-      end
-
-      it "rejects the second update" do
-        fandom_nom = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Test Fandom")
-        # Simulate tab 1 saving 2 characters while tab 2 is still open
-        CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char A")
-        CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char B")
-        nomination.reload
-
-        # Tab 2 submits with the fandom + 2 new characters (it never saw Char A/B)
-        result = nomination.update(
-          fandom_nominations_attributes: {
-            "0" => {
-              id: fandom_nom.id,
-              tagname: "Test Fandom",
-              character_nominations_attributes: {
-                "0" => { tagname: "Char C", from_fandom_nomination: true },
-                "1" => { tagname: "Char D", from_fandom_nomination: true }
-              }
-            }
-          }
-        )
-
-        expect(result).to be_falsey
-        expect(nomination.errors[:base]).to include("You can only nominate 2 character tags per fandom.")
-      end
-    end
   end
 end

--- a/spec/models/tag_set_nomination_spec.rb
+++ b/spec/models/tag_set_nomination_spec.rb
@@ -65,4 +65,63 @@ describe TagSetNomination do
       end
     end
   end
+
+  describe "#nomination_limits" do
+    let(:owned_tag_set) { create(:owned_tag_set) }
+    let(:nomination) { create(:tag_set_nomination, owned_tag_set: owned_tag_set) }
+
+    context "when fandom nominations exceed the limit via update" do
+      before do
+        owned_tag_set.update_column(:fandom_nomination_limit, 2)
+      end
+
+      it "rejects adding a fandom beyond the limit" do
+        fandom_a = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom A")
+        fandom_b = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom B")
+        nomination.reload
+
+        result = nomination.update(
+          fandom_nominations_attributes: {
+            "0" => { tagname: "Fandom A", id: fandom_a.id },
+            "1" => { tagname: "Fandom B", id: fandom_b.id },
+            "2" => { tagname: "Fandom C" }
+          }
+        )
+
+        expect(result).to be_falsey
+        expect(nomination.errors[:base]).to include("You can only nominate 2 fandom tags")
+      end
+    end
+
+    context "when character nominations exceed the limit via update" do
+      before do
+        owned_tag_set.update_column(:fandom_nomination_limit, 1)
+        owned_tag_set.update_column(:character_nomination_limit, 2)
+      end
+
+      it "rejects adding a character beyond the limit" do
+        fandom_nom = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Test Fandom")
+        CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char A")
+        CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char B")
+        nomination.reload
+
+        result = nomination.update(
+          fandom_nominations_attributes: {
+            "0" => {
+              id: fandom_nom.id,
+              tagname: "Test Fandom",
+              character_nominations_attributes: {
+                "0" => { tagname: "Char A", id: fandom_nom.character_nominations.first.id, from_fandom_nomination: true },
+                "1" => { tagname: "Char B", id: fandom_nom.character_nominations.second.id, from_fandom_nomination: true },
+                "2" => { tagname: "Char C", from_fandom_nomination: true }
+              }
+            }
+          }
+        )
+
+        expect(result).to be_falsey
+        expect(nomination.errors[:base]).to include("You can only nominate 2 character tags per fandom.")
+      end
+    end
+  end
 end

--- a/spec/models/tag_set_nomination_spec.rb
+++ b/spec/models/tag_set_nomination_spec.rb
@@ -70,21 +70,22 @@ describe TagSetNomination do
     let(:owned_tag_set) { create(:owned_tag_set) }
     let(:nomination) { create(:tag_set_nomination, owned_tag_set: owned_tag_set) }
 
-    context "when fandom nominations exceed the limit via update" do
+    context "when a concurrent update adds a fandom beyond the limit" do
       before do
         owned_tag_set.update_column(:fandom_nomination_limit, 2)
       end
 
-      it "rejects adding a fandom beyond the limit" do
+      it "rejects the second update" do
         fandom_a = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom A")
-        fandom_b = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom B")
+        # Simulate tab 1 saving a second fandom while tab 2 is still open
+        FandomNomination.create!(tag_set_nomination: nomination, tagname: "Fandom B")
         nomination.reload
 
+        # Tab 2 submits with the original fandom + a new one (it never saw Fandom B)
         result = nomination.update(
           fandom_nominations_attributes: {
             "0" => { tagname: "Fandom A", id: fandom_a.id },
-            "1" => { tagname: "Fandom B", id: fandom_b.id },
-            "2" => { tagname: "Fandom C" }
+            "1" => { tagname: "Fandom C" }
           }
         )
 
@@ -93,27 +94,28 @@ describe TagSetNomination do
       end
     end
 
-    context "when character nominations exceed the limit via update" do
+    context "when a concurrent update adds a character beyond the limit" do
       before do
         owned_tag_set.update_column(:fandom_nomination_limit, 1)
         owned_tag_set.update_column(:character_nomination_limit, 2)
       end
 
-      it "rejects adding a character beyond the limit" do
+      it "rejects the second update" do
         fandom_nom = FandomNomination.create!(tag_set_nomination: nomination, tagname: "Test Fandom")
+        # Simulate tab 1 saving 2 characters while tab 2 is still open
         CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char A")
         CharacterNomination.create!(tag_set_nomination: nomination, fandom_nomination: fandom_nom, tagname: "Char B")
         nomination.reload
 
+        # Tab 2 submits with the fandom + 2 new characters (it never saw Char A/B)
         result = nomination.update(
           fandom_nominations_attributes: {
             "0" => {
               id: fandom_nom.id,
               tagname: "Test Fandom",
               character_nominations_attributes: {
-                "0" => { tagname: "Char A", id: fandom_nom.character_nominations.first.id, from_fandom_nomination: true },
-                "1" => { tagname: "Char B", id: fandom_nom.character_nominations.second.id, from_fandom_nomination: true },
-                "2" => { tagname: "Char C", from_fandom_nomination: true }
+                "0" => { tagname: "Char C", from_fandom_nomination: true },
+                "1" => { tagname: "Char D", from_fandom_nomination: true }
               }
             }
           }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6246

## Purpose

A user can bypass nomination limits by editing the same nomination in multiple browser tabs simultaneously. The `nomination_limits` validation used `.count`, which queries the database and only sees persisted records. When Rails assigns nested attributes before saving, new nominations exist in memory but not yet in the DB, so the validation passes and the extra nomination gets saved.

This PR changes the validation to use `.size` on the in-memory collection (via `active_nominations` helper), which correctly counts both persisted and unsaved records. It also filters out nominations that are marked for destruction or have a blank tagname (how the form "removes" a nomination).

## Testing Instructions

**Fandom bypass:**
1. Create a tag set with fandom limit = 2.
2. Create a nomination with only 1 fandom filled in.
3. Open the edit form in 2 browser tabs.
4. In tab 1, add a 2nd fandom and submit.
5. In tab 2, add a different 2nd fandom and submit.
6. Verify tab 2 shows the error "You can only nominate 2 fandom tags".

**Editing down (regression check):**
1. If a nomination already has more entries than the limit (from before the fix), verify you can edit it and remove entries to bring it within the limit.

## Credit

Pablo Monfort (he/him)