### PR TITLE
AO3-7344 Allow certain admins to change work comment settings

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -14,7 +14,6 @@ class WorksController < ApplicationController
   before_action :check_ownership, except: [:index, :show, :navigate, :new, :create, :import, :show_multiple, :edit_multiple, :edit, :update, :update_multiple, :delete_multiple, :search, :mark_for_later, :mark_as_read, :drafts, :collected, :share]
   # admins should have the ability to edit works (tags, language, and more) as per our ToS
   before_action :check_ownership_or_admin, only: [:edit, :update]
-  before_action :log_admin_activity, only: [:update]
   before_action :check_parent_visible, only: [:navigate]
   before_action :check_visibility, only: [:show, :navigate, :share, :mark_for_later, :mark_as_read]
 
@@ -832,19 +831,14 @@ class WorksController < ApplicationController
     end
   end
 
-  def log_admin_activity
-    if logged_in_as_admin?
-      summary = "Old tags: #{@work.tags.pluck(:name).join(', ')}" if params[:action] == "update"
-
-      AdminActivity.log_action(current_admin, @work, action: params[:action], summary: summary)
-    end
-  end
-
   private
 
   def admin_update_work
     @work.preview_mode = (params[:preview_button] || params[:edit_button]).present?
-    @work.attributes = work_tag_params
+    old_tags = @work.tags.pluck(:name).join(", ")
+    old_language_id = @work.language_id
+    old_comment_permissions = @work.comment_permissions
+    @work.attributes = work_admin_params
 
     if params[:edit_button] || work_cannot_be_saved?
       render :edit
@@ -853,15 +847,44 @@ class WorksController < ApplicationController
       render :preview_tags
     elsif params[:save_button]
       @work.save
+      log_admin_work_update(old_tags, old_language_id, old_comment_permissions)
       flash[:notice] = t("works.update.tags_updated")
       redirect_to(@work)
     else
       @work.posted = true
       @work.minor_version += 1
       @work.save!
+      log_admin_work_update(old_tags, old_language_id, old_comment_permissions)
       flash[:notice] = t("works.update.work_updated")
       redirect_to(@work)
     end
+  end
+
+  def log_admin_work_update(old_tags, old_language_id, old_comment_permissions)
+    if old_tags != @work.tags.pluck(:name).join(", ") || old_language_id != @work.language_id
+      AdminActivity.log_action(current_admin, @work,
+                               action: "update",
+                               summary: "Old tags: #{old_tags}")
+    end
+
+    return unless old_comment_permissions != @work.comment_permissions
+
+    AdminActivity.log_action(current_admin, @work,
+                             action: "edit comment settings",
+                             summary: comment_settings_summary(old_comment_permissions, @work.comment_permissions))
+  end
+
+  def comment_settings_summary(old_setting, new_setting)
+    helpers.safe_join(
+      [
+        helpers.tag.p("Old comment setting: #{comment_setting_name(old_setting)}"),
+        helpers.tag.p("New comment setting: #{comment_setting_name(new_setting)}")
+      ]
+    )
+  end
+
+  def comment_setting_name(setting)
+    t("comments.commentable.permissions.options.#{setting}")
   end
 
   def build_options(params)
@@ -926,6 +949,20 @@ class WorksController < ApplicationController
       category_strings: [],
       archive_warning_strings: []
     )
+  end
+
+  def work_admin_params
+    submitted_params = params.require(:work).dup
+    submitted_params.delete(:comment_permissions) unless policy(@work).comment_settings_access?
+
+    permitted_attributes = [
+      :rating_string, :fandom_string, :relationship_string, :character_string,
+      :archive_warning_string, :category_string, :freeform_string, :language_id,
+      { category_strings: [], archive_warning_strings: [] }
+    ]
+    permitted_attributes << :comment_permissions
+
+    submitted_params.permit(*permitted_attributes)
   end
 
   def work_search_params

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AdminHelper
+  include HtmlCleaner
+
   def admin_activity_login_string(activity)
     activity.admin.nil? ? ts("Admin deleted") : activity.admin_login
   end
