### PR TITLE
AO3-7511 Update privacy rights link anchor in Privacy Policy

### DIFF
--- a/app/views/home/_privacy.html.erb
+++ b/app/views/home/_privacy.html.erb
@@ -124,7 +124,7 @@
   <li id="III.E.2">
     <p>
       <%= t(".your_rights.potential_other_rights_html",
-            other_rights_link: link_to(t(".your_rights.other_rights"), tos_faq_path(anchor: "privacy_rights_faq"))) %>
+            other_rights_link: link_to(t(".your_rights.other_rights"), tos_faq_path(anchor: "privacy_rights_list"))) %>
     </p>
   </li>
   <li id="III.E.3"><p><%= t(".your_rights.require_user_specific_proof") %></p></li>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7511

## Purpose

Updates the "other rights regarding your Personal Information" link in Section III.E of the Privacy Policy so it points directly to the relevant bullet list in the Terms of Service FAQ.

## Testing Instructions

1. Go to `/privacy#III.E` (e.g. https://test.archiveofourown.org/privacy#III.E).
2. Click the "other rights regarding your Personal Information" link.
3. Confirm it navigates to `/tos_faq#privacy_rights_list` and lands at the bullet list beginning with "As provided by the laws of your applicable jurisdiction, these rights may include:".


## Credit

Name: notpies
Pronouns: he/him