### PR TITLE
AO3-7503 Change regex string for title when creating new tag set

### DIFF
--- a/app/models/tagset_models/owned_tag_set.rb
+++ b/app/models/tagset_models/owned_tag_set.rb
@@ -40,10 +40,9 @@ class OwnedTagSet < ApplicationRecord
   validates_length_of :title,
     maximum: ArchiveConfig.TITLE_MAX,
     too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.TITLE_MAX)
-  validates_format_of :title,
-    with: /\A[^,*<>^{}=`\\%]+\z/,
-    message: '^The title of a tag set cannot include the following restricted characters: , &#94; * < > { } = ` \\ %'
-
+  validates :title,
+            format: { without: /[,*<>^{}=`\\%]/,
+                      message: :restricted_characters }
   validates_length_of :description,
     allow_blank: true,
     maximum: ArchiveConfig.SUMMARY_MAX,

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -183,6 +183,10 @@ en:
             muted_id:
               taken: You have already muted that user.
           format: "%{message}"
+        owned_tag_set:
+          attributes:
+            title:
+              restricted_characters: "^The title of a tag set cannot include the following restricted characters: , &#94; * < > { } = ` \\ %"
         prompt:
           tags_not_in_fandom: "^These %{tag_label} tags in your %{prompt_type} are not in the selected fandom(s), %{fandom}: %{taglist} (Your moderator may be able to fix this.)"
         prompt_meme:

--- a/spec/models/owned_tag_set_spec.rb
+++ b/spec/models/owned_tag_set_spec.rb
@@ -125,4 +125,29 @@ describe OwnedTagSet do
       end
     end
   end
+
+  describe "#title_validation" do
+    context "given a title that contains restricted characters" do
+      it "is invalid and returns an error message about restricted characters" do
+        owned_tag_set.title = "Invalid Title*"
+        expect(owned_tag_set).not_to be_valid
+        expect(owned_tag_set.errors[:title].join).to match(/restricted characters/)
+      end
+    end
+
+    context "given an empty title" do
+      it "is invalid" do
+        owned_tag_set.title = ""
+        expect(owned_tag_set).not_to be_valid
+        expect(owned_tag_set.errors[:title].join).not_to match(/restricted characters/)
+      end
+    end
+
+    context "given a title that does not contain restricted characters" do
+      it "is valid" do
+        owned_tag_set.title = "My Tag Set"
+        expect(owned_tag_set).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [ X ] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ X ] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [ X ] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [ X ] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7503

## Purpose

Fixes a bug present when creating a title for a new tag set. When leaving empty, an additional error was thrown about characters that were not allowed. This PR fixes it so that that specific error is not thrown when submitting an empty title. 

## Credit

mmarianaamy (she/her)

## Notes

This is my first pull request, feel free to let me know if I missed something :)

While testing, I realized that '<' and '>' were accepted as characters, contrary to the error message (and assumed desired functionality). This was a preexisting bug before this commit. Based on the docs, I will assume this should be addressed in a separate PR and issue. 
