### PR TITLE
AO3-7477 Update challenge-matching.html popup per feedback on AO3-6277

### DIFF
--- a/public/help/challenge-matching.html
+++ b/public/help/challenge-matching.html
@@ -24,3 +24,14 @@ your challenge partway through the sign-up process -- read further for details a
 
 <p>After you have dealt with all the invalid sign-ups, you can then start matching again.</p>
 
+<h4>No Matches</h4>
+
+<p>If you have no potential matches, there are a few things you can do:</p>
+
+<p>First, make sure that your gift exchange's Minimum Number to Match settings are set correctly. If they are set too high, then matching may not work.</p>
+
+<p>If you're still having issues, check your gift exchange's sign-ups. If none of the sign-ups match with each other, you may need to contact participants and ask if there are more things they're willing to create or receive.</p>
+
+<p>You can also change the Minimum Number to Match settings to 0 and assign matches manually.</p>
+
+<p>For more information, check out <a href="/faq/gift-exchange?language_id=en#giftxfaqmatch">What is matching and how do I complete the process in my Gift Exchange?</a>, or the <a href="/faq/tutorial-running-a-gift-exchange-on-ao3?language_id=en#giftxmatching">Matching</a> section in our tutorial, <a href="/faq/tutorial-running-a-gift-exchange-on-ao3">Running a Gift Exchange on AO3</a>.</p>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7477

## Purpose

Adds info about having no matches to the challenge matching info popup as per the ticket.

## Testing Instructions

Create a gift-matching challenge with >1 signup, close signups, then click on the popup at /challenge_name/potential_matches.

<img width="3182" height="1320" alt="image" src="https://github.com/user-attachments/assets/58ba0537-a6ad-413a-890d-fb1886aef3c6" />

## References

https://otwarchive.atlassian.net/browse/AO3-6277?focusedCommentId=381530

## Credit

James Larson (he/she)
