### PR TITLE
AO3-7492 Error 500 when trying to post a work with invalid URL in media src attributes

### DIFF
--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -104,6 +104,8 @@ module OtwSanitize
       # Just in case we're missing a protocol
       url = "https://" + url unless url =~ /http/
       Addressable::URI.parse(url).normalize.host
+    rescue Addressable::URI::InvalidURIError
+      nil
     end
 
     def banned_source?

--- a/lib/otw_sanitize/media_sanitizer.rb
+++ b/lib/otw_sanitize/media_sanitizer.rb
@@ -79,6 +79,8 @@ module OtwSanitize
       return unless media_node?
       return if banned_source?
 
+      node.remove_attribute("src") if source_url.present? && !valid_source_url?
+
       config = Sanitize::Config.merge(Sanitize::Config::ARCHIVE, ALLOWLIST_CONFIG)
       Sanitize.clean_node!(node, config)
       tidy_boolean_attributes(node)
@@ -97,13 +99,20 @@ module OtwSanitize
       node["src"] || ""
     end
 
+    def valid_source_url?
+      source_host.present?
+    end
+
     def source_host
       url = source_url
       return nil if url.blank?
 
       # Just in case we're missing a protocol
       url = "https://" + url unless url =~ /http/
-      Addressable::URI.parse(url).normalize.host
+      host = Addressable::URI.parse(url).normalize.host
+      return nil if host.blank? || host =~ /\s/
+      
+      host
     rescue Addressable::URI::InvalidURIError
       nil
     end

--- a/spec/lib/otw_sanitize/media_sanitizer_spec.rb
+++ b/spec/lib/otw_sanitize/media_sanitizer_spec.rb
@@ -59,6 +59,20 @@ describe OtwSanitize::MediaSanitizer do
         expect(content).to match("flower.webm")
       end
 
+      %w[audio video source track].each do |element|
+        it "does not raise an error for #{element} elements with invalid src URLs" do
+          html = "<#{element} src='BAD URL'></#{element}>"
+          expect { Sanitize.fragment(html, config) }.not_to raise_error
+        end
+
+        it "removes src on #{element} elements with invalid src URLs" do
+          html = "<#{element} src='BAD URL'></#{element}>"
+          content = Sanitize.fragment(html, config)
+          expect(content).not_to match("src")
+          expect(content).not_to match("BAD URL")
+        end
+      end
+
       it "does not close source elements" do
         html = "
           <video controls width='250'>

--- a/spec/lib/otw_sanitize/media_sanitizer_spec.rb
+++ b/spec/lib/otw_sanitize/media_sanitizer_spec.rb
@@ -62,7 +62,8 @@ describe OtwSanitize::MediaSanitizer do
       %w[audio video source track].each do |element|
         it "does not raise an error for #{element} elements with invalid src URLs" do
           html = "<#{element} src='BAD URL'></#{element}>"
-          expect { Sanitize.fragment(html, config) }.not_to raise_error
+          expect { Sanitize.fragment(html, config) }
+            .not_to raise_error
         end
 
         it "removes src on #{element} elements with invalid src URLs" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7492

## Purpose
What does this PR do?
When a user creates a new work, and enters invalid URL in media src attributes, this PR removes the bad src attributes, when posting the work, removing the previous experience of receiving and Error 500. 

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?
See Jira issue for testing instructions. 

## References

## Credit
Scott Venkataraman he/him