### PR TITLE
AO3-7397 Update seed data to include user for SKIN_PREVIEW_URL

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -814,5 +814,5 @@ ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: 3S99KdpdEWLnCYudBgUfdCFDBWePWCud
 # The relative URL to redirect to when previewing a skin
 # e.g. /users/OTW_Translation/works ->
 # http://test.archiveofourown.org/users/OTW_Translation/works?site_skin=[skin_id]
-# This will not work in dev unless you manually create the OTW_Translation user
+# This user is included in the fixtures for dev
 SKIN_PREVIEW_URL: '/users/OTW_Translation/works'

--- a/test/fixtures/preferences.yml
+++ b/test/fixtures/preferences.yml
@@ -153,6 +153,28 @@ preference_484751136:
   minimize_search_engines: false
   hide_warnings: false
   disable_work_skins: false
+preference_484751137:
+  history_enabled: true
+  hide_freeform: false
+  comment_emails_off: false
+  created_at: 2010-10-13 11:37:58 Z
+  collection_inbox_off: false
+  collection_emails_off: false
+  skin_id: 1
+  comment_inbox_off: false
+  comment_copy_to_self_off: true
+  work_title_format: TITLE - AUTHOR - FANDOM
+  view_full_works: false
+  updated_at: 2010-10-13 11:37:58 Z
+  first_login: true
+  adult: true
+  id: 484751137
+  user_id: 34
+  recipient_emails_off: false
+  time_zone:
+  minimize_search_engines: false
+  hide_warnings: false
+  disable_work_skins: false
 preference_484751114: 
   history_enabled: true
   hide_freeform: false

--- a/test/fixtures/pseuds.yml
+++ b/test/fixtures/pseuds.yml
@@ -99,6 +99,16 @@ pseud_00041:
   id: 41
   user_id: 1
   description: ""
+pseud_00042:
+  name: OTW_Translation
+  icon_alt_text: ""
+  created_at: 2010-10-13 11:37:58 Z
+  delta: true
+  updated_at: 2010-10-13 11:37:58 Z
+  is_default: true
+  id: 42
+  user_id: 34
+  description: ""
 pseud_00029: 
   name: Llwyden
   icon_alt_text: ""

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -90,6 +90,16 @@ user_00033:
   banned: false
   login: testsuspended
   email: suspended@example.com
+user_00034:
+  encrypted_password: <%= Devise::Encryptor.digest(User, "testuser") %>
+  created_at: 2010-10-13 11:37:58 Z
+  confirmed_at: 2010-10-13 22:03:16 Z
+  updated_at: 2010-10-13 22:03:17 Z
+  id: 34
+  suspended: false
+  banned: false
+  login: OTW_Translation
+  email: otwtranslation@example.com
 user_00025: 
   password_salt: 2aa64c10d3ea67188845a59d3d9d411d52301838
   created_at: 2009-12-12 21:07:52 Z


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7397

## Purpose

Adds OTW_Translation user to the seed data so skin previews work in dev without requiring additional steps. 

I didn't include the official role for the user because the role has no bearing on the skin preview feature, but I can add it if we want it. (We do have testofficial already.)

## Testing Instructions

On a dev environment with a seed database and the site skins loaded:

1. Confirm you can log in as OTW_Translation using the password testuser
2. Log in as any user, go to `/skins?skin_type=Site`, and confirm pressing "Preview" on a skin does not error

## Credit

Sarken, she/her
