### PR TITLE
AO3-7457 Extract work blurb presenter

### DIFF
--- a/app/presenters/work_blurb_presenter.rb
+++ b/app/presenters/work_blurb_presenter.rb
@@ -1,0 +1,55 @@
+class WorkBlurbPresenter
+  def initialize(works, force_reveal: false, blurb: true)
+    @works = Array(works).compact
+    @force_reveal = force_reveal
+    @blurb = blurb
+  end
+
+  def render_in(view_context)
+    view_context.safe_join(works.map { |work| render_work(view_context, work) })
+  end
+
+  private
+
+  attr_reader :works
+
+  def render_work(view_context, work)
+    if blurb?
+      render_blurb(view_context, work)
+    else
+      render_module(view_context, work)
+    end
+  end
+
+  def render_blurb(view_context, work)
+    view_context.render(
+      "works/work_blurb",
+      work: work,
+      work_module_html: render_module(view_context, work)
+    )
+  end
+
+  def render_module(view_context, work)
+    view_context.render(module_partial_path(view_context, work), work: work)
+  end
+
+  def module_partial_path(view_context, work)
+    use_mystery_blurb?(view_context, work) ? "works/mystery_blurb" : "works/work_module"
+  end
+
+  def use_mystery_blurb?(view_context, work)
+    work.unrevealed? && !viewer_owns_work?(view_context, work) && !force_reveal?
+  end
+
+  def viewer_owns_work?(view_context, work)
+    view_context.is_author_of?(work)
+  end
+
+  def force_reveal?
+    @force_reveal
+  end
+
+  def blurb?
+    @blurb
+  end
+end

--- a/app/views/bookmarks/_bookmark_item_module.html.erb
+++ b/app/views/bookmarks/_bookmark_item_module.html.erb
@@ -4,5 +4,5 @@
 <% elsif bookmarkable.is_a?(Series) %>
   <%= render 'series/series_module', series: bookmarkable %>
 <% else %>
-  <%= render 'works/work_module', work: bookmarkable %>
+  <%= render WorkBlurbPresenter.new(bookmarkable, blurb: false) %>
 <% end %>

--- a/app/views/bookmarks/_bookmarks.html.erb
+++ b/app/views/bookmarks/_bookmarks.html.erb
@@ -1,6 +1,6 @@
 <% # show blurb for whatever is bookmarked if we're looking at a single bookmarked object %>
 <% if params[:work_id] %>
-  <%= render 'works/work_blurb', :work => @bookmarkable %>
+  <%= render WorkBlurbPresenter.new(@bookmarkable) %>
 <% elsif params[:external_work_id] %>
   <%= render 'external_works/blurb', :external_work => @bookmarkable %>
 <% elsif params[:series_id] %>

--- a/app/views/collection_items/_item_fields.html.erb
+++ b/app/views/collection_items/_item_fields.html.erb
@@ -42,7 +42,7 @@
       <% id = "blurb_#{collection_item.item_type}_#{collection_item.item_id}_#{collection_item.collection.name}" %>
       <blockquote id="<%= id %>" class="<% if collection_item.item_type == 'Bookmark' %>bookmark <% else %>work <% end %> blurb toggled">
         <% if collection_item.item_type == 'Work' %>
-          <%= render "works/work_module", work: collection_item.item, is_unrevealed: false %>
+          <%= render WorkBlurbPresenter.new(collection_item.item, blurb: false) %>
         <% elsif collection_item.item_type == 'Bookmark' %>
           <% bookmark = collection_item.item %>
           <% bookmarkable = bookmark.bookmarkable %>

--- a/app/views/collections/_works_module.html.erb
+++ b/app/views/collections/_works_module.html.erb
@@ -7,9 +7,7 @@
     <% end %>
   </h3>
   <ul class="index group">
-    <% for work in works %>
-  	  <%= render 'works/work_blurb', :work => work %>
-    <% end %>
+    <%= render WorkBlurbPresenter.new(works) %>
   </ul>
   <% if works.total_entries > ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD %>
     <ul class="actions" role="navigation"><li><%= link_to ts("Works (%{count})", :count => works.total_entries), collection_works_path(@collection) %></li></ul>

--- a/app/views/external_authors/claim.html.erb
+++ b/app/views/external_authors/claim.html.erb
@@ -42,9 +42,7 @@
 <div class="work listbox group">
   <h3 class="heading"><%= t(".my_imported", count: works_count) %></h3>
   <ul id="imported_works" class="index group">
