### PR TITLE
AO3-1250 Fix series visibility and work count filters for unrevealed and anonymous collections

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -44,8 +44,9 @@ class SeriesController < ApplicationController
   def show
     @works = @series.works_in_order.posted.includes(:pseuds)
                .select(&:visible?)
-               .reject { |work| (work.unrevealed? || work.anonymous?) && !(current_user && current_user.is_author_of?(@series)) }
+               .reject { |work| work.unrevealed? || work.anonymous? }
                .paginate(page: params[:page])
+
 
     # sets the page title with the data for the series
     if @series.unrevealed?

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -43,10 +43,9 @@ class SeriesController < ApplicationController
   # GET /series/1.xml
   def show
     @works = @series.works_in_order.posted.includes(:pseuds)
-               .select(&:visible?)
-               .reject { |work| work.unrevealed? || work.anonymous? }
-               .paginate(page: params[:page])
-
+      .select(&:visible?)
+      .reject { |work| work.unrevealed? || work.anonymous? }
+      .paginate(page: params[:page])
 
     # sets the page title with the data for the series
     if @series.unrevealed?

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -42,7 +42,10 @@ class SeriesController < ApplicationController
   # GET /series/1
   # GET /series/1.xml
   def show
-    @works = @series.works_in_order.posted.includes(:pseuds).select(&:visible?).paginate(page: params[:page])
+    @works = @series.works_in_order.posted.includes(:pseuds)
+               .select(&:visible?)
+               .reject { |work| (work.unrevealed? || work.anonymous?) && !(current_user && current_user.is_author_of?(@series)) }
+               .paginate(page: params[:page])
 
     # sets the page title with the data for the series
     if @series.unrevealed?

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -54,18 +54,29 @@ module SeriesHelper
     end
   end
 
+  # Use visible work positions instead of raw positions to avoid gaps in
+  # displayed series numbering when intermediate works are hidden.
+  def visible_work_position(work, series)
+    visible_works = series.works_in_order.posted.where.not(in_unrevealed_collection: true).where.not(in_anon_collection: true).select(&:visible?)
+    visible_works.index(work)
+  end
+
   def work_series_description(work, series)
-    serial = SerialWork.where(work_id: work.id, series_id: series.id).first
-    ts("Part <strong>%{position}</strong> of %{title}".html_safe, position: serial.position, title: link_to(series.title, series))
+    position = visible_work_position(work, series)
+    return unless position
+
+    t("series_helper.work_series_description_html", position: position + 1, title: link_to(series.title, series))
   end
 
   def series_list_with_work_position(work, email_styling: false)
-    safe_join(work.series.map do |s|
-                t("series_helper.series_description_html",
-                  index: s.serial_works.where(work_id: work.id).pick(:position),
-                  series_link: email_styling ? style_link(s.title, series_url(s)) : link_to(s.title, series_url(s)))
-              end,
-              t("support.array.words_connector"))
+    safe_join(work.series.filter_map do |s|
+      position = visible_work_position(work, s)
+      next unless position
+
+      t("series_helper.series_description_html",
+        index: position + 1,
+        series_link: email_styling ? style_link(s.title, series_url(s)) : link_to(s.title, series_url(s)))
+    end, t("support.array.words_connector"))
   end
 
   # Generates confirmation message for "Remove Me As Co-Creator"

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -7,9 +7,7 @@ module SeriesHelper
 
   # this should only show prev and next works visible to the current user
   def series_data_for_work(work)
-    if work.unrevealed? || work.anonymous?
-      return [content_tag(:span, ts("Part of a series (hidden)"), class: "series")]
-    end
+    return [content_tag(:span, t("series_helper.series_data_for_work.hidden_notice"), class: "series")] if work.unrevealed? || work.anonymous?
 
     series = work.serial_works.map(&:series).compact
     series.map do |serial|

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -13,8 +13,9 @@ module SeriesHelper
 
     series = work.serial_works.map(&:series).compact
     series.map do |serial|
