### PR TITLE
AO3-6444 Don't store support ticket info in database, and reduce amount of abuse report info stored

### DIFF
--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -16,12 +16,16 @@ class AbuseReportsController < ApplicationController
     @abuse_report.ip_address = request.remote_ip
     @abuse_report.user_agent = request.env["HTTP_USER_AGENT"].presence&.to(499)
     if @abuse_report.save
-      @abuse_report.email_and_send
-      flash[:notice] = ts("Your report was submitted to the Policy & Abuse team. A confirmation message has been sent to the email address you provided.")
-      redirect_to root_path
-    else
-      render action: "new"
+      if @abuse_report.email_and_send
+        flash[:notice] = t(".success")
+        redirect_to root_path
+        return
+      else
+        flash[:error] = t(".failure_send")
+        @abuse_report.destroy # avoid contributing to reporting limits
+      end
     end
+    render action: "new"
   end
 
   private

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -22,16 +22,16 @@ class FeedbacksController < ApplicationController
     @feedback.ip_address = request.remote_ip
     @feedback.referer = nil unless @feedback.referer && ArchiveConfig.PERMITTED_HOSTS.include?(URI(@feedback.referer).host)
     @feedback.site_skin = helpers.current_skin
-    if @feedback.save
-      @feedback.email_and_send
-      flash[:notice] = t("successfully_sent",
-        default: "Your message was sent to the Archive team - thank you!")
-      redirect_to(url_from(@feedback.referer) || root_path)
-    else
-      flash[:error] = t("failure_send",
-        default: "Sorry, your message could not be saved - please try again!")
-      render action: "new"
+    if @feedback.valid?
+      if @feedback.email_and_send
+        flash[:notice] = t(".successfully_sent")
+        redirect_to(url_from(@feedback.referer) || root_path)
+        return
+      else
+        flash[:error] = t(".failure_send")
+      end
     end
+    render action: "new"
   end
 
   private

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -349,17 +349,16 @@ class UserMailer < ApplicationMailer
   ### OTHER NOTIFICATIONS ###
 
   # archive feedback
-  def feedback(feedback_id)
-    feedback = Feedback.find(feedback_id)
-    return unless feedback.email
+  def feedback(feedback)
+    return unless feedback[:email]
 
-    @summary = feedback.summary
-    @comment = feedback.comment
-    @username = feedback.username if feedback.username.present?
-    @language = feedback.language
+    @summary = feedback[:summary]
+    @comment = feedback[:comment]
+    @username = feedback[:username] if feedback[:username].present?
+    @language = feedback[:language]
     mail(
-      to: feedback.email,
-      subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, summary: strip_html_breaks_simple(feedback.summary))
+      to: feedback[:email],
+      subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, summary: strip_html_breaks_simple(@summary))
     )
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -362,16 +362,15 @@ class UserMailer < ApplicationMailer
     )
   end
 
-  def abuse_report(abuse_report_id)
-    abuse_report = AbuseReport.find(abuse_report_id)
-    @username = abuse_report.username
-    @email = abuse_report.email
-    @url = abuse_report.url
-    @summary = abuse_report.summary
-    @comment = abuse_report.comment
+  def abuse_report(abuse_report)
+    @username = abuse_report[:username]
+    @email = abuse_report[:email]
+    @url = abuse_report[:url]
+    @summary = abuse_report[:summary]
+    @comment = abuse_report[:comment]
     mail(
-      to: abuse_report.email,
-      subject: t("user_mailer.abuse_report.subject", app_name: ArchiveConfig.APP_SHORT_NAME, summary: strip_html_breaks_simple(@summary))
+      to: abuse_report[:email],
+      subject: default_i18n_subject(app_name: ArchiveConfig.APP_SHORT_NAME, summary: strip_html_breaks_simple(@summary))
     )
   end
 end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -284,12 +284,7 @@ class AbuseReport < ApplicationRecord
 
   # run daily with resque scheduler
   def self.delete_old_report_records
