### PR TITLE
AO3-7519 Update browser page title when creating an AO3 News Post

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -50,6 +50,7 @@ class AdminPostsController < Admin::BaseController
   # GET /admin_posts/new
   # GET /admin_posts/new.xml
   def new
+    @page_subtitle = t(".page_title")
     @admin_post = AdminPost.new
     authorize @admin_post
   end

--- a/app/views/admin_posts/new.html.erb
+++ b/app/views/admin_posts/new.html.erb
@@ -1,5 +1,5 @@
 <!--Descriptive page name, messages and instructions-->
-<h2 class="heading"><%= ts("New AO3 News Post") %></h2>
+<h2 class="heading"><%= t(".page_heading") %></h2>
 <!--/descriptions-->
 
 <!--subnav-->

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -538,6 +538,9 @@ en:
       page_title: AO3 News Drafts
     index:
       page_title: AO3 News
+    new:
+      page_heading: New AO3 News Post
+      page_title: New AO3 News Post
     posting_fieldset:
       actions:
         cancel: Cancel


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7519

## Purpose

What does this PR do?
- Updates the locale config to contain the string "New AO3 News Post" for both `page_title` and `page_heading` for new ao3 news posts.
- Changes the browser page title to "New AO3 News Post | Archive of Our Own (or Example Archive)" when creating an AO3 News post.

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?
- Log in as admin that can create news posts
- Navigate to Admin Posts > Post AO3 News
- The browser page title should now say "New AO3 News Post | Archive of Our Own (or Example Archive)"

## Credit

Name: 99patricia (Patricia Zafra)
Pronouns: she/her