### PR TITLE
AO3-3754 Fix preview notices using flash.now

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -145,7 +145,7 @@ class ChaptersController < ApplicationController
     elsif params[:preview_button]
       @preview_mode = true
       if @chapter.posted?
-        flash[:notice] = ts("This is a preview of what this chapter will look like after your changes have been applied. You should probably read the whole thing to check for problems before posting.")
+        flash.now[:notice] = ts("This is a preview of what this chapter will look like after your changes have been applied. You should probably read the whole thing to check for problems before posting.")
       else
         draft_flash_message(@work)
       end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -145,7 +145,7 @@ class ChaptersController < ApplicationController
     elsif params[:preview_button]
       @preview_mode = true
       if @chapter.posted?
-        flash.now[:notice] = ts("This is a preview of what this chapter will look like after your changes have been applied. You should probably read the whole thing to check for problems before posting.")
+        flash.now[:notice] = t(".preview_notice")
       else
         draft_flash_message(@work)
       end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -369,7 +369,7 @@ class WorksController < ApplicationController
     if params[:edit_button] || work_cannot_be_saved?
       render :edit
     elsif params[:preview_button]
-      flash[:notice] = t(".unposted_notice") unless @work.posted?
+      flash.now[:notice] = t(".unposted_notice") unless @work.posted?
 
       in_moderated_collection
       @preview_mode = true

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -128,6 +128,8 @@ en:
     show:
       chapter_position: " - Chapter %{position}"
       unrevealed: Mystery Work
+    update:
+      preview_notice: This is a preview of what this chapter will look like after your changes have been applied. You should probably read the whole thing to check for problems before posting.
   collection_items:
     create:
       invited: invited


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-3754

## Purpose

Preview notices were using flash in a way that caused them to persist even in other pages. This change switches to flash.now so the message is displayed only for the current request.

Please advise if automated tests are required for this type of flash behavior fix.

## Testing Instructions

See Jira ticket.

## Credit

kurumiuchi (they/them)