-      works_in_series = serial.works_in_order.posted.select(
-        # Include only the fields needed to calculate visibility:
+      works_in_series = serial.works_in_order.posted.where.not(
+        in_unrevealed_collection: true, in_anon_collection: true
+      ).select(
         :id, :restricted, :hidden_by_admin, :posted
       ).select(&:visible?)
 

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -13,9 +13,7 @@ module SeriesHelper
 
     series = work.serial_works.map(&:series).compact
     series.map do |serial|
-      works_in_series = serial.works_in_order.posted.where.not(
-        in_unrevealed_collection: true, in_anon_collection: true
-      ).select(
+      works_in_series = serial.works_in_order.posted.where.not(in_unrevealed_collection: true).where.not(in_anon_collection: true).select(
         :id, :restricted, :hidden_by_admin, :posted
       ).select(&:visible?)
 

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -7,6 +7,10 @@ module SeriesHelper
 
   # this should only show prev and next works visible to the current user
   def series_data_for_work(work)
+    if work.unrevealed? || work.anonymous?
+      return [content_tag(:span, ts("Part of a series (hidden)"), class: "series")]
+    end
+
     series = work.serial_works.map(&:series).compact
     series.map do |serial|
       works_in_series = serial.works_in_order.posted.select(

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -112,10 +112,11 @@ class Series < ApplicationRecord
   end
 
   def visible_work_count
+    works = self.works.posted
     if User.current_user.nil?
-      self.works.posted.unrestricted.count
+      works.unrestricted.reject(&:anonymous?).reject(&:unrevealed?).count
     else
-      self.works.posted.count
+      works.reject(&:anonymous?).reject(&:unrevealed?).count
     end
   end
 

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -53,6 +53,7 @@ en:
     series_data_for_work:
       hidden_notice: Part of a series (hidden)
     series_description_html: Part %{index} of %{series_link}
+    work_series_description_html: Part <strong>%{position}</strong> of %{title}
   tags_helper:
     get_symbol_link:
       title: Symbols key

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -50,6 +50,8 @@ en:
     qr_code_as_svg:
       default_label: QR code
   series_helper:
+    series_data_for_work:
+      hidden_notice: Part of a series (hidden)
     series_description_html: Part %{index} of %{series_link}
   tags_helper:
     get_symbol_link:
@@ -83,7 +85,3 @@ en:
       anonymous: Anonymous
       multifandom: Multifandom
       unspecified_fandom: No fandom specified
-  series_helper:
-    series_description_html: Part %{index} of %{series_link}
-    series_data_for_work:
-      hidden_notice: "Part of a series (hidden)"

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -83,3 +83,7 @@ en:
       anonymous: Anonymous
       multifandom: Multifandom
       unspecified_fandom: No fandom specified
+  series_helper:
+    series_description_html: Part %{index} of %{series_link}
+    series_data_for_work:
+      hidden_notice: "Part of a series (hidden)"

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -195,17 +195,17 @@ Feature: Collection
       And I add the work "After" to series "New series"
     When "AO3-1250: series anonymity issues" is fixed
     ### even the author should not see the work listed within the series
-    # Then the work "Hiding Work" should be part of the "New series" series in the database
-    #   And the work "Hiding Work" should not be visible on the "New series" series page
-    #   And the series "New series" should not be visible on the "Hiding Work" work page
-    #   And the neighbors of "Hiding Work" in the "New series" series should link over it
+    Then the work "Hiding Work" should be part of the "New series" series in the database
+      And the work "Hiding Work" should not be visible on the "New series" series page
+      And the series "New series" should not be visible on the "Hiding Work" work page
+      And the neighbors of "Hiding Work" in the "New series" series should link over it
     When I am logged out
     Then the work "Hiding Work" should be part of the "New series" series in the database
       And the work "Hiding Work" should not be visible on the "New series" series page
       And the series "New series" should not be visible on the "Hiding Work" work page
     When "AO3-1250: series anonymity issues" is fixed
-    #  And I should not see "Mystery Work"
-    #  And the neighbors of "Hiding Work" in the "New series" series should link over it
+     And I should not see "Mystery Work"
+     And the neighbors of "Hiding Work" in the "New series" series should link over it
     When I reveal works for "Hidden Treasury"
       And I am logged out
     Then the work "Hiding Work" should be visible on the "New series" series page
@@ -223,16 +223,16 @@ Feature: Collection
       And I add the work "After" to series "New series"
     Then the work "Anon Work" should be part of the "New series" series in the database
     When "AO3-1250: series anonymity fixes" is fixed
-      # even the author should not see the work in the series
-      # And the work "Anon Work" should not be visible on the "New series" series page
-      # And the series "New series" should not be visible on the "Anon Work" work page
-      # And the neighbors of "Anon Work" in the "New series" series should link over it
+    ### even the author should not see the work in the series
+      And the work "Anon Work" should not be visible on the "New series" series page
+      And the series "New series" should not be visible on the "Anon Work" work page
+      And the neighbors of "Anon Work" in the "New series" series should link over it
     When I am logged out
     Then the work "Anon Work" should be part of the "New series" series in the database
     When "AO3-1250: series anonymity fixes" is fixed
-      # And the work "Anon Work" should not be visible on the "New series" series page
-      # And the series "New series" should not be visible on the "Anon Work" work page
-      # And the neighbors of "Anon Work" in the "New series" series should link over it
+      And the work "Anon Work" should not be visible on the "New series" series page
+      And the series "New series" should not be visible on the "Anon Work" work page
+      And the neighbors of "Anon Work" in the "New series" series should link over it
     When I reveal authors for "Anon Treasury"
       And I am logged out
     Then the work "Anon Work" should be visible on the "New series" series page

--- a/features/step_definitions/series_steps.rb
+++ b/features/step_definitions/series_steps.rb
@@ -132,11 +132,15 @@ Then /^the neighbors of "([^\"]*)" in the "([^\"]*)" series should link over it$
     visit work_path(neighbor.work)
     # the neighbors should link to each other if they both exist
     if neighbors.count > 1 && index == 0
-      click_link("Next Work →")
+      within("#series") do
+        click_link("Next Work →")
+      end
       page.should_not have_content(work_title)
       page.should have_content(neighbors[1].work.title)
     elsif neighbors.count > 1 && index == 1
-      click_link("← Previous Work")
+      within("#series") do
+        click_link("← Previous Work")
+      end
       page.should_not have_content(work_title)
       page.should have_content(neighbors[0].work.title)
     end
@@ -151,10 +155,14 @@ Then /^the neighbors of "([^\"]*)" in the "([^\"]*)" series should link to it$/ 
   neighbors.each do |neighbor|
     visit work_path(neighbor.work)
     if neighbor.position > position
-      click_link("← Previous Work")
+      within("#series") do
+        click_link("← Previous Work")
+      end
       page.should have_content(work_title)
     else
-      click_link("Next Work →")
+      within("#series") do
+        click_link("Next Work →")
+      end
       page.should have_content(work_title)
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-1250

## Purpose

This PR fixes work and series visibility handling, updates work counts within series, and ensures series navigation skips hidden and anonymous works.

## Testing Instructions

The QA team can verify this behavior manually on a local instance by following these steps:

### Setup
1. Create and post a public work ("Before") and add it to the new series (e.g., "New series"). 
2. Create a second public work ("After") and add it to the series.

### Case 1: Unrevealed Collections
1. Create a hidden collection ("Hidden Collection").  Check the box for **"This collection is unrevealed"**
2. Create a work ("Mystery Work"), add it to "Hidden Collection", and add it to "New series".
3. **Verify:** As any user (including the author while logged out), "Mystery Work" should not appear on the "New series" page. The work counter should not include it.
4. On the "After" work page, verify the series navigation banner links directly back to "Before" (skipping over "Mystery Work").
5. Reveal the collection. 
6. **Verify:** "Mystery Work" should now appear on the series page, the counter should increment, and the series navigation banner on "After" should correctly link to "Hiding Work".

### Case 2: Anonymous Collections
1. Create an anonymous collection ("Anon Treasury").
2. Post a work ("Anon Work"), add it to "Anon Treasury", and add it to "New series".
3. **Verify:** The work is listed, but the author's name is masked as "Anonymous".
4. Reveal the authors for the collection.
5. **Verify:** The author's true pseud is now correctly visible across the series lists and navigation indexes.


If you have a Jira account with access, please update or comment on the issue
with any new or missing testing instructions instead. - Don't have account, but can create in the future.

You can remove this section if there are already full testing instructions in the Jira issue.

## Credit

* Name: [Anastasia095](https://github.com/Anastasia095/Anastasia095)
* Pronouns: [She/Her]
