### PR TITLE
AO3-7517 Disable phone number detection in emails on iOS

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,5 @@
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <meta name="format-detection" content="telephone=no" />
 <title></title>
 <style type="text/css">

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,6 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="format-detection" content="telephone=no">
 <title></title>
 <style type="text/css">
   .ReadMsgBody { width: 100% !important; }

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,6 +1,6 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="format-detection" content="telephone=no">
+<meta name="format-detection" content="telephone=no" />
 <title></title>
 <style type="text/css">
   .ReadMsgBody { width: 100% !important; }

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -5,9 +5,7 @@ shared_examples_for "a multipart email" do
   end
 
   it "disables phone number detection in the HTML version" do
-    html = Nokogiri::HTML(email.html_part.decoded)
-
-    expect(html.at_xpath("//meta[@name='format-detection'][@content='telephone=no']")).to be_present
+    expect(email.html_part).to have_xpath("//meta[@name='format-detection'][@content='telephone=no']")
   end
 
   it "does not have exposed HTML" do

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -4,6 +4,12 @@ shared_examples_for "a multipart email" do
     expect(email.body.parts.map(&:content_type)).to eq(["text/plain; charset=UTF-8", "text/html; charset=UTF-8"])
   end
 
+  it "disables phone number detection in the HTML version" do
+    html = Nokogiri::HTML(email.html_part.decoded)
+
+    expect(html.at_xpath("//meta[@name='format-detection'][@content='telephone=no']")).to be_present
+  end
+
   it "does not have exposed HTML" do
     expect(email).not_to have_html_part_content("&lt;")
   end

--- a/spec/support/shared_examples/mailer_shared_examples.rb
+++ b/spec/support/shared_examples/mailer_shared_examples.rb
@@ -5,7 +5,7 @@ shared_examples_for "a multipart email" do
   end
 
   it "disables phone number detection in the HTML version" do
-    expect(email.html_part).to have_xpath("//meta[@name='format-detection'][@content='telephone=no']")
+    expect(email).to have_html_part_content('<meta name="format-detection" content="telephone=no" />')
   end
 
   it "does not have exposed HTML" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7517 (Please fill in issue number and remove this comment.)

## Purpose

What does this PR do?

Prevent IOS from considering numerical strings of certain lengths as phone numbers via adding a certain meta tag to the email.

## Credit

varram (he/him)