-    <% @external_author.works.each do |work| %>
-      <%= render "works/work_blurb", work: work %>
-    <% end %>
+    <%= render WorkBlurbPresenter.new(@external_author.works) %>
   </ul>
   <p class="actions">
     <% if logged_in? %>

--- a/app/views/gifts/_gift_blurb.html.erb
+++ b/app/views/gifts/_gift_blurb.html.erb
@@ -1,6 +1,6 @@
 <% # expects "work" and "gift" %>
 <li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.anonymous? %>anonymous <% end %><% if work.unrevealed? %>mystery <% end %>gift work <%= css_classes_for_creation_blurb(work) %>" role="article">
-  <%= render "works/work_module", work: work %>
+  <%= render WorkBlurbPresenter.new(work, blurb: false) %>
   <% if @user && @user == current_user && (gift = work.gifts.where(:pseud_id => current_user.pseuds.pluck(:id)).first) %>
     <h6 class="landmark heading"><%= ts("Recipient Actions") %></h6>
     <p class="actions">

--- a/app/views/orphans/index.html.erb
+++ b/app/views/orphans/index.html.erb
@@ -7,9 +7,7 @@
 
 <!--main content-->
 <ul class="work index group">
-  <% for work in @works %>
-	<%= render :partial => 'works/work_blurb', :locals => {:work => work} %>
-  <% end %>
+  <%= render WorkBlurbPresenter.new(@works) %>
 </ul>
 <!--/content-->
 

--- a/app/views/prompts/_prompt_blurb.html.erb
+++ b/app/views/prompts/_prompt_blurb.html.erb
@@ -87,7 +87,7 @@
           <% prompt.fulfilled_claims.map(&:creation).each do |creation| %>
             <% if creation.is_a?(Work) %>
               <% unless guest? && creation.restricted %>
-                <%= render "works/work_blurb", work: creation %>
+                <%= render WorkBlurbPresenter.new(creation) %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/readings/_reading_blurb.html.erb
+++ b/app/views/readings/_reading_blurb.html.erb
@@ -10,7 +10,7 @@
 
   <% unless reading.work.nil? %>
 
-    <%= render 'works/work_module', work: reading.work %>
+    <%= render WorkBlurbPresenter.new(reading.work, blurb: false) %>
 
   <% end %>
 

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -89,7 +89,7 @@
   <%= will_paginate @works %>
 <% end %>
 <ul class="series work index group">
-  <%= render partial: "works/work_blurb", collection: @works, as: :work %>
+  <%= render WorkBlurbPresenter.new(@works) %>
 </ul>
 
 <% unless @works.blank? %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -118,9 +118,7 @@
       <h3 class="heading"><%= ts('Works which have used it as a tag') %>:</h3>
       <%= paginated_section @works do %>
           <ul class="index group">
-            <% for work in @works %>
-              <%= render :partial => 'works/work_blurb', :locals => {:work => work} %>
-            <% end %>
+            <%= render WorkBlurbPresenter.new(@works) %>
           </ul>
         <% end %>
       </div>

--- a/app/views/troubleshooting/show.html.erb
+++ b/app/views/troubleshooting/show.html.erb
@@ -5,7 +5,7 @@
   <p><%= link_to @item.name, tag_path(@item) %> (<%= @item.type %>)</p>
 <% elsif @item.is_a?(Work) %>
   <ol class="work index group">
-    <%= render "works/work_blurb", work: @item %>
+    <%= render WorkBlurbPresenter.new(@item) %>
   </ol>
 <% end %>
 

--- a/app/views/users/_contents.html.erb
+++ b/app/views/users/_contents.html.erb
@@ -38,7 +38,7 @@
   <div class="work listbox group" id="user-works">
     <h3 class="heading"><%= ts("Recent works") %></h3>
     <ul class="index group">
-      <%= render partial: 'works/work_blurb', collection: @works, as: :work %>
+      <%= render WorkBlurbPresenter.new(@works) %>
     </ul>
     <% if @pseud %>
       <% if @pseud.works.count > ArchiveConfig.NUMBER_OF_ITEMS_VISIBLE_IN_DASHBOARD %>

--- a/app/views/works/_adult.html.erb
+++ b/app/views/works/_adult.html.erb
@@ -25,5 +25,5 @@
 <div class="clear"></div>
 
 <ol class="work index group">
-  <%= render "works/work_blurb", work: @work %>
+  <%= render WorkBlurbPresenter.new(@work) %>
 </ol>

