### PR TITLE
AO3-6547 Extract WorkRecipients concern from Work model

### DIFF
--- a/app/models/concerns/work_recipients.rb
+++ b/app/models/concerns/work_recipients.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module WorkRecipients
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :gifts, dependent: :destroy
+    accepts_nested_attributes_for :gifts, allow_destroy: true
+
+    attr_accessor :new_gifts
+
+    validate :new_recipients_allow_gifts
+    validate :new_recipients_have_not_blocked_gift_giver
+  end
+
+  def recipients=(recipient_names)
+    new_gifts = []
+    gifts = [] # rebuild the list of associated gifts using the new list of names
+    # add back in the rejected gift recips; we don't let users delete rejected gifts in order to prevent regifting
+    recip_names = recipient_names.split(',') + self.gifts.are_rejected.collect(&:recipient)
+    recip_names.uniq.each do |name|
+      name.strip!
+      gift = self.gifts.for_name_or_byline(name).first
+      if gift
+        gifts << gift # new gifts are added after saving, not now
+        new_gifts << gift unless self.posted # all gifts are new if work not posted
+      else
+        g = self.gifts.new(recipient: name)
+        if g.valid?
+          new_gifts << g # new gifts are added after saving, not now
+        else
+          g.errors.full_messages.each { |msg| self.errors.add(:base, msg) }
+        end
+      end
+    end
+    self.gifts = gifts
+    self.new_gifts = new_gifts
+  end
+
+  def recipients(for_form = false)
+    names = (for_form ? self.gifts.not_rejected : self.gifts).collect(&:recipient)
+    names << self.new_gifts.collect(&:recipient) if self.new_gifts.present?
+    names.flatten.uniq.join(",")
+  end
+
+  private
+
+  def new_recipients_allow_gifts
+    return if self.new_gifts.blank?
+
+    self.new_gifts.each do |gift|
+      next if gift.pseud.blank?
+      next if gift.pseud&.user&.preference&.allow_gifts?
+      next if challenge_bypass(gift)
+
+      self.errors.add(:base, :blocked_gifts, byline: gift.pseud.byline)
+    end
+  end
+
+  def new_recipients_have_not_blocked_gift_giver
+    return if self.new_gifts.blank?
+
+    self.new_gifts.each do |gift|
+      # Already dealt with in #new_recipients_allow_gifts
+      next if gift.pseud&.user&.preference && !gift.pseud.user.preference.allow_gifts?
+
+      next if challenge_bypass(gift)
+
+      blocked_users = gift.pseud&.user&.blocked_users || []
+      next if blocked_users.empty?
+
+      pseuds_after_saving.each do |pseud|
+        next unless blocked_users.include?(pseud.user)
+
+        if User.current_user == pseud.user
+          self.errors.add(:base, :blocked_your_gifts, byline: gift.pseud.byline)
+        else
+          self.errors.add(:base, :blocked_gifts, byline: gift.pseud.byline)
+        end
+      end
+    end
+  end
+
+  def save_new_gifts
+    return if self.new_gifts.blank?
+
+    self.new_gifts.each do |gift|
+      next if self.gifts.for_name_or_byline(gift.recipient).present?
+
+      # Recreate the gift once the work is saved. This ensures the work_id is
+      # set properly.
+      Gift.create(recipient: gift.recipient, work: self)
+    end
+  end
+
+  def challenge_bypass(gift)
+    self.challenge_assignments.map(&:requesting_pseud).include?(gift.pseud) ||
+      self.challenge_claims
+        .reject { |c| c.request_prompt.anonymous? }
+        .map(&:requesting_pseud)
+        .include?(gift.pseud)
+  end
+end

--- a/app/models/concerns/work_recipients.rb
+++ b/app/models/concerns/work_recipients.rb
@@ -9,6 +9,16 @@ module WorkRecipients
 
     attr_accessor :new_gifts
 
