### PR TITLE
AO3-5387 Submitting sign ups when only field is title, Description, or URL

### DIFF
--- a/app/models/challenge_signup.rb
+++ b/app/models/challenge_signup.rb
@@ -31,7 +31,7 @@ class ChallengeSignup < ApplicationRecord
   accepts_nested_attributes_for :offers, :prompts, :requests,
                                 allow_destroy: true,
                                 reject_if: proc { |attrs|
-                                  attrs[:url].blank? && attrs[:description].blank? &&
+                                  attrs[:url].blank? && attrs[:description].blank? && attrs[:title].blank? && 
                                     (attrs[:tag_set_attributes].nil? || attrs[:tag_set_attributes].all? { |_k, v| v.blank? }) &&
                                     (attrs[:optional_tag_set_attributes].nil? || attrs[:optional_tag_set_attributes].all? { |_k, v| v.blank? })
                                 }

--- a/spec/controllers/challenge_signups_controller_spec.rb
+++ b/spec/controllers/challenge_signups_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ChallengeSignupsController do
   include LoginMacros
@@ -17,6 +17,10 @@ describe ChallengeSignupsController do
   let(:open_collection_owner) { User.find(open_collection.all_owners.first.user_id) }
   let(:open_signup_owner) { Pseud.find(open_signup.pseud_id).user }
 
+  let(:open_challenge2) { create(:prompt_meme) }
+  let(:open_collection2) { create(:collection, challenge: open_challenge2) }
+  let(:open_collection_owner2) { User.find(open_collection2.all_owners.first.user_id) }
+
   describe "new" do
     context "when sign-ups are closed" do
       it "redirects and errors" do
@@ -33,6 +37,24 @@ describe ChallengeSignupsController do
         get :new, params: { collection_id: open_collection.name, pseud: user.pseuds.first }
         it_redirects_to_with_notice(edit_collection_signup_path(open_collection, open_signup),
                                     "You are already signed up for this challenge. You can edit your sign-up below.")
+      end
+
+      it "allows sign up when only title field is filled out" do
+        fake_login_known_user(user)
+        open_challenge2.request_restriction.update!(title_allowed: true, title_required: true, description_allowed: false, 
+                                                    fandom_num_allowed: 0, character_num_allowed: 0, freeform_num_allowed: 0, category_num_allowed: 0, 
+                                                    rating_num_allowed: 0, relationship_num_allowed: 0, archive_warning_num_allowed: 0)
+        open_challenge2.update!(signup_open: true)
+        post :create, params: { collection_id: open_collection2.name, pseud: user.pseuds.first, challenge_signup: {
+          pseud_id: user.pseuds.first.id,
+          requests_attributes: {
+            "0" => {
+              title: "Tester title"
+            }
+          }
+        } }
+        signup = ChallengeSignup.last
+        it_redirects_to_with_notice(collection_signup_path(open_collection2, signup), "Sign-up was successfully created.")
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5387

## Purpose

Allows challenge sign-ups to happen if at least one of title, description, or URL is included when everything else is empty. Before, these were considered invalid and made certain challenges impossible to sign up for

## Credit

kiyazz (he/him)
