### PR TITLE
AO3-7403 Eager load associations that are used on inbox page

### DIFF
--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -19,14 +19,6 @@ class InboxComment < ApplicationRecord
     end
     direction = (filters[:date]&.upcase == "ASC" ? "created_at ASC" : "created_at DESC")
 
-    # Eager-load the associations the inbox view touches for each
-    # feedback_comment, to avoid N+1 queries while rendering:
-    #   pseud.user.official            -> user roles
-    #   commenter icon                 -> pseud icon attachment
-    #   commentable link/title         -> parent (and parent.work for chapters)
-    # can_reply_to_comment? runs two separate block checks, each its own query:
-    #   commenter blocked me?          -> pseud.user.block_of_current_user
-    #   work creator blocked me?       -> work.users' block_of_current_user
     includes(
       feedback_comment: [
         { pseud: [

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -35,9 +35,9 @@ class InboxComment < ApplicationRecord
         ] },
         { parent: { work: { users: :block_of_current_user } } }
       ]
-    ).
-      order(direction).
-      where(read: read, replied_to: replied_to)
+    )
+      .order(direction)
+      .where(read: read, replied_to: replied_to)
   }
 
   scope :for_homepage, -> {

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -31,7 +31,7 @@ class InboxComment < ApplicationRecord
           { user: %i[roles block_of_current_user] },
           { icon_attachment: :blob }
         ] },
-        { parent: { work: :users } }
+        { parent: { work: { users: :block_of_current_user } } }
       ]
     ).
       order(direction).

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -21,10 +21,12 @@ class InboxComment < ApplicationRecord
 
     # Eager-load the associations the inbox view touches for each
     # feedback_comment, to avoid N+1 queries while rendering:
