### PR TITLE
AO3-7498 Update tk0miya/action-erblint and fork it to pin the reviewdog version

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,7 +30,7 @@ jobs:
           skip_install: true
           fail_level: any
 
-  erb-lint:
+  erb_lint:
     name: ERB Lint runner
     runs-on: ubuntu-latest
     env:
@@ -44,9 +44,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: erb-lint
-        uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b
+      - name: erb_lint
+        uses: otwcode/action-erblint@ece7c46883ef6a311194b9be3e6a2837945898e7
         with:
           use_bundler: true
           reporter: github-pr-check
           fail_level: any
+          config_file: .erb-lint.yml


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7498

## Purpose

Updates the action by forking it, and applying two commits on top:
* One commit reversing the renaming of the gem since we've not updated the gem
* One commit to pin the install script and reviewdog version to the [latest reviewdog release](https://github.com/reviewdog/reviewdog/commit/df70ed74df59de7ebfd9276afabd62ea2de4d7dd), to protect against supply chain attacks

Refer to https://github.com/otwcode/action-erblint/tree/patch/f830853 for the commits. The branch is named after the upstream commit it's based on. So when upstream updates we should make a new branch and keep the old one, preventing failure of workflows due to the commit hash used in the action getting deleted from our fork.

## References

The pinning is based on https://github.com/reviewdog/action-rubocop/commit/fcb74ba274da10b18d038d0bcddaae3518739634. In the future when dependabot pokes us to update that action due to a reviewdog bump then we should also update the erblint action.

## Testing Instructions

I tested at https://github.com/Bilka2/otwarchive/pull/25. Errors are reported correctly if there any and it uses the config file for our custom error.

## Credit

Bilka