-    AbuseReport.where(created_at: ..[ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD,
-                                     ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD,
-                                     ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD,
-                                     ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD,
-                                     ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD,
-                                     1].max.days.ago).delete_all
+    AbuseReport.where(created_at: ..ArchiveConfig.ABUSE_REPORTS_RETENTION_PERIOD.days.ago).delete_all
   end
 
   private

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -1,4 +1,6 @@
 class AbuseReport < ApplicationRecord
+  attr_accessor :comment, :summary, :language, :username, :user_agent
+
   validates :email, email_format: { allow_blank: false }
   validates_presence_of :language
   validates_presence_of :summary
@@ -12,11 +14,6 @@ class AbuseReport < ApplicationRecord
                                 max: ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED)
 
   before_validation :truncate_url, if: :will_save_change_to_url?
-
-  # It doesn't have the type set properly in the database, so override it here:
-  attribute :summary_sanitizer_version, :integer, default: 0
-
-  attr_accessor :user_agent
 
   # Truncates the user-provided URL to the maximum we can store in the database. We don't want to reject reports with very long URLs, but we need to do
   # something to avoid a 500 error for long URLs.
@@ -46,6 +43,16 @@ class AbuseReport < ApplicationRecord
       comment_author: name,
       comment_author_email: email,
       comment_content: comment
+    }
+  end
+
+  def mailer_attributes
+    {
+      email: email,
+      username: username,
+      url: url,
+      summary: summary,
+      comment: comment
     }
   end
 
@@ -116,12 +123,15 @@ class AbuseReport < ApplicationRecord
   end
 
   def email_and_send
-    UserMailer.abuse_report(id).deliver_later
-    send_report
+    if self.send_report
+      UserMailer.abuse_report(self.mailer_attributes).deliver_later
+      return true
+    end
+    false
   end
 
   def send_report
-    return unless zoho_enabled?
+    return true unless zoho_enabled?
 
     reporter = AbuseReporter.new(
       title: summary,
@@ -136,9 +146,10 @@ class AbuseReport < ApplicationRecord
     )
     response = reporter.send_report!
     ticket_id = response["id"]
-    return if ticket_id.blank?
+    return false if ticket_id.blank?
 
     attach_work_download(ticket_id)
+    true
   end
 
   def creator_ids
@@ -269,6 +280,16 @@ class AbuseReport < ApplicationRecord
                           volunteers from being overwhelmed, please do not seek
                           out violations to report, but only report violations you
                           encounter during your normal browsing."))
+  end
+
+  # run daily with resque scheduler
+  def self.delete_old_report_records
+    AbuseReport.where(created_at: ..[ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD,
+                                     ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD,
+                                     ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD,
+                                     ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD,
+                                     ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD,
+                                     1].max.days.ago).delete_all
   end
 
   private

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,10 @@
 # Class which holds feedback sent to the archive administrators about the archive as a whole
-class Feedback < ApplicationRecord
-  attr_accessor :ip_address, :referer, :site_skin
+class Feedback
+  include ActiveModel::Model
+
+  attr_accessor :summary, :comment, :language,
+                :email, :username, :user_agent, :ip_address,
+                :referer, :site_skin, :rollout
 
   # NOTE: this has NOTHING to do with the Comment class!
   # This is just the name of the text field in the Feedback
@@ -9,13 +13,14 @@ class Feedback < ApplicationRecord
   validates_presence_of :summary
   validates_presence_of :language
   validates :email, email_format: { allow_blank: false }
-  validates_length_of :summary, maximum: ArchiveConfig.FEEDBACK_SUMMARY_MAX,
-    too_long: ts("must be less than %{max} characters long.", max: ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED)
+  # i18n-tasks-use t("activemodel.errors.models.feedback.attributes.summary.too_long")
+  validates :summary, length: { maximum: ArchiveConfig.FEEDBACK_SUMMARY_MAX,
+                                too_long: :too_long, max_displayed: ArchiveConfig.FEEDBACK_SUMMARY_MAX_DISPLAYED }
 
-  validate :check_for_spam
+  validate :check_for_spam, unless: :logged_in_with_matching_email?
   def check_for_spam