--- a/app/views/works/_mystery_blurb.html.erb
+++ b/app/views/works/_mystery_blurb.html.erb
@@ -1,7 +1,7 @@
 <div class="mystery header picture module">
   <h4 class="heading"><%= ts("Mystery Work") %></h4>
-  <% if item.approved_collections.unrevealed.present? %>
-    <h5 class="heading"><%= h(ts("Part of ")) + show_collections_data(item.approved_collections.unrevealed) %></h5>
+  <% if work.approved_collections.unrevealed.present? %>
+    <h5 class="heading"><%= h("Part of ") + show_collections_data(work.approved_collections.unrevealed) %></h5>
   <% end %>
   <div class="icon"></div>
 </div>

--- a/app/views/works/_mystery_blurb.html.erb
+++ b/app/views/works/_mystery_blurb.html.erb
@@ -1,7 +1,7 @@
 <div class="mystery header picture module">
   <h4 class="heading"><%= ts("Mystery Work") %></h4>
   <% if work.approved_collections.unrevealed.present? %>
-    <h5 class="heading"><%= h("Part of ") + show_collections_data(work.approved_collections.unrevealed) %></h5>
+    <h5 class="heading"><%= safe_join([t(".part_of"), show_collections_data(work.approved_collections.unrevealed)], " ") %></h5>
   <% end %>
   <div class="icon"></div>
 </div>

--- a/app/views/works/_work_blurb.html.erb
+++ b/app/views/works/_work_blurb.html.erb
@@ -1,6 +1,6 @@
-<% # expects "work" %>
+<%# expects "work" and "work_module_html" %>
 <li id="work_<%= work.id %>" class="<% if is_author_of?(work) %>own <% end %><% if work.anonymous? %>anonymous <% end %><% if work.unrevealed? %>mystery <% end %>work <%= css_classes_for_creation_blurb(work) %>" role="article">
-  <%= render "works/work_module", work: work %>
+  <%= work_module_html %>
   <% if is_author_of?(work) %>
     <h6 class="landmark heading"><%= ts("Author Actions") %></h6>
   	<ul class="actions">

--- a/app/views/works/_work_module.html.erb
+++ b/app/views/works/_work_module.html.erb
@@ -1,7 +1,4 @@
 <% # expects "work" %>
-<% if work.unrevealed? && !is_author_of?(work) && !(User.current_user.is_a?(Admin) && current_page?(controller: "works", action: "collected")) %>
-  <%= render "works/mystery_blurb", item: work %>
-<% else %>
   <!--title, author, fandom-->
   <div class="<% if work.anonymous? %>anonymous <% end %>header module">
     <!-- updated_at=<%= work.updated_at.to_i.to_s %> -->
@@ -116,5 +113,3 @@
 <% #### END CACHE stats #### %>
 
   </dl>
-
-<% end %>

--- a/app/views/works/collected.html.erb
+++ b/app/views/works/collected.html.erb
@@ -25,9 +25,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts("Listing Works") %></h3>
 <ol class="work index group">
-  <% for work in @works %>
-    <% if work %><%= render 'work_blurb', :work => work %><% end %>
-  <% end %>
+  <%= render WorkBlurbPresenter.new(@works, force_reveal: User.current_user.is_a?(Admin)) %>
 </ol>
   
 <!--/content-->

--- a/app/views/works/drafts.html.erb
+++ b/app/views/works/drafts.html.erb
@@ -13,9 +13,7 @@
 
 <!--main content-->
 <ul class="work index group">
-  <% for work in @works %>
-    <%= render 'work_blurb', :work => work %>
-  <% end %>
+  <%= render WorkBlurbPresenter.new(@works) %>
 </ul>
 <!--/content-->
 

--- a/app/views/works/index.html.erb
+++ b/app/views/works/index.html.erb
@@ -51,7 +51,7 @@
 <!--main content-->
 <h3 class="landmark heading"><%= ts("Listing Works") %></h3>
 <ol class="work index group">
-  <%= render partial: "work_blurb", collection: @works, as: :work %>
+  <%= render WorkBlurbPresenter.new(@works) %>
 </ol>
 
 <!--/content-->

--- a/app/views/works/search_results.html.erb
+++ b/app/views/works/search_results.html.erb
@@ -24,11 +24,7 @@
 
   <h3 class="landmark heading">Works List</h3>
   <ol class="work index group">
