### PR TITLE
AO3-7495 List metatags in alphabetical order on tag landing page

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -160,7 +160,7 @@ module TagsHelper
   def meta_tag_tree(tag)
     meta_ul = "".html_safe
     unless tag.direct_meta_tags.empty?
-      tag.direct_meta_tags.each do |meta|
+      tag.direct_meta_tags.order(:name).each do |meta|
         meta_ul += content_tag(:li, link_to_tag(meta))
         unless meta.direct_meta_tags.empty?
           meta_ul += content_tag(:li, meta_tag_tree(meta))

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -76,7 +76,7 @@
   <% unless @tag.direct_meta_tags.blank? %>
   <div class="meta listbox group">
     <h3 class="heading"><%= ts('Metatags') %>:</h3>
-    <% cache "tag-#{@tag.cache_key}-metatags-v2", expires_in: 24.hours, skip_digest: true do %>
+    <% cache "tag-#{@tag.cache_key}-metatags-v3", expires_in: 24.hours, skip_digest: true do %>
       <%= meta_tag_tree(@tag) %>
     <% end %>
   </div>

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -383,6 +383,22 @@ Feature: Tag wrangling
     Then "Angsta" should appear before "Angstb"
       And "Angstb" should appear before "Angstc"
 
+  Scenario: Metatags are listed in alphabetical order
+    Given a canonical freeform "Sex and Feels and Pain"
+      And a canonical freeform "Smut"
+      And it is currently 1 second from now
+      And a canonical freeform "Angst"
+      And it is currently 1 second from now
+      And a canonical freeform "Fluff"
+      And "Smut" is a metatag of the freeform "Sex and Feels and Pain"
+      And it is currently 1 second from now
+      And "Angst" is a metatag of the freeform "Sex and Feels and Pain"
+      And it is currently 1 second from now
+      And "Fluff" is a metatag of the freeform "Sex and Feels and Pain"
+    When I view the tag "Sex and Feels and Pain"
+    Then "Angst" should appear before "Fluff"
+      And "Fluff" should appear before "Smut"
+
   Scenario: Tags in mass wrangling bins should have a link to the comment page with the comment count.
 
     Given I am logged in as a tag wrangler

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -371,6 +371,8 @@ Feature: Tag wrangling
     Given a canonical freeform "Angst"
       And a canonical freeform "Angstc"
       And it is currently 1 second from now
+      # The waits are here so we can be sure the tags are created/attached in
+      # a non-sorted order, so the test can check that reordering is happening
       And a canonical freeform "Angstb"
       And it is currently 1 second from now
       And a canonical freeform "Angsta"
@@ -387,6 +389,8 @@ Feature: Tag wrangling
     Given a canonical freeform "Sex and Feels and Pain"
       And a canonical freeform "Smut"
       And it is currently 1 second from now
+      # The waits are here so we can be sure the tags are created/attached in
+      # a non-sorted order, so the test can check that reordering is happening
       And a canonical freeform "Angst"
       And it is currently 1 second from now
       And a canonical freeform "Fluff"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -370,14 +370,10 @@ Feature: Tag wrangling
   Scenario: Subtags are listed in alphabetical order
     Given a canonical freeform "Angst"
       And a canonical freeform "Angstc"
-      And it is currently 1 second from now
       And a canonical freeform "Angstb"
-      And it is currently 1 second from now
       And a canonical freeform "Angsta"
       And "Angst" is a metatag of the freeform "Angstc"
-      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Angstb"
-      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Angsta"
     When I view the tag "Angst"
     Then "Angsta" should appear before "Angstb"
@@ -386,14 +382,10 @@ Feature: Tag wrangling
   Scenario: Metatags are listed in alphabetical order
     Given a canonical freeform "Sex and Feels and Pain"
       And a canonical freeform "Smut"
-      And it is currently 1 second from now
       And a canonical freeform "Angst"
-      And it is currently 1 second from now
       And a canonical freeform "Fluff"
       And "Smut" is a metatag of the freeform "Sex and Feels and Pain"
-      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Sex and Feels and Pain"
-      And it is currently 1 second from now
       And "Fluff" is a metatag of the freeform "Sex and Feels and Pain"
     When I view the tag "Sex and Feels and Pain"
     Then "Angst" should appear before "Fluff"

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -370,10 +370,14 @@ Feature: Tag wrangling
   Scenario: Subtags are listed in alphabetical order
     Given a canonical freeform "Angst"
       And a canonical freeform "Angstc"
+      And it is currently 1 second from now
       And a canonical freeform "Angstb"
+      And it is currently 1 second from now
       And a canonical freeform "Angsta"
       And "Angst" is a metatag of the freeform "Angstc"
+      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Angstb"
+      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Angsta"
     When I view the tag "Angst"
     Then "Angsta" should appear before "Angstb"
@@ -382,10 +386,14 @@ Feature: Tag wrangling
   Scenario: Metatags are listed in alphabetical order
     Given a canonical freeform "Sex and Feels and Pain"
       And a canonical freeform "Smut"
+      And it is currently 1 second from now
       And a canonical freeform "Angst"
+      And it is currently 1 second from now
       And a canonical freeform "Fluff"
       And "Smut" is a metatag of the freeform "Sex and Feels and Pain"
+      And it is currently 1 second from now
       And "Angst" is a metatag of the freeform "Sex and Feels and Pain"
+      And it is currently 1 second from now
       And "Fluff" is a metatag of the freeform "Sex and Feels and Pain"
     When I view the tag "Sex and Feels and Pain"
     Then "Angst" should appear before "Fluff"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7495

## Purpose

When querying meta taggings, order by name of the tags so they list alphabetically.

## References

I practically copied what Bilka did on https://github.com/otwcode/otwarchive/pull/4986

## Credit

ömer faruk (he/him)