### PR TITLE
AO3-5657 Reassign tag set nominations when pseud is deleted

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -40,7 +40,7 @@ class Pseud < ApplicationRecord
   has_many :direct_filters, through: :works
   has_many :collection_participants, dependent: :destroy
   has_many :collections, through: :collection_participants
-  has_many :tag_set_nominations
+  has_many :tag_set_nominations, dependent: :destroy
   has_many :tag_set_ownerships, dependent: :destroy
   has_many :tag_sets, through: :tag_set_ownerships
   has_many :challenge_signups, dependent: :destroy

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -40,6 +40,7 @@ class Pseud < ApplicationRecord
   has_many :direct_filters, through: :works
   has_many :collection_participants, dependent: :destroy
   has_many :collections, through: :collection_participants
+  has_many :tag_set_nominations
   has_many :tag_set_ownerships, dependent: :destroy
   has_many :tag_sets, through: :tag_set_ownerships
   has_many :challenge_signups, dependent: :destroy
@@ -321,6 +322,7 @@ class Pseud < ApplicationRecord
     change_collections_membership
     change_gift_recipients
     change_challenge_participation
+    change_tag_set_nominations
     self.destroy
   end
 
@@ -406,6 +408,15 @@ class Pseud < ApplicationRecord
 
     bookmarks.update_all(pseud_id: default_pseud_id)
     IndexQueue.enqueue_ids(Bookmark, bookmark_ids, :main)
+  end
+
+  def change_tag_set_nominations
+    default_pseud_id = user.default_pseud.id
+    # Destroy nominations for tag sets where the default pseud already has one,
+    # to avoid violating the (owned_tag_set_id, pseud_id) uniqueness constraint.
+    existing_tag_set_ids = TagSetNomination.where(pseud_id: default_pseud_id).pluck(:owned_tag_set_id)
+    tag_set_nominations.where(owned_tag_set_id: existing_tag_set_ids).destroy_all
+    tag_set_nominations.update_all(pseud_id: default_pseud_id)
   end
 
   def change_collections_membership

--- a/spec/models/pseud_spec.rb
+++ b/spec/models/pseud_spec.rb
@@ -94,6 +94,42 @@ describe Pseud do
     end
   end
 
+  describe "#change_tag_set_nominations" do
+    let(:user) { create(:user) }
+    let(:pseud) { create(:pseud, user: user) }
+    let(:default_pseud) { user.default_pseud }
+
+    it "reassigns tag set nominations to the default pseud" do
+      nomination = create(:tag_set_nomination, pseud: pseud)
+
+      pseud.change_tag_set_nominations
+
+      expect(nomination.reload.pseud_id).to eq(default_pseud.id)
+    end
+
+    it "destroys nominations that conflict with the default pseud" do
+      tag_set = create(:owned_tag_set)
+      create(:tag_set_nomination, pseud: default_pseud, owned_tag_set: tag_set)
+      conflicting = create(:tag_set_nomination, pseud: pseud, owned_tag_set: tag_set)
+
+      pseud.change_tag_set_nominations
+
+      expect(TagSetNomination.find_by(id: conflicting.id)).to be_nil
+    end
+
+    it "reassigns non-conflicting nominations to the default pseud and destroys conflicting ones" do
+      tag_set = create(:owned_tag_set)
+      create(:tag_set_nomination, pseud: default_pseud, owned_tag_set: tag_set)
+      conflicting = create(:tag_set_nomination, pseud: pseud, owned_tag_set: tag_set)
+      other_nomination = create(:tag_set_nomination, pseud: pseud)
+
+      pseud.change_tag_set_nominations
+
+      expect(TagSetNomination.find_by(id: conflicting.id)).to be_nil
+      expect(other_nomination.reload.pseud_id).to eq(default_pseud.id)
+    end
+  end
+
   describe "#change_bookmarks_ownership" do
     let(:user) { create(:user) }
     let(:pseud) { create(:pseud, user: user) }


### PR DESCRIPTION
## Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-5657

## Purpose

When a user deletes a pseud, tag set nominations associated with that pseud are left orphaned in the database. The owned_by scope uses an inner join through the pseud, so these orphaned nominations become invisible to the user.

This PR adds tag set nomination reassignment to Pseud#replace_me_with_default, following the same pattern used for comments, gifts, challenge signups, and collection participants. If the default pseud already has a nomination for the same tag set, the conflicting nomination from the deleted pseud is destroyed (along with its associated tag nominations via dependent: :destroy). Otherwise, the nomination is reassigned to the default pseud.

## Testing Instructions

1. Log in as User A.
2. Go to Browse > Tags > Tag Sets > New Tag Set.
3. Check the "Currently taking nominations?" box and set at least one nomination limit to a non-zero value.
4. Fill in the rest of the fields and press "Submit" to create the tag set.
5. Log in as User B.
6. Go to My Preferences > Manage My Pseuds > New Pseud and create a new pseud.
7. Fill in the fields as desired and press "Create" to create a new post.
8. View the tag set created by User A and click "Nominate."
9. Select the pseud that you just created.
10. Nominate tags as desired, and then press "Submit."
11. Go to My Preferences > Manage My Pseuds.
12. Find the pseud that you just created/nominated for, and press the "Delete" button.
13. View the tag set again and click "Nominate."
14. **Expected:** You should be redirected to your existing nominations (now under your default pseud), not a new nomination form.

## Credit

Pablo Monfort (he/him)