-    approved = logged_in_with_matching_email? || !AkismetClient.spam?(akismet_attributes)
-    errors.add(:base, ts("This report looks like spam to our system!")) unless approved
+    # i18n-tasks-use t("activemodel.errors.models.feedback.attributes.base.spam")
+    errors.add(:base, :spam) if AkismetClient.spam?(akismet_attributes)
   end
 
   def logged_in_with_matching_email?
@@ -36,17 +41,22 @@ class Feedback < ApplicationRecord
     }
   end
 
-  def mark_as_spam!
-    AkismetClient.submit_spam(akismet_attributes)
-  end
-
-  def mark_as_ham!
-    AkismetClient.submit_ham(akismet_attributes)
+  def mailer_attributes
+    {
+      email: email,
+      summary: summary,
+      comment: comment,
+      username: username,
+      language: language
+    }
   end
 
   def email_and_send
-    UserMailer.feedback(id).deliver_later
-    send_report
+    if self.send_report
+      UserMailer.feedback(self.mailer_attributes).deliver_later
+      return true
+    end
+    false
   end
 
   def rollout_string
@@ -61,7 +71,7 @@ class Feedback < ApplicationRecord
   end
 
   def send_report
-    return unless zoho_enabled?
+    return true unless zoho_enabled?
 
     reporter = SupportReporter.new(
       title: summary,
@@ -76,7 +86,7 @@ class Feedback < ApplicationRecord
       referer: referer,
       site_skin: site_skin
     )
-    reporter.send_report!
+    reporter.send_report!&.dig("id").present?
   end
 
   private

--- a/config/config.yml
+++ b/config/config.yml
@@ -167,6 +167,9 @@ IMPORT_MAX_WORKS: 25
 IMPORT_MAX_CHAPTERS: 200
 IMPORT_MAX_WORKS_BY_ARCHIVIST: 200
 
+# time period, in days, to keep abuse report records before deleting them
+# must be greater than the ABUSE_REPORTS_PER_*_PERIOD options below
+ABUSE_REPORTS_RETENTION_PERIOD: 550
 # max number of abuse reports to accept for a given user profile URL
 ABUSE_REPORTS_PER_USER_MAX: 5
 # time period, in days, used to total number of reports for a given user URL

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -235,6 +235,10 @@ en:
     index:
       choose_media: Please choose a media category to start browsing fandoms.
       collection_page_title: "%{collection_title} - Fandoms"
+  feedbacks:
+    create:
+      failure_send: Sorry, your message could not be sent - please try again later.
+      successfully_sent: Your message was sent to the Archive team - thank you!
   gifts:
     index:
       page_subtitle: "%{name} - Gifts"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  abuse_reports:
+    create:
+      failure_send: Sorry, your report could not be submitted. Please try again later.
+      success: Your report was submitted to the Policy & Abuse team. A confirmation message has been sent to the email address you provided.
   admin:
     access:
       action_access_denied: Sorry, only an authorized admin can do that.

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -1,5 +1,14 @@
 ---
 en:
+  activemodel:
+    errors:
+      models:
+        feedback:
+          attributes:
+            base:
+              spam: This report looks like spam to our system!
+            summary:
+              too_long: must be less than %{max_displayed} characters long.
   activerecord:
     attributes:
       admin/role:

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -122,3 +122,12 @@ disable_admin_post_comments:
   description: >-
     Disables all comments on admin (news) posts older than the
     configured window.
+
+delete_old_abuse_report_records:
+  every: 1d
+  class: "AbuseReport"
+  queue: utilities
+  args: delete_old_report_records
+  description: >-
+    Deletes abuse report records that are no longer needed for
+    rate limiting.