+    # If the recipient doesn't allow gifts, it should not be possible to give them
+    # a gift work unless it fulfills a gift exchange assignment or non-anonymous
+    # prompt meme claim for the recipient.
+    # We don't want the work to save if the gift shouldn't exist, but the gift
+    # model can't access a work's challenge_assignments or challenge_claims until
+    # the work and its assignments and claims are saved. Gifts are created after
+    # the work is saved, so it's too late then to prevent the work from saving.
+    # Additionally, the work's assignments and claims don't appear to be available
+    # by the time gift validations run, which means the gift is never created if
+    # the user doesn't allow them.
     validate :new_recipients_allow_gifts
     validate :new_recipients_have_not_blocked_gift_giver
   end
@@ -17,7 +27,7 @@ module WorkRecipients
     new_gifts = []
     gifts = [] # rebuild the list of associated gifts using the new list of names
     # add back in the rejected gift recips; we don't let users delete rejected gifts in order to prevent regifting
-    recip_names = recipient_names.split(',') + self.gifts.are_rejected.collect(&:recipient)
+    recip_names = recipient_names.split(",") + self.gifts.are_rejected.collect(&:recipient)
     recip_names.uniq.each do |name|
       name.strip!
       gift = self.gifts.for_name_or_byline(name).first
@@ -37,10 +47,10 @@ module WorkRecipients
     self.new_gifts = new_gifts
   end
 
-  def recipients(for_form = false)
+  def recipients(for_form: false)
     names = (for_form ? self.gifts.not_rejected : self.gifts).collect(&:recipient)
-    names << self.new_gifts.collect(&:recipient) if self.new_gifts.present?
-    names.flatten.uniq.join(",")
+    names.concat(self.new_gifts.collect(&:recipient)) if self.new_gifts.present?
+    names.uniq.join(",")
   end
 
   private
@@ -51,7 +61,7 @@ module WorkRecipients
     self.new_gifts.each do |gift|
       next if gift.pseud.blank?
       next if gift.pseud&.user&.preference&.allow_gifts?
-      next if challenge_bypass(gift)
+      next if challenge_bypass?(gift)
 
       self.errors.add(:base, :blocked_gifts, byline: gift.pseud.byline)
     end
@@ -64,7 +74,7 @@ module WorkRecipients
       # Already dealt with in #new_recipients_allow_gifts
       next if gift.pseud&.user&.preference && !gift.pseud.user.preference.allow_gifts?
 
-      next if challenge_bypass(gift)
+      next if challenge_bypass?(gift)
 
       blocked_users = gift.pseud&.user&.blocked_users || []
       next if blocked_users.empty?
@@ -85,15 +95,13 @@ module WorkRecipients
     return if self.new_gifts.blank?
 
     self.new_gifts.each do |gift|
-      next if self.gifts.for_name_or_byline(gift.recipient).present?
+      next if self.gifts.for_name_or_byline(gift.recipient).exists?
 
-      # Recreate the gift once the work is saved. This ensures the work_id is
-      # set properly.
-      Gift.create(recipient: gift.recipient, work: self)
+      gifts.create(recipient: gift.recipient)
     end
   end
 
-  def challenge_bypass(gift)
+  def challenge_bypass?(gift)
     self.challenge_assignments.map(&:requesting_pseud).include?(gift.pseud) ||
       self.challenge_claims
         .reject { |c| c.request_prompt.anonymous? }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -7,6 +7,7 @@ class Work < ApplicationRecord
   include BookmarkCountCaching
   include WorkChapterCountCaching
   include Creatable
+  include WorkRecipients
 
   ########################################################################
   # ASSOCIATIONS
@@ -30,9 +31,6 @@ class Work < ApplicationRecord
   has_many :approved_children, through: :approved_related_works, source: :work
 
   accepts_nested_attributes_for :parent_work_relationships, allow_destroy: true, reject_if: proc { |attrs| attrs.values_at(:url, :author, :title).all?(&:blank?) }
