### PR TITLE
AO3-7449 Fix fanwork anchor pluralization

### DIFF
--- a/app/views/home/_content.html.erb
+++ b/app/views/home/_content.html.erb
@@ -49,7 +49,7 @@
   </small>
 </p>
 
-<h4 class="heading" id="II.B"><span id="fanwork"><%= t(".fanworks.heading") %></span></h4>
+<h4 class="heading" id="II.B"><span id="fanworks"><%= t(".fanworks.heading") %></span></h4>
 <p>
   <%= t(".fanworks.must_be_fanworks_html",
         non_fanwork_content_link: link_to(t(".fanworks.non_fanwork_content"), tos_faq_path(anchor: "non_fanwork_examples"))) %>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7449

## Purpose

Changes the id attribute on the Section II.B anchor in the Content Policy from `fanwork` to `fanworks`, so that `content#fanworks` links correctly to that section.

## Testing Instructions

As referenced in AO3-7449:
1. https://archiveofourown.org/content#fanworks should scroll directly to Section II.B
2. https://archiveofourown.org/content#fanwork should go to the top of the page

Note: as a first time contributor, I don't yet have Jira access to the AO3 project. I do have a Jira account (email: j4wang@gmail.com).

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

- Name: John Wang
- Pronouns: he/him