--- a/db/migrate/20260626223058_drop_feedbacks_table.rb
+++ b/db/migrate/20260626223058_drop_feedbacks_table.rb
@@ -1,0 +1,20 @@
+class DropFeedbacksTable < ActiveRecord::Migration[8.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    drop_table :feedbacks do |t|
+      t.text "comment", null: false
+      t.string "email"
+      t.string "summary"
+      t.string "user_agent", limit: 500
+      t.string "category"
+      t.integer "comment_sanitizer_version", limit: 2, default: 0, null: false
+      t.integer "summary_sanitizer_version", limit: 2, default: 0, null: false
+      t.string "username"
+      t.string "language"
+      t.string "rollout"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260626231022_remove_content_from_abuse_reports.rb
+++ b/db/migrate/20260626231022_remove_content_from_abuse_reports.rb
@@ -1,0 +1,15 @@
+class RemoveContentFromAbuseReports < ActiveRecord::Migration[8.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    change_table :abuse_reports do |t|
+      t.remove :comment, type: :text, null: false
+      t.remove :updated_at, type: :datetime, precision: nil
+      t.remove :comment_sanitizer_version, type: :integer, limit: 2, default: 0, null: false
+      t.remove :summary, type: :string
+      t.remove :summary_sanitizer_version, type: :integer, limit: 2, default: 0, null: false
+      t.remove :language, type: :string
+      t.remove :username, type: :string
+    end
+  end
+end

--- a/lib/tasks/resanitize.rake
+++ b/lib/tasks/resanitize.rake
@@ -2,7 +2,6 @@ namespace :resanitize do
   desc "Re-run the sanitizer on all fields."
   task(all: :environment) do
     [
-      AbuseReport,
       AdminActivity,
       AdminBanner,
       AdminPost,

--- a/lib/tasks/resanitize.rake
+++ b/lib/tasks/resanitize.rake
@@ -13,7 +13,6 @@ namespace :resanitize do
       CollectionProfile,
       Comment,
       ExternalWork,
-      Feedback,
       GiftExchange,
       KnownIssue,
       OwnedTagSet,

--- a/spec/controllers/abuse_reports_controller_spec.rb
+++ b/spec/controllers/abuse_reports_controller_spec.rb
@@ -6,6 +6,9 @@ describe AbuseReportsController do
   include LoginMacros
 
   describe "POST #create" do
+    success_response = { headers: { content_type: "application/json" }, body: '{"data":[{"id":"1"}]}' }.freeze
+    failure_response = { status: 400, headers: { content_type: "application/json" }, body: "{}" }.freeze
+
     let(:mock_zoho) { instance_double(ZohoResourceClient) }
 
     let(:default_parameters) do
@@ -30,7 +33,7 @@ describe AbuseReportsController do
     it "specifies a channel" do
       expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
         "channel" => "Abuse Form"
-      )).and_return({})
+      )).and_return(success_response)
       post :create, params: default_parameters
     end
 
@@ -45,7 +48,7 @@ describe AbuseReportsController do
           "cf" => include(
             "cf_user_agent" => user_agent.to(499)
           )
-        )).and_return({})
+        )).and_return(success_response)
         post :create, params: default_parameters
       end
     end
@@ -60,8 +63,27 @@ describe AbuseReportsController do
           "cf" => include(
             "cf_user_agent" => "Unknown user agent"
           )
-        )).and_return({})
+        )).and_return(success_response)
         post :create, params: default_parameters
+      end
+    end
+
+    context "when the abuse report is invalid" do
+      it "renders the new template with an error message" do
+        post :create, params: default_parameters.deep_merge(abuse_report: { email: "not an email" })
+        expect(response).to render_template(:new)
+        expect(assigns[:abuse_report].errors.full_messages).to include("Email should look like an email address.")
+      end
+    end
+
+    context "when Zoho does not accept the ticket" do
+      it "renders the new template with an error message" do
+        expect(mock_zoho).to receive(:create_ticket).and_return(failure_response)
+
+        post :create, params: default_parameters
+
+        expect(response).to render_template(:new)
+        expect(flash[:error]).to include("Sorry, your report could not be submitted. Please try again later.")
       end
     end
   end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -6,6 +6,9 @@ describe FeedbacksController do
   include LoginMacros
 
   describe "POST #create" do
+    success_response = { headers: { content_type: "application/json" }, body: '{"data":[{"id":"1"}]}' }.freeze
+    failure_response = { status: 400, headers: { content_type: "application/json" }, body: "{}" }.freeze
+
     let(:mock_zoho) { instance_double(ZohoResourceClient) }
 
     let(:default_parameters) do
