### PR TITLE
AO3-4412 Resolving N+1 issues when loading inbox comments on the homepage

### DIFF
--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -37,19 +37,16 @@ class InboxComment < ApplicationRecord
 
   # Remove comments that do not exist, were flagged as spam, or hidden by admin
   def self.with_bad_comments_removed
-    includes(
-      feedback_comment: [
-        { pseud: [
-          { user: %i[roles block_of_current_user] },
-          { icon_attachment: { blob: {
-            variant_records: { image_attachment: :blob },
-            preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
-          } } }
-        ] },
-        { parent: { work: { users: :block_of_current_user } } }
-      ]
-    )
-      .joins("LEFT JOIN comments ON comments.id = inbox_comments.feedback_comment_id")
+    joins("LEFT JOIN comments ON comments.id = inbox_comments.feedback_comment_id")
       .where("comments.id IS NOT NULL AND comments.is_deleted = 0 AND comments.approved AND NOT comments.hidden_by_admin")
+      .includes(
+        feedback_comment: [
+          { pseud: [
+            { user: %i[roles block_of_current_user] },
+            *Pseud.with_attached_icon.includes_values
+          ] },
+          { parent: { work: { users: :block_of_current_user } } }
+        ]
+      )
   end
 end

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -37,7 +37,19 @@ class InboxComment < ApplicationRecord
 
   # Remove comments that do not exist, were flagged as spam, or hidden by admin
   def self.with_bad_comments_removed
-    joins("LEFT JOIN comments ON comments.id = inbox_comments.feedback_comment_id")
+    includes(
+      feedback_comment: [
+        { pseud: [
+          { user: %i[roles block_of_current_user] },
+          { icon_attachment: { blob: {
+              variant_records: { image_attachment: :blob },
+              preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
+            } } }
+        ] },
+        { parent: { work: { users: :block_of_current_user } } }
+      ]
+    )
+      .joins("LEFT JOIN comments ON comments.id = inbox_comments.feedback_comment_id")
       .where("comments.id IS NOT NULL AND comments.is_deleted = 0 AND comments.approved AND NOT comments.hidden_by_admin")
   end
 end

--- a/app/models/inbox_comment.rb
+++ b/app/models/inbox_comment.rb
@@ -42,9 +42,9 @@ class InboxComment < ApplicationRecord
         { pseud: [
           { user: %i[roles block_of_current_user] },
           { icon_attachment: { blob: {
-              variant_records: { image_attachment: :blob },
-              preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
-            } } }
+            variant_records: { image_attachment: :blob },
+            preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
+          } } }
         ] },
         { parent: { work: { users: :block_of_current_user } } }
       ]

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -9,7 +9,7 @@ describe "n+1 queries in the inbox controller for the homepage" do
 
       subject do
         proc do
-          get '/'
+          get "/"
         end
       end
 

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe "n+1 queries in the inbox controller for the homepage" do
+  include LoginMacros
+
+  describe "#index", n_plus_one: true do
+    context "when displaying a user's unread messages on the homepage" do
+      let!(:user) { create(:user) }
+
+      subject do
+        proc do
+          get '/'
+        end
+      end
+
+      before do
+        fake_login_known_user(user)
+      end
+
+      context "when all works are cached" do
+        populate do |n|
+          create_list(:inbox_comment, n)
+          subject.call # this caches the comments
+        end
+
+        it "produces a constant number of queries" do
+          expect { subject.call }
+            .to perform_constant_number_of_queries
+        end
+      end
+
+      context "when nothing is cached" do
+        populate do |n|
+          create_list(:inbox_comment, n)
+        end
+
+        it "performs around 9 queries per message" do
+          # TODO: Ideally, we'd like the uncached inbox listings to also have a
+          # constant number of queries, instead of the linear number of queries
+          # we're checking for here. But we also don't want to put too much
+          # unnecessary load on the databases when we have a bunch of cache hits,
+          # so this requires some care & tuning.
+          expect { subject.call }
+            .to perform_linear_number_of_queries(slope: 9).with_warming_up
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -11,7 +11,7 @@ describe "n+1 queries in the inbox controller for the homepage: " do
         before { fake_login_known_user(user) }
 
         populate do |n|