-
-  has_many :gifts, dependent: :destroy
-  accepts_nested_attributes_for :gifts, allow_destroy: true
 
   has_many :subscriptions, as: :subscribable, dependent: :destroy
 
@@ -73,7 +71,6 @@ class Work < ApplicationRecord
   # Virtual attribute to use as a placeholder for pseuds before the work has been saved
   # Can't write to work.pseuds until the work has an id
   attr_accessor :new_parent, :url_for_parent
-  attr_accessor :new_gifts
   attr_accessor :preview_mode
 
   # Virtual attribute for whether the hidden-for-spam email has been sent, so the normal work-hidden email should not be sent
@@ -169,55 +166,6 @@ class Work < ApplicationRecord
   validates :user_defined_tags_count,
             at_most: { maximum: proc { ArchiveConfig.USER_DEFINED_TAGS_MAX } },
             unless: -> { User.current_user.is_a?(Admin) }
-
-  # If the recipient doesn't allow gifts, it should not be possible to give them
-  # a gift work unless it fulfills a gift exchange assignment or non-anonymous
-  # prompt meme claim for the recipient.
-  # We don't want the work to save if the gift shouldn't exist, but the gift
-  # model can't access a work's challenge_assignments or challenge_claims until
-  # the work and its assignments and claims are saved. Gifts are created after
-  # the work is saved, so it's too late then to prevent the work from saving.
-  # Additionally, the work's assignments and claims don't appear to be available
-  # by the time gift validations run, which means the gift is never created if
-  # the user doesn't allow them.
-  validate :new_recipients_allow_gifts
-
-  def new_recipients_allow_gifts
-    return if self.new_gifts.blank?
-
-    self.new_gifts.each do |gift|
-      next if gift.pseud.blank?
-      next if gift.pseud&.user&.preference&.allow_gifts?
-      next if challenge_bypass(gift)
-
-      self.errors.add(:base, :blocked_gifts, byline: gift.pseud.byline)
-    end
-  end
-
-  validate :new_recipients_have_not_blocked_gift_giver
-  def new_recipients_have_not_blocked_gift_giver
-    return if self.new_gifts.blank?
-
-    self.new_gifts.each do |gift|
-      # Already dealt with in #new_recipients_allow_gifts
-      next if gift.pseud&.user&.preference && !gift.pseud.user.preference.allow_gifts?
-
-      next if challenge_bypass(gift)
-
-      blocked_users = gift.pseud&.user&.blocked_users || []
-      next if blocked_users.empty?
-
-      pseuds_after_saving.each do |pseud|
-        next unless blocked_users.include?(pseud.user)
-
-        if User.current_user == pseud.user
-          self.errors.add(:base, :blocked_your_gifts, byline: gift.pseud.byline)
-        else
-          self.errors.add(:base, :blocked_gifts, byline: gift.pseud.byline)
-        end
-      end
-    end
-  end
 
   enum :comment_permissions, {
     enable_all: 0,
@@ -517,48 +465,6 @@ class Work < ApplicationRecord
     self.challenge_assignments =
       ChallengeAssignment.where(id: ids)
         .select { |assign| valid_users.include?(assign.offering_user) }
-  end
-
-  def recipients=(recipient_names)
-    new_gifts = []
-    gifts = [] # rebuild the list of associated gifts using the new list of names
-    # add back in the rejected gift recips; we don't let users delete rejected gifts in order to prevent regifting
-    recip_names = recipient_names.split(',') + self.gifts.are_rejected.collect(&:recipient)
-    recip_names.uniq.each do |name|
-      name.strip!
-      gift = self.gifts.for_name_or_byline(name).first
-      if gift
-        gifts << gift # new gifts are added after saving, not now
-        new_gifts << gift unless self.posted # all gifts are new if work not posted
-      else
-        g = self.gifts.new(recipient: name)
-        if g.valid?
-          new_gifts << g # new gifts are added after saving, not now
-        else
-          g.errors.full_messages.each { |msg| self.errors.add(:base, msg) }
-        end
-      end
-    end
-    self.gifts = gifts
-    self.new_gifts = new_gifts
-  end
-
-  def recipients(for_form = false)
-    names = (for_form ? self.gifts.not_rejected : self.gifts).collect(&:recipient)
-    names << self.new_gifts.collect(&:recipient) if self.new_gifts.present?
-    names.flatten.uniq.join(",")
-  end
-
-  def save_new_gifts
-    return if self.new_gifts.blank?
-
-    self.new_gifts.each do |gift|
-      next if self.gifts.for_name_or_byline(gift.recipient).present?
-
-      # Recreate the gift once the work is saved. This ensures the work_id is
-      # set properly.
-      Gift.create(recipient: gift.recipient, work: self)
-    end
   end
 
   def marked_for_later?(user)
@@ -1316,11 +1222,4 @@ class Work < ApplicationRecord
     (saved_changes.keys & pertinent_attributes).present?
   end
 
-  def challenge_bypass(gift)
-    self.challenge_assignments.map(&:requesting_pseud).include?(gift.pseud) ||
-      self.challenge_claims
-        .reject { |c| c.request_prompt.anonymous? }
-        .map(&:requesting_pseud)
-        .include?(gift.pseud)
-  end
 end

--- a/app/views/works/_standard_form.html.erb
+++ b/app/views/works/_standard_form.html.erb
@@ -86,7 +86,7 @@
         <%= link_to_help_modal(help_works_recipients_path, t(".works_recipients_help_title")) %>
       </dt>
       <dd class="recipient" title="<%= ts("gift to") %>">
-        <%= f.text_field :recipients, autocomplete_options("pseud", value: @work.recipients(for_form = true)) %>
+        <%= f.text_field :recipients, autocomplete_options("pseud", value: @work.recipients(for_form: true)) %>
       </dd>
 
       <!-- Inspiration / remix -->

--- a/lib/creation_notifier.rb
+++ b/lib/creation_notifier.rb
@@ -38,11 +38,7 @@ module CreationNotifier
     recip_preferences = Preference.where(user_id: recipient_pseuds.map(&:user_id), recipient_emails_off: false)
     recip_preferences.each do |userpref|
       I18n.with_locale(userpref.locale_for_mails) do
-        if self.collections.empty? || self.collections.first.nil?
-          UserMailer.recipient_notification(userpref.user_id, self.id).deliver_after_commit
-        else
-          UserMailer.recipient_notification(userpref.user_id, self.id, self.collections.first.id).deliver_after_commit
-        end
+        UserMailer.recipient_notification(userpref.user_id, self.id, self.collections.first&.id).deliver_after_commit
       end
     end
   end


### PR DESCRIPTION
## Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6547

## Purpose

Extract all work recipients logic into a `WorkRecipients` concern to make the code cleaner and easier to modify. The recipients code was spread across `Work` and `CreationNotifier`.

Changes:
- Create `app/models/concerns/work_recipients.rb` with all recipients logic moved from `Work`: gifts association, `recipients=`/`recipients` methods, validations (`new_recipients_allow_gifts`, `new_recipients_have_not_blocked_gift_giver`), `save_new_gifts`, and `challenge_bypass?`
- Simplify collections branch in `notify_recipients`
- Use keyword argument for `recipients(for_form:)` instead of positional boolean
- Use `.exists?` instead of `.present?` in `save_new_gifts`
- Use `gifts.create` instead of `Gift.create(work: self)`
- Rename `challenge_bypass` to `challenge_bypass?` (Ruby predicate convention)

No behavior changes.

## Testing Instructions

Testing instructions are in the Jira issue.

## Credit

Pablo Monfort (he/him)