### PR TITLE
AO3-7452 Update technical integrity links in Content Policy

### DIFF
--- a/app/views/home/_content.html.erb
+++ b/app/views/home/_content.html.erb
@@ -273,7 +273,7 @@
     </p>
     <p id="technical_integrity">
       <%= t(".illegal_inappropriate_content.conduct_threatening_technical_integrity_html",
-            technical_integrity_link: link_to(t(".illegal_inappropriate_content.technical_integrity"), tos_faq_path(anchor: "technical_integrity_faq"))) %>
+            technical_integrity_link: link_to(t(".illegal_inappropriate_content.technical_integrity"), tos_faq_path(anchor: "integrity_threat"))) %>
     </p>
   </li>
   <li id="II.K.2">
@@ -296,7 +296,7 @@
     <%= t(".illegal_inappropriate_content.tos_faq_in_parens_html",
           tos_faq_link: link_to(
             t(".illegal_inappropriate_content.tos_faq"),
-            tos_faq_path(anchor: "offensive_content_faq"),
+            tos_faq_path(anchor: "technical_integrity_faq"),
             aria: {
               label: t(".illegal_inappropriate_content.tos_faq_link_label")
             }

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1777,7 +1777,7 @@ en:
         technical_integrity: technical integrity
         tos_faq: FAQ for Section II.K
         tos_faq_in_parens_html: "(%{tos_faq_link})"
-        tos_faq_link_label: Offensive Content vs Illegal Content FAQ
+        tos_faq_link_label: Spam and Technical Integrity FAQ
         violates_us_law_html: If you encounter Content that you believe violates a specific law of the United States, you can %{report_it_to_us_link}.
       impersonation:
         function: function


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7452

## Purpose

These changes are for Section II.K on the Content Policy page.

Updates the link for "technical integrity" to point to `tos_faq#integrity_threat` instead of `tos_faq#technical_integrity_faq`.

Updates the link for "FAQ for Section II.K" to point to `tos_faq#technical_integrity_faq` instead of `tos_faq#offensive_content_faq`.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Can verify through manual checking.

- The link for "technical integrity" should point to https://archiveofourown.org/tos_faq#integrity_threat
- The link for "FAQ for Section II.K" should point to https://archiveofourown.org/tos_faq#technical_integrity_faq

I am a first-time contributer and do not have access to edit the Jira board. I do have a Jira account (email: isabellemyz33@gmail.com)

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

- Name: Isabelle Zhang
- Pronouns: she/her