@@ -28,7 +31,7 @@ describe FeedbacksController do
     it "specifies a channel" do
       expect(mock_zoho).to receive(:create_ticket).with(ticket_attributes: include(
         "channel" => "Support Form"
-      ))
+      )).and_return(success_response)
       post :create, params: default_parameters
     end
 
@@ -51,7 +54,7 @@ describe FeedbacksController do
             "cf" => include(
               "cf_site_skin" => Skin.default.title
             )
-          ))
+          )).and_return(success_response)
           post :create, params: default_parameters
         end
       end
@@ -68,7 +71,8 @@ describe FeedbacksController do
             "cf" => include(
               "cf_site_skin" => skin.title
             )
-          ))
+          )).and_return(success_response)
+
           post :create, params: default_parameters
         end
       end
@@ -85,7 +89,8 @@ describe FeedbacksController do
             "cf" => include(
               "cf_site_skin" => "Custom skin"
             )
-          ))
+          )).and_return(success_response)
+
           post :create, params: default_parameters
         end
       end
@@ -102,7 +107,8 @@ describe FeedbacksController do
           "cf" => include(
             "cf_user_agent" => user_agent.to(499)
           )
-        ))
+        )).and_return(success_response)
+
         post :create, params: default_parameters
         expect(assigns[:feedback].user_agent.length).to eq(500)
       end
@@ -118,9 +124,29 @@ describe FeedbacksController do
           "cf" => include(
             "cf_user_agent" => "Unknown user agent"
           )
-        ))
+        )).and_return(success_response)
+
         post :create, params: default_parameters
         expect(assigns[:feedback].user_agent).to be_nil
+      end
+    end
+
+    context "when the feedback is invalid" do
+      it "renders the new template with an error message" do
+        post :create, params: default_parameters.deep_merge(feedback: { email: "not an email" })
+        expect(response).to render_template(:new)
+        expect(assigns[:feedback].errors.full_messages).to include("Email should look like an email address.")
+      end
+    end
+
+    context "when Zoho does not accept the ticket" do
+      it "renders the new template with an error message" do
+        expect(mock_zoho).to receive(:create_ticket).and_return(failure_response)
+
+        post :create, params: default_parameters
+
+        expect(response).to render_template(:new)
+        expect(flash[:error]).to include("Sorry, your message could not be sent - please try again later")
       end
     end
   end

--- a/spec/lib/tasks/resanitize.rake_spec.rb
+++ b/spec/lib/tasks/resanitize.rake_spec.rb
@@ -39,7 +39,6 @@ describe "rake resanitize:all" do
   end
 
   {
-    abuse_report: [:summary, :comment],
     admin_activity: [:summary],
     admin_banner: [:content],
     admin_post: [:content],

--- a/spec/lib/tasks/resanitize.rake_spec.rb
+++ b/spec/lib/tasks/resanitize.rake_spec.rb
@@ -49,7 +49,6 @@ describe "rake resanitize:all" do
     collection_profile: [:intro, :faq, :rules],
     comment: [:comment_content],
     external_work: [:summary],
-    feedback: [:summary, :comment],
     gift_exchange: [:signup_instructions_general,
                     :signup_instructions_requests,
                     :signup_instructions_offers],

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -880,9 +880,9 @@ describe UserMailer do
 
   describe "feedback" do
     context "when username is present" do
-      subject(:email) { UserMailer.feedback(feedback.id) }
+      subject(:email) { UserMailer.feedback(feedback.mailer_attributes) }
 
-      let(:feedback) { create(:feedback) }
+      let(:feedback) { build(:feedback) }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"
@@ -912,9 +912,9 @@ describe UserMailer do
     end
 
     context "when username is not present" do
-      subject(:email) { UserMailer.feedback(feedback.id) }
+      subject(:email) { UserMailer.feedback(feedback.mailer_attributes) }
 
-      let(:feedback) { create(:feedback, username: "A. Name") }
+      let(:feedback) { build(:feedback, username: "A. Name") }
 
       # Test the headers
       it_behaves_like "an email with a valid sender"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -829,7 +829,7 @@ describe UserMailer do
 
   describe "abuse_report" do
     let(:report) { create(:abuse_report) }
-    let(:email) { UserMailer.abuse_report(report.id) }
+    let(:email) { UserMailer.abuse_report(report.mailer_attributes) }
 
     it "has the correct subject" do
       expect(email).to have_subject "[#{ArchiveConfig.APP_SHORT_NAME}] Abuse - #{report.summary}"

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -1129,8 +1129,8 @@ describe AbuseReport do
 
       expect([AbuseReport.exists?(old_comment_report), AbuseReport.exists?(old_bookmark_report),
               AbuseReport.exists?(old_user_report), AbuseReport.exists?(old_work_report),
-              AbuseReport.exists?(old_series_report), AbuseReport.exists?(old_report)]
-            ).to include(false)
+              AbuseReport.exists?(old_series_report), AbuseReport.exists?(old_report)])
+        .to include(false)
     end
 
     it "does not delete any reports that could still be used for rate limiting" do

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -1104,4 +1104,44 @@ describe AbuseReport do
       end
     end
   end
