### PR TITLE
AO3-7258 Add over-reporting limit for specific collections

### DIFF
--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -256,13 +256,16 @@ class AbuseReport < ApplicationRecord
                                                  series_report_period,
                                                  "%#{series_params_only}%").count
       errors.add(:base, :over_reported_series) if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_SERIES_MAX
-    when %r{/collections/\w+/$}
+    when %r{/collections/\w+/}
       collection_params_only = url.match(%r{/collections/\w+/}).to_s
       collection_report_period = ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD.days.ago
       existing_reports_total = AbuseReport.where('created_at > ? AND
-                                                  url LIKE ?',
+                                                  url LIKE ? AND
+                                                  url NOT REGEXP ?',
                                                   collection_report_period,
-                                                  "%#{collection_params_only}%").count
+                                                  "%#{collection_params_only}%",
+                                                  "#{collection_params_only}works/[0-9]+").count
+
       errors.add(:base, :over_reported_collection) if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX
     end
   end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -260,12 +260,11 @@ class AbuseReport < ApplicationRecord
       collection_params_only = url.match(%r{/collections/\w+/}).to_s
       collection_report_period = ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD.days.ago
       existing_reports_total = AbuseReport.where('created_at > ? AND
-                                                  url LIKE ? AND
-                                                  url NOT REGEXP ?',
-                                                  collection_report_period,
-                                                  "%#{collection_params_only}%",
-                                                  "#{collection_params_only}works/[0-9]+").count
-
+                                                 url LIKE ? AND
+                                                 url NOT REGEXP ?',
+                                                 collection_report_period,
+                                                 "%#{collection_params_only}%",
+                                                 "#{collection_params_only}works/[0-9]+").count
       errors.add(:base, :over_reported_collection) if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX
     end
   end

--- a/app/models/abuse_report.rb
+++ b/app/models/abuse_report.rb
@@ -59,9 +59,10 @@ class AbuseReport < ApplicationRecord
   # Profile URLs: "users/username"
   # Bookmark URLs: "bookmarks/123"
   # Series URLs: "series/123"
+  # Collection URLs: "collections/collection_name"
   before_validation :standardize_url, on: :create
   def standardize_url
-    return unless url =~ %r{((chapters|works|comments|bookmarks|series)/\d+)} || url =~ %r{(users/\w+)}
+    return unless url =~ %r{((chapters|works|comments|bookmarks|series)/\d+)} || url =~ %r{((users|collections)/\w+)}
 
     self.url = add_scheme_to_url(url)
     self.url = clean_url(url)
@@ -255,6 +256,14 @@ class AbuseReport < ApplicationRecord
                                                  series_report_period,
                                                  "%#{series_params_only}%").count
       errors.add(:base, :over_reported_series) if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_SERIES_MAX
+    when %r{/collections/\w+/$}
+      collection_params_only = url.match(%r{/collections/\w+/}).to_s
+      collection_report_period = ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD.days.ago
+      existing_reports_total = AbuseReport.where('created_at > ? AND
+                                                  url LIKE ?',
+                                                  collection_report_period,
+                                                  "%#{collection_params_only}%").count
+      errors.add(:base, :over_reported_collection) if existing_reports_total >= ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX
     end
   end
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -189,6 +189,10 @@ ABUSE_REPORTS_PER_BOOKMARK_MAX: 3
 ABUSE_REPORTS_PER_BOOKMARK_PERIOD: 30
 # max number of abuse reports to accept from a given email
 ABUSE_REPORTS_PER_EMAIL_MAX: 5
+# max number of abuse reports to accept for a collection in a given period
+ABUSE_REPORTS_PER_COLLECTION_MAX: 3
+# time period, in days, used to total number of reports for a given collection URL
+ABUSE_REPORTS_PER_COLLECTION_PERIOD: 30
 
 # number of items in various displays
 ITEMS_PER_PAGE: 25

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -93,6 +93,7 @@ en:
               over_reported_bookmark: This bookmark has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
               over_reported_comment: This comment has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
               over_reported_series: This series has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
+              over_reported_collection: This collection has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
             url:
               not_on_archive: does not appear to be on this site.
         admin_post:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -91,9 +91,9 @@ en:
             base:
               over_reported: This page has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
               over_reported_bookmark: This bookmark has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
+              over_reported_collection: This collection has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
               over_reported_comment: This comment has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
               over_reported_series: This series has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
-              over_reported_collection: This collection has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.
             url:
               not_on_archive: does not appear to be on this site.
         admin_post:

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -169,6 +169,14 @@ describe AbuseReport do
       end
     end
 
+    shared_examples "enough collection reports" do |url|
+      let(:report) { build(:abuse_report, url: url) }
+      it "can't be submitted" do
+        expect(report.save).to be_falsey
+        expect(report.errors[:base].first).to include("This collection has already been reported.")
+      end
+    end
+
     shared_examples "alright" do |url|
       let(:report) { build(:abuse_report, url: url) }
       it "can be submitted" do