-          create_list(:inbox_comment, n, user: user, feedback_comment: build_feedback_comment.call)
+          n.times { create(:inbox_comment, user: user, feedback_comment: build_feedback_comment.call) }
         end
 
         warmup { get root_path }

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "n+1 queries in the inbox controller for the homepage: " do
+describe "n+1 queries in the inbox module on the homepage: " do
   include LoginMacros
 
   describe "#show", n_plus_one: true do

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -1,48 +1,49 @@
 require "spec_helper"
 
-describe "n+1 queries in the inbox controller for the homepage" do
+describe "n+1 queries in the inbox controller for the homepage: " do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
-    context "when displaying a user's unread messages on the homepage" do
+  describe "#show", n_plus_one: true do
+    context "displaying a user's unread messages on the homepage" do
       let!(:user) { create(:user) }
 
-      subject do
-        proc do
-          get "/"
-        end
-      end
+      shared_examples "a constant number of queries" do
+        before { fake_login_known_user(user) }
 
-      before do
-        fake_login_known_user(user)
-      end
-
-      context "when all works are cached" do
         populate do |n|
-          create_list(:inbox_comment, n)
-          subject.call # this caches the comments
+          create_list(:inbox_comment, n, user: user, feedback_comment: build_feedback_comment.call)
+        end
+
+        warmup { get "/" }
+
+        it "displys the right number of comments" do
+          get "/"
+          expect(response.body.scan('id="feedback_comment_').size).to eq(current_scale.to_i)
         end
 
         it "produces a constant number of queries" do
-          expect { subject.call }
-            .to perform_constant_number_of_queries
+          expect do
+            get "/"
+          end.to perform_constant_number_of_queries
         end
       end
 
-      context "when nothing is cached" do
-        populate do |n|
-          create_list(:inbox_comment, n)
-        end
+      context "with comments from registered users" do
+        let(:build_feedback_comment) { -> { create(:comment) } }
 
-        it "performs around 9 queries per message" do
-          # TODO: Ideally, we'd like the uncached inbox listings to also have a
-          # constant number of queries, instead of the linear number of queries
-          # we're checking for here. But we also don't want to put too much
-          # unnecessary load on the databases when we have a bunch of cache hits,
-          # so this requires some care & tuning.
-          expect { subject.call }
-            .to perform_linear_number_of_queries(slope: 9).with_warming_up
-        end
+        it_behaves_like "a constant number of queries"
+      end
+
+      context "with comments from guests" do
+        let(:build_feedback_comment) { -> { create(:comment, :by_guest) } }
+
+        it_behaves_like "a constant number of queries"
+      end
+
+      context "with reply comments" do
+        let(:build_feedback_comment) { -> { create(:comment, commentable: create(:comment)) } }
+
+        it_behaves_like "a constant number of queries"
       end
     end
   end

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -14,16 +14,12 @@ describe "n+1 queries in the inbox controller for the homepage: " do
           create_list(:inbox_comment, n, user: user, feedback_comment: build_feedback_comment.call)
         end
 
-        warmup { get "/" }
-
-        it "displys the right number of comments" do
-          get "/"
-          expect(response.body.scan('id="feedback_comment_').size).to eq(current_scale.to_i)
-        end
+        warmup { get root_path }
 
         it "produces a constant number of queries" do
           expect do
-            get "/"
+            get root_path
+            expect(response.body.scan('id="feedback_comment_').size).to eq(current_scale.to_i)
           end.to perform_constant_number_of_queries
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4412

## Purpose

There fixes an issue where there were N+1 database queries when loading inbox comments on the homepage.

## Testing Instructions

Testing is all automated. 

Note: the line numbers in the Jira issue no longer point to the relevant lines, as they have moved from commits in the intervening years.

## Credit

FlyingFalcon they/them

[AO3-4380]: https://otwarchive.atlassian.net/browse/AO3-4380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