-    #   pseud.user.official       -> user roles
-    #   blocked_by? checks        -> user/work_creators' block_of_current_user
-    #   commenter icon            -> pseud icon attachment
-    #   commentable link/title    -> parent (and parent.work for chapters)
+    #   pseud.user.official            -> user roles
+    #   commenter icon                 -> pseud icon attachment
+    #   commentable link/title         -> parent (and parent.work for chapters)
+    # can_reply_to_comment? runs two separate block checks, each its own query:
+    #   commenter blocked me?          -> pseud.user.block_of_current_user
+    #   work creator blocked me?       -> work.users' block_of_current_user
     includes(
       feedback_comment: [
         { pseud: [

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -19,7 +19,21 @@ class InboxComment < ApplicationRecord
     end
     direction = (filters[:date]&.upcase == "ASC" ? "created_at ASC" : "created_at DESC")
 
-    includes(feedback_comment: :pseud).
+    # Eager-load the associations the inbox view touches for each
+    # feedback_comment, to avoid N+1 queries while rendering:
+    #   pseud.user.official       -> user roles
+    #   blocked_by? checks        -> user/work_creators' block_of_current_user
+    #   commenter icon            -> pseud icon attachment
+    #   commentable link/title    -> parent (and parent.work for chapters)
+    includes(
+      feedback_comment: [
+        { pseud: [
+          { user: %i[roles block_of_current_user] },
+          { icon_attachment: :blob }
+        ] },
+        { parent: { work: :users } }
+      ]
+    ).
       order(direction).
       where(read: read, replied_to: replied_to)
   }

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -23,7 +23,7 @@ class InboxComment < ApplicationRecord
       feedback_comment: [
         { pseud: [
           { user: %i[roles block_of_current_user] },
-          { icon_attachment: :blob }
+          *Pseud.with_attached_icon.includes_values
         ] },
         { parent: { work: { users: :block_of_current_user } } }
       ]

--- a/factories/comments.rb
+++ b/factories/comments.rb
@@ -37,5 +37,13 @@ FactoryBot.define do
   factory :inbox_comment do
     user { create(:user) }
     feedback_comment { create(:comment) }
+
+    trait :with_guest_comment do
+      feedback_comment { create(:comment, :by_guest) }
+    end
+
+    trait :with_reply_comment do
+      feedback_comment { create(:comment, commentable: create(:comment)) }
+    end
   end
 end

--- a/factories/comments.rb
+++ b/factories/comments.rb
@@ -37,13 +37,5 @@ FactoryBot.define do
   factory :inbox_comment do
     user { create(:user) }
     feedback_comment { create(:comment) }
-
-    trait :with_guest_comment do
-      feedback_comment { create(:comment, :by_guest) }
-    end
-
-    trait :with_reply_comment do
-      feedback_comment { create(:comment, commentable: create(:comment)) }
-    end
   end
 end

--- a/spec/requests/inbox_n_plus_one_spec.rb
+++ b/spec/requests/inbox_n_plus_one_spec.rb
@@ -6,18 +6,32 @@ describe "n+1 queries in the InboxController" do
   describe "#show" do
     let!(:user) { create(:user) }
 
-    context "when displaying multiple inbox comments", n_plus_one: true do
-      before { fake_login_known_user(user) }
+    shared_examples "a constant number of queries" do |*traits|
+      context "when displaying multiple inbox comments", n_plus_one: true do
+        before { fake_login_known_user(user) }
 
-      populate { |n| create_list(:inbox_comment, n, user: user) }
+        populate { |n| create_list(:inbox_comment, n, *traits, user: user) }
 
-      warmup { get user_inbox_path(user) }
+        warmup { get user_inbox_path(user) }
 
-      it "produces a constant number of queries" do
-        expect do
-          get user_inbox_path(user)
-        end.to perform_constant_number_of_queries
+        it "produces a constant number of queries" do
+          expect do
+            get user_inbox_path(user)
+          end.to perform_constant_number_of_queries
+        end
       end
+    end
+
+    context "with comments from registered users" do
+      it_behaves_like "a constant number of queries"
+    end
+
+    context "with comments from guests" do
+      it_behaves_like "a constant number of queries", :with_guest_comment
+    end
+
+    context "with reply comments" do
+      it_behaves_like "a constant number of queries", :with_reply_comment
     end
   end
 end

--- a/spec/requests/inbox_n_plus_one_spec.rb
+++ b/spec/requests/inbox_n_plus_one_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "n+1 queries in the InboxController" do
+  include LoginMacros
+
+  describe "#show" do
+    let!(:user) { create(:user) }
+
+    context "when displaying multiple inbox comments", n_plus_one: true do
+      before { fake_login_known_user(user) }
+
+      populate { |n| create_list(:inbox_comment, n, user: user) }
+
+      warmup { get user_inbox_path(user) }
+
+      it "produces a constant number of queries" do
+        expect do
+          get user_inbox_path(user)
+        end.to perform_constant_number_of_queries
+      end
+    end
+  end
+end

--- a/spec/requests/inbox_n_plus_one_spec.rb
+++ b/spec/requests/inbox_n_plus_one_spec.rb
@@ -6,11 +6,13 @@ describe "n+1 queries in the InboxController" do
   describe "#show" do
     let!(:user) { create(:user) }
 
-    shared_examples "a constant number of queries" do |*traits|
+    shared_examples "a constant number of queries" do
       context "when displaying multiple inbox comments", n_plus_one: true do
         before { fake_login_known_user(user) }
 
-        populate { |n| create_list(:inbox_comment, n, *traits, user: user) }
+        populate do |n|
+          n.times { create(:inbox_comment, user: user, feedback_comment: build_feedback_comment.call) }
+        end
 
         warmup { get user_inbox_path(user) }
 
@@ -23,15 +25,21 @@ describe "n+1 queries in the InboxController" do
     end
 
     context "with comments from registered users" do
+      let(:build_feedback_comment) { -> { create(:comment) } }
+
       it_behaves_like "a constant number of queries"
     end
 
     context "with comments from guests" do
-      it_behaves_like "a constant number of queries", :with_guest_comment
+      let(:build_feedback_comment) { -> { create(:comment, :by_guest) } }
+
+      it_behaves_like "a constant number of queries"
     end
 
     context "with reply comments" do
-      it_behaves_like "a constant number of queries", :with_reply_comment
+      let(:build_feedback_comment) { -> { create(:comment, commentable: create(:comment)) } }
+
+      it_behaves_like "a constant number of queries"
     end
   end
 end

--- a/spec/requests/inbox_n_plus_one_spec.rb
+++ b/spec/requests/inbox_n_plus_one_spec.rb
@@ -19,6 +19,7 @@ describe "n+1 queries in the InboxController" do
         it "produces a constant number of queries" do
           expect do
             get user_inbox_path(user)
+            expect(response.body.scan('id="feedback_comment_').size).to eq(current_scale.to_i)
           end.to perform_constant_number_of_queries
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7403

## Purpose

Removes n+1 from the inbox page. 

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

(I am guessing the following as I am new)

I am not sure if n+1s are tracked in the QA env. If not, making sure the behavior has not changed would be good enough. If sentries are raised in QA for n+1s, then this PR should stop those errors for this page. 

## Credit

Sherin 