+
+  describe "#delete_old_report_records" do
+    let!(:old_comment_report) { create(:abuse_report, url: "https://archiveofourown.org/comments/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD.days.ago).id }
+    let!(:old_bookmark_report) { create(:abuse_report, url: "https://archiveofourown.org/bookmarks/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD.days.ago).id }
+    let!(:old_user_report) { create(:abuse_report, url: "https://archiveofourown.org/users/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD.days.ago).id }
+    let!(:old_work_report) { create(:abuse_report, url: "https://archiveofourown.org/works/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD.days.ago).id }
+    let!(:old_series_report) { create(:abuse_report, url: "https://archiveofourown.org/series/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD.days.ago).id }
+    let!(:old_report) { create(:abuse_report, url: "https://archiveofourown.org/for_email_based_ratelimiting", created_at: 1.day.ago).id }
+
+    let!(:recent_comment_report) { create(:abuse_report, url: "https://archiveofourown.org/comments/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_bookmark_report) { create(:abuse_report, url: "https://archiveofourown.org/bookmarks/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_user_report) { create(:abuse_report, url: "https://archiveofourown.org/users/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_work_report) { create(:abuse_report, url: "https://archiveofourown.org/works/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_series_report) { create(:abuse_report, url: "https://archiveofourown.org/series/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_report) { create(:abuse_report, url: "https://archiveofourown.org/for_email_based_ratelimiting", created_at: 1.day.ago + 1.minute).id }
+
+    before do
+      freeze_time
+    end
+
+    it "deletes reports outside of all rate limiting periods" do
+      AbuseReport.delete_old_report_records
+
+      expect([AbuseReport.exists?(old_comment_report), AbuseReport.exists?(old_bookmark_report),
+              AbuseReport.exists?(old_user_report), AbuseReport.exists?(old_work_report),
+              AbuseReport.exists?(old_series_report), AbuseReport.exists?(old_report)]
+            ).to include(false)
+    end
+
+    it "does not delete any reports that could still be used for rate limiting" do
+      AbuseReport.delete_old_report_records
+
+      expect(AbuseReport.exists?(recent_comment_report)).to be_truthy
+      expect(AbuseReport.exists?(recent_bookmark_report)).to be_truthy
+      expect(AbuseReport.exists?(recent_user_report)).to be_truthy
+      expect(AbuseReport.exists?(recent_work_report)).to be_truthy
+      expect(AbuseReport.exists?(recent_series_report)).to be_truthy
+      expect(AbuseReport.exists?(recent_report)).to be_truthy
+    end
+  end
 end

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -1106,41 +1106,24 @@ describe AbuseReport do
   end
 
   describe "#delete_old_report_records" do
-    let!(:old_comment_report) { create(:abuse_report, url: "https://archiveofourown.org/comments/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD.days.ago).id }
-    let!(:old_bookmark_report) { create(:abuse_report, url: "https://archiveofourown.org/bookmarks/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD.days.ago).id }
-    let!(:old_user_report) { create(:abuse_report, url: "https://archiveofourown.org/users/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD.days.ago).id }
-    let!(:old_work_report) { create(:abuse_report, url: "https://archiveofourown.org/works/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD.days.ago).id }
-    let!(:old_series_report) { create(:abuse_report, url: "https://archiveofourown.org/series/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD.days.ago).id }
-    let!(:old_report) { create(:abuse_report, url: "https://archiveofourown.org/for_email_based_ratelimiting", created_at: 1.day.ago).id }
-
-    let!(:recent_comment_report) { create(:abuse_report, url: "https://archiveofourown.org/comments/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_COMMENT_PERIOD.days.ago + 1.minute).id }
-    let!(:recent_bookmark_report) { create(:abuse_report, url: "https://archiveofourown.org/bookmarks/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_BOOKMARK_PERIOD.days.ago + 1.minute).id }
-    let!(:recent_user_report) { create(:abuse_report, url: "https://archiveofourown.org/users/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_USER_PERIOD.days.ago + 1.minute).id }
-    let!(:recent_work_report) { create(:abuse_report, url: "https://archiveofourown.org/works/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_WORK_PERIOD.days.ago + 1.minute).id }
-    let!(:recent_series_report) { create(:abuse_report, url: "https://archiveofourown.org/series/123", created_at: ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD.days.ago + 1.minute).id }
-    let!(:recent_report) { create(:abuse_report, url: "https://archiveofourown.org/for_email_based_ratelimiting", created_at: 1.day.ago + 1.minute).id }
+    let!(:expired_report) { create(:abuse_report, created_at: ArchiveConfig.ABUSE_REPORTS_RETENTION_PERIOD.days.ago).id }
+    let!(:old_report) { create(:abuse_report, created_at: ArchiveConfig.ABUSE_REPORTS_RETENTION_PERIOD.days.ago + 1.minute).id }
+    let!(:recent_report) { create(:abuse_report).id }
 
     before do
       freeze_time
     end
 
-    it "deletes reports outside of all rate limiting periods" do
+    it "deletes reports outside the retention period" do
       AbuseReport.delete_old_report_records
 
-      expect([AbuseReport.exists?(old_comment_report), AbuseReport.exists?(old_bookmark_report),
-              AbuseReport.exists?(old_user_report), AbuseReport.exists?(old_work_report),
-              AbuseReport.exists?(old_series_report), AbuseReport.exists?(old_report)])
-        .to include(false)
+      expect(AbuseReport.exists?(expired_report)).to be_falsy
     end
 
     it "does not delete any reports that could still be used for rate limiting" do
       AbuseReport.delete_old_report_records
 
-      expect(AbuseReport.exists?(recent_comment_report)).to be_truthy
-      expect(AbuseReport.exists?(recent_bookmark_report)).to be_truthy
-      expect(AbuseReport.exists?(recent_user_report)).to be_truthy
-      expect(AbuseReport.exists?(recent_work_report)).to be_truthy
-      expect(AbuseReport.exists?(recent_series_report)).to be_truthy
+      expect(AbuseReport.exists?(old_report)).to be_truthy
       expect(AbuseReport.exists?(recent_report)).to be_truthy
     end
   end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Feedback do
+  include ActiveJob::TestHelper
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::TestAdapter.new
+  end
+
   context "when report is not spam" do
     context "valid reports" do
       it "is valid" do
@@ -11,7 +16,7 @@ describe Feedback do
     context "comment missing" do
       let(:report_without_comment) { build(:feedback, comment: nil) }
       it "is invalid" do
-        expect(report_without_comment.save).to be_falsey
+        expect(report_without_comment).to be_invalid
         expect(report_without_comment.errors[:comment]).not_to be_empty
       end
     end
@@ -32,7 +37,7 @@ describe Feedback do
       BAD_EMAILS.each do |email|
         let(:bad_email) { build(:feedback, email: email) }
         it "fails email format check and cannot be created" do
-          expect(bad_email.save).to be_falsey
+          expect(bad_email).to be_invalid
           expect(bad_email.errors[:email]).to include("should look like an email address.")
         end
       end
@@ -40,26 +45,22 @@ describe Feedback do
 
     context "with IP address" do
       let(:ip) { Faker::Internet.ip_v4_address }
-      let(:feedback) { create(:feedback, ip_address: ip) }
+      let(:feedback) { build(:feedback, ip_address: ip) }
   
       it "has IP in Akismet attributes" do
         expect(feedback.akismet_attributes[:user_ip]).to eq(ip)
-      end
-  
-      it "does not store IP in the database" do
-        expect(Feedback.find(feedback.id)[:ip_address]).to be_nil
       end
     end
 
     let(:no_email_provided) { build(:feedback, email: nil) }
     it "is invalid if an email is not provided" do
-      expect(no_email_provided.save).to be_falsey
+      expect(no_email_provided).to be_invalid
       expect(no_email_provided.errors[:email]).not_to be_empty
     end
 
     let(:email_provided) { build(:feedback) }
     it "is valid if an email is provided" do
-      expect(email_provided.save).to be_truthy
+      expect(email_provided).to be_valid
       expect(email_provided.errors[:email]).to be_empty
     end
   end
@@ -74,13 +75,13 @@ describe Feedback do
     end
 
     it "is not valid if Akismet flags it as spam" do
-      expect(spam_report.save).to be_falsey
+      expect(spam_report).to be_invalid
       expect(spam_report.errors[:base]).to include("This report looks like spam to our system!")
     end
 
     it "is valid even with spam if logged in and providing correct email" do
       User.current_user = legit_user
-      expect(safe_report.save).to be_truthy
+      expect(safe_report).to be_valid
     end
   end
 
@@ -98,6 +99,34 @@ describe Feedback do
 
     it "has user_role \"guest\" when reporter is logged out" do
       expect(report.akismet_attributes[:user_role]).to eq("guest")
+    end
+  end
+
+  describe "#email_and_send" do
+    let(:report) { build(:feedback) }
+
+    context "the report is accepted by Zoho" do
+      before do
+        expect(report).to receive(:send_report).and_return(true)
+      end
+
+      it "enqueues an email to the reporter" do
+        expect do
+          expect(report.email_and_send).to be_truthy
+        end.to have_enqueued_mail(UserMailer, :feedback).with(report.mailer_attributes)
+      end
+    end
+
+    context "report is not accepted by Zoho" do
+      before do
+        expect(report).to receive(:send_report).and_return(false)
+      end
+
+      it "does not enqueue an email to the reporter" do
+        expect do
+          expect(report.email_and_send).to be_falsy
+        end.not_to have_enqueued_mail(UserMailer, :feedback).with(report.mailer_attributes)
+      end
     end
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -2,8 +2,8 @@ class UserMailerPreview < ApplicationMailerPreview
   # Sent to a user when they submit an abuse report
   # URL: /rails/mailers/user_mailer/abuse_report
   def abuse_report
-    abuse_report = create(:abuse_report, url: "https://#{ArchiveConfig.APP_HOST}/tags/1984%20-%20George%20Orwell")
-    UserMailer.abuse_report(abuse_report.id)
+    abuse_report = build(:abuse_report, url: "https://#{ArchiveConfig.APP_HOST}/tags/1984%20-%20George%20Orwell")
+    UserMailer.abuse_report(abuse_report.mailer_attributes)
   end
 
   [:series, :chapter, :work].each do |creation_type|

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -40,8 +40,7 @@ class UserMailerPreview < ApplicationMailerPreview
   # Sent to a user when the submit a support request (AKA feedback)
   # URL: /rails/mailers/user_mailer/feedback
   def feedback
-    feedback = create(:feedback)
-    UserMailer.feedback(feedback.id)
+    UserMailer.feedback(build(:feedback).mailer_attributes)
   end
 
   # Sent by gift exchanges to the participants


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6444

## Purpose

Drops the feedbacks table, and removes all columns in the abuse reports table that are not used for rate limiting. If tickets cannot be immediately sent to Zoho, the form submission fails with a "try again later" error message.

Also adds a task (scheduled daily) to delete abuse report information that is outside of the rate limiting period.

## Credit

marcus8448 (he/him)