### PR TITLE
AO3-7504 Removing tag title errors on length and restricted characters

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -162,14 +162,11 @@ class Tag < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
   validates :name,
-            length: { minimum: 1,
-                      message: "cannot be blank." }
-  validates :name,
             length: { maximum: ArchiveConfig.TAG_MAX,
                       message: "^Tag name '%{value}' is too long -- try using less than %{count} characters or using commas to separate your tags." }
   validates :name,
-            format: { with: /\A[^,，、*<>^{}=`\\%]+\z/,
-                      message: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %" }
+            format: { without: /[,，、*<>^{}=`\\%]/,
+                      message: :restricted_characters }
   validates :name,
             format: { without: /\A\p{Cf}+\z/,
                       message: "^Tag name cannot be blank." }

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -229,6 +229,10 @@ en:
             subscribable:
               blank: The item you tried to subscribe to does not exist. It may have been deleted.
               format: "%{message}"
+        tag:
+          attributes:
+            name:
+              restricted_characters: "^Tag name '%{value}' cannot include the following restricted characters: , &#94; * < > { } = ` ， 、 \\ %"
         user:
           attributes:
             age_over_13:


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7504

## Purpose

There are 2 unnecessary errors that appear when a title is empty. One appears as a duplicate, and the other complains about characters even when empty. These don't appear anymore. 

## Credit

mmarianaamy (she/her)