-    <% @works.each do |work| %>
-      <% unless work.nil? %>
-        <%= render :partial => 'work_blurb', :locals => {:work => work} %>
-      <% end %>
-    <% end %>
+    <%= render WorkBlurbPresenter.new(@works) %>
   </ol>
  
  <%= will_paginate @works %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -3394,6 +3394,8 @@ en:
       original_creators:
         one: 'Original Creator ID:'
         other: 'Original Creator IDs:'
+    mystery_blurb:
+      part_of: Part of
     navigate:
       page_heading_html: Chapter Index for %{work_link} by %{creators}
     new_import:

--- a/spec/presenters/work_blurb_presenter_spec.rb
+++ b/spec/presenters/work_blurb_presenter_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+class WorkBlurbPresenterViewContext
+  attr_reader :renders
+
+  def initialize(owned_works: [])
+    @owned_works = owned_works
+    @renders = []
+  end
+
+  def render(partial, locals)
+    @renders << [partial, locals]
+    partial
+  end
+
+  def safe_join(parts)
+    parts.join
+  end
+
+  def is_author_of?(work)
+    @owned_works.include?(work)
+  end
+end
+
+RSpec.describe WorkBlurbPresenter do
+  let(:revealed_work) { instance_double(Work, unrevealed?: false) }
+  let(:unrevealed_work) { instance_double(Work, unrevealed?: true) }
+
+  it "renders the work blurb shell by default" do
+    view_context = WorkBlurbPresenterViewContext.new
+
+    described_class.new(revealed_work).render_in(view_context)
+
+    expect(view_context.renders).to eq([
+      ["works/work_module", { work: revealed_work }],
+      ["works/work_blurb", { work: revealed_work, work_module_html: "works/work_module" }]
+    ])
+  end
+
+  it "renders only the work module when blurb is false" do
+    view_context = WorkBlurbPresenterViewContext.new
+
+    described_class.new(revealed_work, blurb: false).render_in(view_context)
+
+    expect(view_context.renders).to eq([
+      ["works/work_module", { work: revealed_work }]
+    ])
+  end
+
+  it "uses the mystery blurb for unrevealed works the viewer does not own" do
+    view_context = WorkBlurbPresenterViewContext.new
+
+    described_class.new(unrevealed_work).render_in(view_context)
+
+    expect(view_context.renders.first).to eq([
+      "works/mystery_blurb",
+      { work: unrevealed_work }
+    ])
+  end
+
+  it "uses the full work module for unrevealed works the viewer owns" do
+    view_context = WorkBlurbPresenterViewContext.new(owned_works: [unrevealed_work])
+
+    described_class.new(unrevealed_work).render_in(view_context)
+
+    expect(view_context.renders.first).to eq([
+      "works/work_module",
+      { work: unrevealed_work }
+    ])
+  end
+
+  it "uses the full work module when forced to reveal" do
+    view_context = WorkBlurbPresenterViewContext.new
+
+    described_class.new(unrevealed_work, force_reveal: true).render_in(view_context)
+
+    expect(view_context.renders.first).to eq([
+      "works/work_module",
+      { work: unrevealed_work }
+    ])
+  end
+
+  it "renders each work in a collection" do
+    view_context = WorkBlurbPresenterViewContext.new
+
+    described_class.new([revealed_work, unrevealed_work]).render_in(view_context)
+
+    expect(view_context.renders.map(&:first)).to eq([
+      "works/work_module",
+      "works/work_blurb",
+      "works/mystery_blurb",
+      "works/work_blurb"
+    ])
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7457

## Purpose

My end goal is to cache work blurbs, and to fetch them all in a single `MGET` for all relevant work blurbs.

In order to do this, we need a single place where we can make all the following decisions:

1. For each work, will we display the mystery or the full module?
2. Are we going to include the blurb "chrome" or not?
3. How many works are there?

The end goal is something that will look like:

```
render: WorkBlurbPresenter.new(@works), cached: true
```

... and that will Just Work, resulting in a single MGET cache call. 

We can't do this _without_ this presenter, primarily because of the mystery/non-mystery module distinction, which needs to be calculated on a per-work basis.

I also think this cleans up the code quite nicely:

1. The special case re: an admin viewing a users Works in Collections page is now taken care of _on that page_ rather than in the partial.
2. A number of places where we weren't using `collection:` options got cleaned up 
3. The logic on when a mystery blurb is appropriate is extracted to the presenter and much easier to read
4. A lot of that logic can now be tested in spec/presenters/work_blurb_presenter_spec.rb.

## References

* [Full Speedshop perf audit](https://www.speedshop.co/blog/performance-lessons-from-ao3/)