### PR TITLE
AO3-4059 Change chapters_controller to 404 if given work id is invalid

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -240,11 +240,9 @@ class ChaptersController < ApplicationController
 
   # fetch work these chapters belong to from db
   def load_work
-    @work = params[:work_id] ? Work.find(params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
-    if @work.blank?
-      flash[:error] = ts("Sorry, we couldn't find the work you were looking for.")
-      redirect_to root_path and return
-    end
+    @work = params[:work_id] ? Work.find(params[:work_id]) : Chapter.find(params[:id]).work
+    raise ActiveRecord::RecordNotFound, "Couldn't find work for chapter with id '#{params[:id]}'" if @work.blank?
+
     @check_ownership_of = @work
     @check_visibility_of = @work
   end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -240,7 +240,7 @@ class ChaptersController < ApplicationController
 
   # fetch work these chapters belong to from db
   def load_work
-    @work = params[:work_id] ? Work.find_by!(id: params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
+    @work = params[:work_id] ? Work.find(params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
     if @work.blank?
       flash[:error] = ts("Sorry, we couldn't find the work you were looking for.")
       redirect_to root_path and return

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -240,7 +240,7 @@ class ChaptersController < ApplicationController
 
   # fetch work these chapters belong to from db
   def load_work
-    @work = params[:work_id] ? Work.find_by(id: params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
+    @work = params[:work_id] ? Work.find_by!(id: params[:work_id]) : Chapter.find_by(id: params[:id]).try(:work)
     if @work.blank?
       flash[:error] = ts("Sorry, we couldn't find the work you were looking for.")
       redirect_to root_path and return

--- a/features/step_definitions/work_steps.rb
+++ b/features/step_definitions/work_steps.rb
@@ -283,10 +283,6 @@ When /^I view the work "([^"]*)"(?: in (full|chapter-by-chapter) mode)?$/ do |wo
   step %{I follow "Chapter by Chapter"} if mode == "chapter-by-chapter"
 end
 
-When /^I view a deleted work$/ do
-  visit "/works/12345/chapters/12345"
-end
-
 When /^I view a deleted chapter$/ do
   step "the draft \"DeletedChapterWork\""
   work = Work.find_by(title: "DeletedChapterWork")

--- a/features/works/work_view.feature
+++ b/features/works/work_view.feature
@@ -27,14 +27,6 @@ Feature: View a work with various options
   When I view the work "Whatever"
   Then I should see "Chapter 2"
 
-  Scenario: viewing a work and chapter that have been deleted
-  Given I am logged in as a random user
-    And I view a deleted work
-  Then I should be on the homepage
-    And I should see "Sorry, we couldn't find the work you were looking for."
-  When I follow "Site Map"
-    And I should not see "Sorry, we couldn't find the work you were looking for."
-
   Scenario: viewing a deleted chapter on a work that still exists
   Given I am logged in as a random user
     And I view a deleted chapter

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -173,9 +173,9 @@ describe ChaptersController do
     end
 
     it "shows the chapter if work is not given but chapter exists" do
-        get :show, params: { id: work.chapters.first.id }
-        expect(response).to render_template(:show)
-        expect(assigns[:work]).to eq work
+      get :show, params: { id: work.chapters.first.id }
+      expect(response).to render_template(:show)
+      expect(assigns[:work]).to eq work
     end
 
     it "assigns @chapters to chapters in order" do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -38,14 +38,14 @@ describe ChaptersController do
     chapter
   end
 
-  describe "index" do
+  describe "GET #index" do
     it "redirects to work" do
       get :index, params: { work_id: work.id }
       it_redirects_to work_path(work.id)
     end
   end
 
-  describe "manage" do
+  describe "GET #manage" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :manage, params: { work_id: work.id }
@@ -58,9 +58,10 @@ describe ChaptersController do
         fake_login_known_user(user)
       end
 
-      it "errors and redirects to root path if work does not exist" do
-        get :manage, params: { work_id: 0 }
-        it_redirects_to_with_error(root_path, "Sorry, we couldn't find the work you were looking for.")
+      it "errors if work does not exist" do
+        expect do
+          get :manage, params: { work_id: 0 }
+        end.to raise_error ActiveRecord::RecordNotFound
       end
 
       it "renders manage template" do
@@ -90,7 +91,7 @@ describe ChaptersController do
     end
   end
 
-  describe "show" do
+  describe "GET #show" do
     context "when user is logged out" do
       it "renders show template" do
         get :show, params: { work_id: work.id, id: work.chapters.first }
@@ -157,6 +158,24 @@ describe ChaptersController do
       chapter = create(:chapter)
       get :show, params: { work_id: work.id, id: chapter.id }
       it_redirects_to_with_error(work_path(work), "Sorry, we couldn't find the chapter you were looking for.")
+    end
+
+    it "errors if work and chapter do not exist" do
+      expect do
+        get :show, params: { work_id: 0, id: 0 }
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "errors if work does not exist but chapter exists" do
+      expect do
+        get :show, params: { work_id: 0, id: work.chapters.first.id }
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "shows the chapter if work is not given but chapter exists" do
+        get :show, params: { id: work.chapters.first.id }
+        expect(response).to render_template(:show)
+        expect(assigns[:work]).to eq work
     end
 
     it "assigns @chapters to chapters in order" do
@@ -311,7 +330,7 @@ describe ChaptersController do
     end
   end
 
-  describe "new" do
+  describe "GET #new" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :new, params: { work_id: work.id }
@@ -356,7 +375,7 @@ describe ChaptersController do
     end
   end
 
-  describe "edit" do
+  describe "GET #edit" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :edit, params: { work_id: work.id, id: work.chapters.first.id }
@@ -463,7 +482,7 @@ describe ChaptersController do
     end
   end
 
-  describe "create" do
+  describe "POST #create" do
     let(:chapter_attributes) { { content: "This doesn't matter" } }
 
     context "when user is logged out" do
@@ -674,7 +693,7 @@ describe ChaptersController do
     end
   end
 
-  describe "update" do
+  describe "PUT #update" do
     let(:chapter_attributes) { { content: "This doesn't matter" } }
 
     context "when user is logged out" do
@@ -866,7 +885,7 @@ describe ChaptersController do
     end
   end
 
-  describe "update_positions" do
+  describe "POST #update_positions" do
     let(:chapter1) { work.chapters.first }
     let!(:chapter2) { create(:chapter, :draft, work: work, position: 2, authors: [user.pseuds.first]) }
     let!(:chapter3) { create(:chapter, work: work, position: 3, authors: [user.pseuds.first]) }
@@ -949,7 +968,7 @@ describe ChaptersController do
     end
   end
 
-  describe "preview" do
+  describe "GET #preview" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :preview, params: { work_id: work.id, id: work.chapters.first.id }
@@ -987,7 +1006,7 @@ describe ChaptersController do
     end
   end
 
-  describe "post" do
+  describe "POST #post" do
     before do
       @chapter_to_post = create(:chapter, :draft, work: work, authors: [user.pseuds.first], position: 2)
     end
@@ -1089,7 +1108,7 @@ describe ChaptersController do
     end
   end
 
-  describe "confirm_delete" do
+  describe "GET #confirm_delete" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         get :confirm_delete, params: { work_id: work.id, id: work.chapters.first.id }
@@ -1126,7 +1145,7 @@ describe ChaptersController do
     end
   end
 
-  describe "destroy" do
+  describe "DELETE #destroy" do
     context "when user is logged out" do
       it "errors and redirects to login" do
         delete :destroy, params: { work_id: work.id, id: work.chapters.first.id }

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -154,9 +154,14 @@ describe ChaptersController do
       it_redirects_to work_chapter_path(work_id: work.id, id: chapter.id)
     end
 
-    it "errors and redirects to work if chapter is not found" do
+    it "errors and redirects to work if chapter is not found in work but work is given" do
       chapter = create(:chapter)
       get :show, params: { work_id: work.id, id: chapter.id }
+      it_redirects_to_with_error(work_path(work), "Sorry, we couldn't find the chapter you were looking for.")
+    end
+
+    it "errors and redirects to work if chapter is invalid but work is given" do
+      get :show, params: { work_id: work.id, id: 0 }
       it_redirects_to_with_error(work_path(work), "Sorry, we couldn't find the chapter you were looking for.")
     end
 
@@ -172,10 +177,24 @@ describe ChaptersController do
       end.to raise_error ActiveRecord::RecordNotFound
     end
 
-    it "shows the chapter if work is not given but chapter exists" do
+    it "errors if chapter does not exist and work is not given" do
+      expect do
+        get :show, params: { id: 0 }
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "shows the chapter if chapter exists and work is not given" do
       get :show, params: { id: work.chapters.first.id }
       expect(response).to render_template(:show)
       expect(assigns[:work]).to eq work
+    end
+
+    it "errors if chapter is given but has no work and work is not given" do
+      chapter = work.chapters.first.id
+      work.delete
+      expect do
+        get :show, params: { id: chapter }
+      end.to raise_error ActiveRecord::RecordNotFound
     end
 
     it "assigns @chapters to chapters in order" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4059

## Purpose

Changed the chapters controller so it 404s if the work id in the URL is invalid, instead of redirecting to the homepage.

Changed the chapters controller so it 404s if the chapter id in the URL is invalid and no work id is given.

## References

PR Limit: 7 out of 5
Using reviewer bonus:
#4928
#5024

## Credit

Bilka