@@ -17,11 +19,10 @@ module AdminHelper
     link_to(activity.target_name, url)
   end
 
-  # Summaries for profile and pseud edits, which contain links, need to be
-  # handled differently from summaries that use item.inspect (and thus contain
-  # angle brackets).
+  # Summaries that intentionally contain HTML need to be handled differently
+  # from summaries that use item.inspect (and thus contain angle brackets).
   def admin_activity_summary(activity)
-    if activity.action == "edit pseud" || activity.action == "edit profile"
+    if activity.action.in?(["edit pseud", "edit profile", "edit comment settings"])
       raw sanitize_field(activity, :summary)
     else
       activity.summary

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -11,6 +11,10 @@ class WorkPolicy < UserCreationPolicy
     user_has_roles?(EDIT_TAG_ROLES)
   end
 
+  def comment_settings_access?
+    user_has_roles?(%w[superadmin policy_and_abuse])
+  end
+
   # Support admins need to be able to delete duplicate works.
   def destroy?
     super || user_has_roles?(%w[support])

--- a/app/views/works/_admin_edit_form.html.erb
+++ b/app/views/works/_admin_edit_form.html.erb
@@ -11,6 +11,16 @@
     </dl>
   </fieldset>
 
+  <% if policy(@work).comment_settings_access? %>
+    <fieldset class="privacy" role="article">
+      <legend><%= t("works.permissions.privacy") %></legend>
+      <h3 class="landmark heading"><%= t("works.permissions.privacy") %></h3>
+      <dl>
+        <%= render "work_form_comment_permissions", f: f %>
+      </dl>
+    </fieldset>
+  <% end %>
+
   <%= render "posting_fieldset" %>
 
 <% end %>

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -279,21 +279,7 @@
         <%= link_to_help "comments-moderated" %>
       </dd>
 
-      <dt class="permissions comments">
-        <%= t("comments.commentable.permissions.options.label") %>
-        <%= link_to_help "who-can-comment-on-this-work" %>
-      </dt>
-      <dd class="permissions comments">
-        <fieldset>
-          <%=
-            radio_button_list(f, :comment_permissions, [
-              [:enable_all, t("comments.commentable.permissions.options.enable_all")],
-              [:disable_anon, t("comments.commentable.permissions.options.disable_anon")],
-              [:disable_all, t("comments.commentable.permissions.options.disable_all")]
-            ])
-          %>
-        </fieldset>
-      </dd>
+      <%= render "work_form_comment_permissions", f: f %>
 
     </dl>
   </fieldset>

--- a/app/views/works/_work_form_comment_permissions.html.erb
+++ b/app/views/works/_work_form_comment_permissions.html.erb
@@ -1,0 +1,13 @@
+<dt class="permissions comments">
+  <%= t("comments.commentable.permissions.options.label") %>
+  <%= link_to_help "who-can-comment-on-this-work" %>
+</dt>
+<dd class="permissions comments">
+  <fieldset>
+    <%= radio_button_list(f, :comment_permissions, [
+          [:enable_all, t("comments.commentable.permissions.options.enable_all")],
+          [:disable_anon, t("comments.commentable.permissions.options.disable_anon")],
+          [:disable_all, t("comments.commentable.permissions.options.disable_all")]
+        ]) %>
+  </fieldset>
+</dd>

--- a/features/admins/admin_works.feature
+++ b/features/admins/admin_works.feature
@@ -189,6 +189,9 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
       And I fill in "Additional Tags" with "Admin-Added Freeform"
       And I uncheck "M/M"
       And I check "Other"
+      And I should see "Privacy"
+      And I should see "Who can comment on this work"
+      And I choose "No one can comment"
     When I press "Update"
     Then I should not see "User-Added Fandom"
       And I should see "Admin-Added Fandom"
@@ -205,10 +208,12 @@ Feature: Admin Actions for Works, Comments, Series, Bookmarks
      When I follow "Activities"
      Then I should see "Admin Activities"
      When I visit the last activities item
