### PR TITLE
AO3-7510 Add link about bookmark rules to Content Policy

### DIFF
--- a/app/views/home/_content.html.erb
+++ b/app/views/home/_content.html.erb
@@ -57,7 +57,8 @@
 <p>
   <%= t(".fanworks.bookmarks_only_fanworks_html",
         bookmarks_link: link_to(t(".fanworks.bookmarks"), archive_faq_path("bookmarks")),
-        external_bookmarks_link: link_to(t(".fanworks.external_bookmarks"), archive_faq_path("bookmarks", anchor: "externalbookmark"))) %>
+        external_bookmarks_link: link_to(t(".fanworks.external_bookmarks"), archive_faq_path("bookmarks", anchor: "externalbookmark")),
+        created_for_fanworks_link: link_to(t(".fanworks.created_for_fanworks"), tos_faq_path(anchor: "bookmark_fanworks"))) %>
 </p>
 <p>
   <small>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1810,7 +1810,8 @@ en:
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be created for fanworks. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
+        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be %{created_for_fanworks_link}</a>. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
+        created_for_fanworks: created for fanworks
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks
         must_be_fanworks_html: Works must be fanworks. Posting a Work that primarily consists of %{non_fanwork_content_link} is not allowed.

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1810,7 +1810,7 @@ en:
       effective: 'Effective: November 19, 2024'
       fanworks:
         bookmarks: Bookmarks
-        bookmarks_only_fanworks_html: '%{bookmarks_link} must only be %{created_for_fanworks_link}</a>. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites.'
+        bookmarks_only_fanworks_html: "%{bookmarks_link} must only be %{created_for_fanworks_link}. You may create %{external_bookmarks_link} for fanworks hosted on third-party sites."
         created_for_fanworks: created for fanworks
         external_bookmarks: external bookmarks
         heading: II.B. Fanworks


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7510

## Purpose

What does this PR do?

This PR adds the [desired link](https://archiveofourown.org/tos_faq#bookmark_fanworks) in the fanworks section of content policy to the phrase "created for fanwork". 

## Credit

Name: Aadya
Pronouns: she/her