### PR TITLE
AO3-7525 Use zh-Hans iso for Simplified Chinese

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -158,7 +158,7 @@ phrase:
       - file: ./config/locales/phrase-exports/vi.yml
         params:
           locale_id: vi
-      - file: ./config/locales/phrase-exports/zh-CN.yml
+      - file: ./config/locales/phrase-exports/zh-Hans.yml
         params:
-          locale_id: zh-CN
+          locale_id: zh-Hans
 

--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -131,7 +131,7 @@ class ArchiveFaqsController < ApplicationController
   end
 
   RENAMED_LOCALES = {
-    "sr" => "src", # AO3-6720
+    "sr" => "scr", # AO3-6720
     "zh-CN" => "zh-Hans" # AO3-7525
   }.freeze
 

--- a/app/controllers/archive_faqs_controller.rb
+++ b/app/controllers/archive_faqs_controller.rb
@@ -1,5 +1,6 @@
 class ArchiveFaqsController < ApplicationController
   before_action :admin_only, except: [:index, :show]
+  before_action :redirect_renamed_locales
   before_action :set_locale
   before_action :validate_locale, if: :logged_in_as_admin?
   before_action :require_language_id
@@ -127,6 +128,18 @@ class ArchiveFaqsController < ApplicationController
   # Get the value from set_locale to make sure there's no problem with order
   def default_url_options
     { language_id: set_locale.to_s }
+  end
+
+  RENAMED_LOCALES = {
+    "sr" => "src", # AO3-6720
+    "zh-CN" => "zh-Hans" # AO3-7525
+  }.freeze
+
+  def redirect_renamed_locales
+    return if params[:language_id].blank?
+
+    new_iso = RENAMED_LOCALES[params[:language_id]]
+    redirect_to helpers.current_path_with(language_id: new_iso) if new_iso
   end
 
   # Set the locale as an instance variable first

--- a/app/views/layouts/_proxy_notice.html.erb
+++ b/app/views/layouts/_proxy_notice.html.erb
@@ -16,10 +16,10 @@
       <li><%= t(".point1", locale: :uk) %></li>
       <li><%= t(".point2", locale: :uk) %></li>
     </ol>
-    <p class="important"><%= t(".faux_heading", locale: :"zh-CN") %></p>
+    <p class="important"><%= t(".faux_heading", locale: :"zh-Hans") %></p>
     <ol>
-      <li><%= t(".point1", locale: :"zh-CN") %></li>
-      <li><%= t(".point2", locale: :"zh-CN") %></li>
+      <li><%= t(".point1", locale: :"zh-Hans") %></li>
+      <li><%= t(".point2", locale: :"zh-Hans") %></li>
     </ol>
     <p class="submit"><button class="action" type="button" id="proxy-notice-dismiss"><%= t(".button") %></button></p>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module Otwarchive
       :en, :af, :ar, :bg, :bn, :ca, :cs, :cy, :da, :de, :el, :es, :fa, :fi,
       :fil, :fr, :he, :hi, :hr, :hu, :id, :it, :ja, :ko, :lt, :lv, :mk,
       :mr, :ms, :nb, :nl, :pl, :"pt-BR", :"pt-PT", :ro, :ru, :scr, :sk, :sl,
-      :sv, :th, :tr, :uk, :vi, :"zh-CN"
+      :sv, :th, :tr, :uk, :vi, :"zh-Hans"
     ]
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -17,7 +17,7 @@ data:
   read:
     - config/locales/**/en.yml
     - config/locales/phrase-exports/%{locale}.yml
-    # - locales/views/zh-CN.yml # These are also in the phrase exports
+    # - locales/views/zh-Hans.yml # These are also in the phrase exports
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules

--- a/config/locales/README.md
+++ b/config/locales/README.md
@@ -15,3 +15,4 @@ Aside from the locale name, the files should not be edited.
 
 - "mr-IN" to "mr"
 - "tl" to "fil"
+- "zh-CN" to "zh-Hans"

--- a/config/locales/phrase-exports/zh-Hans.yml
+++ b/config/locales/phrase-exports/zh-Hans.yml
@@ -1,5 +1,5 @@
 ---
-zh-CN:
+zh-Hans:
   activerecord:
     attributes:
       archive_warning:

--- a/config/locales/rails-i18n/locale/zh-Hans.yml
+++ b/config/locales/rails-i18n/locale/zh-Hans.yml
@@ -1,0 +1,181 @@
+---
+zh-Hans:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 验证失败：%{errors}
+        restrict_dependent_destroy:
+          has_one: 由于%{record}需要此记录，所以无法移除记录
+          has_many: 由于%{record}需要此记录，所以无法移除记录
+  date:
+    abbr_day_names:
+      - 周日
+      - 周一
+      - 周二
+      - 周三
+      - 周四
+      - 周五
+      - 周六
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 星期日
+      - 星期一
+      - 星期二
+      - 星期三
+      - 星期四
+      - 星期五
+      - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+      -
+      - 一月
+      - 二月
+      - 三月
+      - 四月
+      - 五月
+      - 六月
+      - 七月
+      - 八月
+      - 九月
+      - 十月
+      - 十一月
+      - 十二月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 大约%{count}小时
+      about_x_months: 大约%{count}个月
+      about_x_years: 大约%{count}年
+      almost_x_years: 接近%{count}年
+      half_a_minute: 半分钟
+      less_than_x_seconds: 不到%{count}秒
+      less_than_x_minutes: 不到%{count}分钟
+      over_x_years: "%{count}年多"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分钟"
+      x_days: "%{count}天"
+      x_months: "%{count}个月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 时
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: 必须是可被接受的
+      blank: 不能为空字符
+      confirmation: 与%{attribute}不匹配
+      empty: 不能留空
+      equal_to: 必须等于%{count}
+      even: 必须为双数
+      exclusion: 是保留关键字
+      greater_than: 必须大于%{count}
+      greater_than_or_equal_to: 必须大于或等于%{count}
+      inclusion: 不包含于列表中
+      invalid: 是无效的
+      less_than: 必须小于%{count}
+      less_than_or_equal_to: 必须小于或等于%{count}
+      model_invalid: 验证失败：%{errors}
+      not_a_number: 不是数字
+      not_an_integer: 必须是整数
+      odd: 必须为单数
+      other_than: 长度非法（不可为%{count}个字符）
+      present: 必须是空白
+      required: 必须存在
+      taken: 已经被使用
+      too_long: 过长（最长为%{count}个字符）
+      too_short: 过短（最短为%{count}个字符）
+      wrong_length: 长度非法（必须为%{count}个字符）
+    template:
+      body: 如下字段出现错误：
+      header: 有%{count}个错误发生导致“%{model}”无法被保存。
+  helpers:
+    select:
+      prompt: 请选择
+    submit:
+      create: 新增%{model}
+      submit: 储存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十亿
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: 字节
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: 和
+      words_connector: "、"
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午

--- a/config/locales/rails-i18n/pluralization/zh-Hans.rb
+++ b/config/locales/rails-i18n/pluralization/zh-Hans.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/other'
+
+::RailsI18n::Pluralization::Other.with_locale(:'zh-Hans')

--- a/config/locales/rails-i18n/pluralization/zh-Hans.rb
+++ b/config/locales/rails-i18n/pluralization/zh-Hans.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require "rails_i18n/common_pluralizations/other"
 
-::RailsI18n::Pluralization::Other.with_locale(:'zh-Hans')
+::RailsI18n::Pluralization::Other.with_locale(:"zh-Hans")

--- a/config/locales/views/zh-Hans.yml
+++ b/config/locales/views/zh-Hans.yml
@@ -1,4 +1,4 @@
-zh-CN:
+zh-Hans:
   layouts:
     proxy_notice:
       faux_heading: "重要提示："

--- a/spec/controllers/archive_faqs_controller_spec.rb
+++ b/spec/controllers/archive_faqs_controller_spec.rb
@@ -131,6 +131,11 @@ describe ArchiveFaqsController do
         get :index, params: { language_id: "" }, session: { language_id: "" }
         it_redirects_to(archive_faqs_path(language_id: "en"))
       end
+
+      it "redirects to the new locale iso when the locale param is the old iso" do
+        get :index, params: { language_id: "zh-CN" }
+        it_redirects_to(archive_faqs_path(language_id: "zh-Hans"))
+      end
     end
 
     context "when logged in as a regular user" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7525

## Purpose

Updates Phrase, i18n and rails-i18n related files to use `zh-Hans` for Simplified Chinese.

## Testing Instructions

TBD

## References

[AO3-6720](https://otwarchive.atlassian.net/browse/AO3-6720)

## Credit

Bilka


[AO3-6720]: https://otwarchive.atlassian.net/browse/AO3-6720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