-     Then I should see "No Archive Warnings Apply"
-      And I should see "Old tags"
-      And I should see "User-Added Fandom"
-      And I should not see "Admin-Added Fandom"
+     Then I should see "edit comment settings"
+      And I should see "Old comment setting: Only registered users can comment"
+      And I should see "New comment setting: No one can comment"
+     When I go to the admin-activities page
+     Then I should see "update"
+      And I should see "edit comment settings"
 
   Scenario: Can edit external works
     Given basic languages

--- a/spec/controllers/works/default_rails_actions_spec.rb
+++ b/spec/controllers/works/default_rails_actions_spec.rb
@@ -643,6 +643,81 @@ describe WorksController, work_search: true do
       before { fake_logout }
 
       it_behaves_like "an action only authorized admins can access", authorized_roles: %w[superadmin policy_and_abuse support]
+
+      context "with the policy_and_abuse role" do
+        let(:admin) { create(:policy_and_abuse_admin) }
+
+        before { fake_login_admin(admin) }
+
+        it "updates comment settings and logs the change" do
+          work.update!(comment_permissions: :disable_anon)
+
+          expect do
+            put :update, params: {
+              id: work,
+              work: { comment_permissions: "disable_all" }
+            }
+          end.to change(AdminActivity, :count).by(1)
+
+          activity = AdminActivity.last
+          expect(work.reload.comment_permissions).to eq("disable_all")
+          expect(activity.admin).to eq(admin)
+          expect(activity.target).to eq(work)
+          expect(activity.action).to eq("edit comment settings")
+          expect(activity.summary).to eq(
+            "<p>Old comment setting: Only registered users can comment</p>" \
+            "<p>New comment setting: No one can comment</p>"
+          )
+        end
+
+        it "logs comment settings separately from tags and language" do
+          work.update!(comment_permissions: :disable_anon)
+
+          expect do
+            put :update, params: {
+              id: work,
+              work: {
+                relationship_string: "kronfaumei",
+                language_id: language.id,
+                comment_permissions: "disable_all"
+              }
+            }
+          end.to change(AdminActivity, :count).by(2)
+
+          activities = AdminActivity.last(2)
+          expect(work.reload.relationship_string).to eq("kronfaumei")
+          expect(work.language).to eq(language)
+          expect(work.comment_permissions).to eq("disable_all")
+          expect(activities.map(&:action)).to eq(["update", "edit comment settings"])
+          expect(activities.first.summary).to include("Old tags:")
+        end
+      end
+
+      context "with the support role" do
+        let(:admin) { create(:support_admin) }
+
+        before { fake_login_admin(admin) }
+
+        it "updates tags and language but not comment settings" do
+          work.update!(comment_permissions: :disable_anon)
+
+          expect do
+            put :update, params: {
+              id: work,
+              work: {
+                relationship_string: "kronfaumei",
+                language_id: language.id,
+                comment_permissions: "disable_all"
+              }
+            }
+          end.to change(AdminActivity, :count).by(1)
+
+          expect(work.reload.relationship_string).to eq("kronfaumei")
+          expect(work.language).to eq(language)
+          expect(work.comment_permissions).to eq("disable_anon")
+          expect(AdminActivity.last.action).to eq("update")
+        end
+      end
     end
 
     before do

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -20,4 +20,15 @@ describe AdminHelper do
       end
     end
   end
+
+  describe "admin activity summary" do
+    it "renders comment settings summaries as HTML" do
+      admin_activity.action = "edit comment settings"
+      admin_activity.summary = "<p>Old comment setting: Only registered users can comment</p>"
+
+      expect(admin_activity_summary(admin_activity)).to eq(
+        "<p>Old comment setting: Only registered users can comment</p>"
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7344 

## Purpose

Allows `superadmin` and `policy_and_abuse` admins to edit a work’s comment settings from the admin Edit Work page.

 Logs comment setting changes separately on `/admin/activities` as `edit comment settings`, with old and new setting names in the summary.

 Support admin access is unchanged.

## Credit

not-varram (he/him)