@@ -332,6 +340,69 @@ describe AbuseReport do
         before { travel(ArchiveConfig.ABUSE_REPORTS_PER_SERIES_PERIOD.days) }
 
         it_behaves_like "alright", series_url
+      end
+    end
+
+    context "for a collection reported the maximum number of times" do
+      collection_url = "http://archiveofourown.org/collections/collection_name"
+
+      before do
+        ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX.times do
+          create(:abuse_report, url: collection_url)
+        end
+        expect(AbuseReport.count).to eq(ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX)
+      end
+
+      # obviously
+      it_behaves_like "enough collection reports", collection_url
+
+      # the same collection, different protocol
+      it_behaves_like "enough collection reports", "https://archiveofourown.org/collections/collection_name"
+
+      # the same collection, with parameters/anchors
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name?show_random=true"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name#timeline"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name?show_random=true#timeline"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/?show_random=true"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/#timeline"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/?show_random=true#timeline"
+
+      # the same collection, subpages
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/profile"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/collections"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/fandoms"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/works"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/bookmarks"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/people"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/tags"
+      it_behaves_like "enough collection reports", "http://archiveofourown.org/collections/collection_name/tags/tag%20name/works"
+
+      # not the same collection
+      it_behaves_like "alright", "http://archiveofourown.org/collections/collection_name_2"
+      it_behaves_like "alright", "http://archiveofourown.org/collections/collection_name2"
+
+      # a specific work under a collection
+      it_behaves_like "alright", "http://archiveofourown.org/collections/collection_name/works/789"
+
+      context "after the collection over-reporting period" do
+        before { travel(ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD.days) }
+
+        it_behaves_like "alright", collection_url
+      end
+    end
+
+    context "when specific works in a collection have been reported" do
+      before do
+        ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX.times do
+          create(:abuse_report, url: "http://archiveofourown.org/collections/collection_name/works/789")
+        end
+      end
+
+      it "does not count them toward the collection report limit" do
+        report = build(:abuse_report, url: "http://archiveofourown.org/collections/collection_name")
+
+        expect(report.save).to be_truthy
+        expect(report.errors[:base]).to be_empty
       end
     end
 

--- a/spec/models/abuse_report_spec.rb
+++ b/spec/models/abuse_report_spec.rb
@@ -384,25 +384,24 @@ describe AbuseReport do
       # a specific work under a collection
       it_behaves_like "alright", "http://archiveofourown.org/collections/collection_name/works/789"
 
+      it "does not count toward the collection report count" do
+        collection_report_count = lambda {
+          AbuseReport.where(
+            "url LIKE ? AND url NOT REGEXP ?",
+            "%/collections/collection_name/%",
+            "/collections/collection_name/works/[0-9]+"
+          ).count
+        }
+
+        expect do
+          create(:abuse_report, url: "http://archiveofourown.org/collections/collection_name/works/789")
+        end.not_to change { collection_report_count.call }
+      end
+
       context "after the collection over-reporting period" do
         before { travel(ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD.days) }
 
         it_behaves_like "alright", collection_url
-      end
-    end
-
-    context "when specific works in a collection have been reported" do
-      before do
-        ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX.times do
-          create(:abuse_report, url: "http://archiveofourown.org/collections/collection_name/works/789")
-        end
-      end
-
-      it "does not count them toward the collection report limit" do
-        report = build(:abuse_report, url: "http://archiveofourown.org/collections/collection_name")
-
-        expect(report.save).to be_truthy
-        expect(report.errors[:base]).to be_empty
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7258

## Purpose

Currently, there is no reporting limit for specific collections, so the same collection can be reported repeatedly without hitting a collection-specific limit.

This PR adds a collection-specific over-reporting check. A collection can now be reported up to `ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_MAX` times within `ArchiveConfig.ABUSE_REPORTS_PER_COLLECTION_PERIOD`. As per the ticket, the default values are 3 reports per 30 days.

When the limit is reached, users see the collection-specific error: `This collection has already been reported. Our volunteers only need one report in order to investigate and resolve an issue, so please be patient and do not submit another report.`

The implementation follows the existing abuse report URL-limit pattern. This pattern is already used for works, bookmarks, comments, series, and users.

Collection URLs are standardized before validation so equivalent URLs such as `/collections/COLLECTION_NAME` and `/collections/COLLECTION_NAME?show_random=true` count towards the same collection. Reports for specific works within a collection, such as `/collections/COLLECTION_NAME/works/####`, are excluded from the collection count and continue to use the work-reporting limit instead.

## Testing Instructions

New tests for the behavior introduced in this PR have been added to `abuse_report_spec.rb`.

To run the new tests, use the following command:
`docker compose run --rm test bundle exec rspec spec/models/abuse_report_spec.rb:346`

Manual testing can also be done to verify the PR changes. Manual testing instructions can be found in the ticket. You will have to increase the `ABUSE_REPORTS_PER_EMAIL_MAX` value in order to successfully complete manual testing.

## References

In the Jira ticket for this issue, another ticket was linked as a related work item: https://otwarchive.atlassian.net/browse/AO3-7253

## Credit

Name: Isabelle Zhang
Pronouns: she/her