### PR TITLE
AO3-7499 Fix that canonical email was updated when requesting an email change

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   # Allows other models to get the current user with User.current_user
   thread_cattr_accessor :current_user
 
+  # Devise confirmable may undo email modifications in before_update, so canonicalize_email has to run after it
   before_create :canonicalize_email
   before_update :canonicalize_email, if: :will_save_change_to_email?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
   # Allows other models to get the current user with User.current_user
   thread_cattr_accessor :current_user
 
-  after_validation :canonicalize_email, if: :will_save_change_to_email?
+  before_create :canonicalize_email
+  before_update :canonicalize_email, if: :will_save_change_to_email?
 
   # Authorization plugin
   acts_as_authorized_user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -496,40 +496,60 @@ describe User do
   end
 
   describe "canonical_email" do
-    let!(:user) { create(:user, email: "old+foo@example.com") }
 
-    context "when user is created" do
+    context "when a user is created" do
+      let(:user) { create(:user, email: "old+foo@example.com") }
+
       it "sets the canonical email" do
         expect(user.canonical_email).to eq("old@example.com")
       end
     end
 
     context "when a user requests an email change" do
+      let!(:existing_user) { create(:user, email: "old+foo@example.com") }
+
       before do
-        user.update!(email: "new+bar@example.com")
-        user.reload
+        existing_user.update!(email: "new+bar@example.com")
+        existing_user.reload
       end
 
       it "does not change the canonical email" do
         # devise reverts the email change and sets unconfirmed_email
-        expect(user.email).to eq("old+foo@example.com")
-        expect(user.unconfirmed_email).to eq("new+bar@example.com")
+        expect(existing_user.email).to eq("old+foo@example.com")
+        expect(existing_user.unconfirmed_email).to eq("new+bar@example.com")
 
-        expect(user.canonical_email).to eq("old@example.com")
+        expect(existing_user.canonical_email).to eq("old@example.com")
       end
 
       context "when the user confirms the email change" do
         before do
-          user.confirm
+          existing_user.confirm
         end
 
         it "changes the canonical email" do
           # devise sets email based on unconfirmed_email and resets unconfirmed_email
-          expect(user.email).to eq("new+bar@example.com")
-          expect(user.unconfirmed_email).to be_nil
+          expect(existing_user.email).to eq("new+bar@example.com")
+          expect(existing_user.unconfirmed_email).to be_nil
 
-          expect(user.canonical_email).to eq("new@example.com")
+          expect(existing_user.canonical_email).to eq("new@example.com")
         end
+      end
+    end
+
+    context "when an admin changes a user's email" do
+      let(:user) { create(:user, email: "old+foo@example.com") }
+
+      before do
+        user.skip_reconfirmation!
+        user.update!(email: "new+bar@example.com")
+        user.reload
+      end
+
+      it "changes the canonical email" do
+        expect(user.email).to eq("new+bar@example.com")
+        expect(user.unconfirmed_email).to be_nil
+
+        expect(user.canonical_email).to eq("new@example.com")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -494,4 +494,43 @@ describe User do
       end
     end
   end
+
+  describe "canonical_email" do
+    let!(:user) { create(:user, email: "old+foo@example.com") }
+
+    context "when user is created" do
+      it "sets the canonical email" do
+        expect(user.canonical_email).to eq("old@example.com")
+      end
+    end
+
+    context "when a user requests an email change" do
+      before do
+        user.update!(email: "new+bar@example.com")
+        user.reload
+      end
+
+      it "does not change the canonical email" do
+        # devise reverts the email change and sets unconfirmed_email
+        expect(user.email).to eq("old+foo@example.com")
+        expect(user.unconfirmed_email).to eq("new+bar@example.com")
+
+        expect(user.canonical_email).to eq("old@example.com")
+      end
+
+      context "when the user confirms the email change" do
+        before do
+          user.confirm
+        end
+
+        it "changes the canonical email" do
+          # devise sets email based on unconfirmed_email and resets unconfirmed_email
+          expect(user.email).to eq("new+bar@example.com")
+          expect(user.unconfirmed_email).to be_nil
+
+          expect(user.canonical_email).to eq("new@example.com")
+        end
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -496,7 +496,6 @@ describe User do
   end
 
   describe "canonical_email" do
-
     context "when a user is created" do
       let(:user) { create(:user, email: "old+foo@example.com") }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7499

## Purpose

Fix that the canonical email was changed due to unconfirmed email change requests.

Failing test pushed first to show that it is testing the right thing.

## Credit

Bilka