### PR TITLE
AO3-7520 AO3-7521 Fix page title when previewing admin posts

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -45,6 +45,8 @@ class AdminPostsController < Admin::BaseController
     @preview_mode = true
     @admin_post = AdminPost.find(params[:id])
     authorize(@admin_post)
+    
+    @page_subtitle = t(".page_title", title: @admin_post.title.html_safe)
   end
 
   # GET /admin_posts/new
@@ -69,6 +71,7 @@ class AdminPostsController < Admin::BaseController
     if !params[:edit_button] && @admin_post.valid?
       if params[:preview_button]
         @preview_mode = true
+        @page_subtitle = t("admin_posts.preview.page_title", title: @admin_post.title.html_safe)
         render action: "preview" and return
       elsif !params[:edit_button] && @admin_post.save
         flash[:notice] = t(".success")
@@ -89,6 +92,7 @@ class AdminPostsController < Admin::BaseController
     if !params[:edit_button] && @admin_post.valid?
       if params[:preview_button]
         @preview_mode = true
+         @page_subtitle = t("admin_posts.preview.page_title", title: @admin_post.title.html_safe)
         render :preview and return
       elsif @admin_post.save
         flash[:notice] = t(".success")

--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -92,7 +92,7 @@ class AdminPostsController < Admin::BaseController
     if !params[:edit_button] && @admin_post.valid?
       if params[:preview_button]
         @preview_mode = true
-         @page_subtitle = t("admin_posts.preview.page_title", title: @admin_post.title.html_safe)
+        @page_subtitle = t("admin_posts.preview.page_title", title: @admin_post.title.html_safe)
         render :preview and return
       elsif @admin_post.save
         flash[:notice] = t(".success")

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -95,6 +95,8 @@ en:
     post:
       error: Sorry, that Admin Post could not be posted.
       success: Admin Post was successfully posted.
+    preview:
+      page_title: "%{title} (Preview)"
     show:
       page_title_draft: "%{title} (Draft)"
     update:


### PR DESCRIPTION
## Issue

[https://otwarchive.atlassian.net/browse/AO3-7520](https://otwarchive.atlassian.net/browse/AO3-7520)
[https://otwarchive.atlassian.net/browse/AO3-7521](https://otwarchive.atlassian.net/browse/AO3-7521)

## Purpose

Fix the page title when previewing an Admin Post from the create or edit form.


## Credit

Name: [Anastasia095](https://github.com/Anastasia095/Anastasia095)
Pronouns: [She/Her]
