### PR TITLE
AO3-6964 Fix that comment reply notice on moderated admin posts mentioned works

### DIFF
--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -32,9 +32,9 @@
 
       <% if comments_are_moderated(commentable) && !current_user_is_work_creator(commentable) %>
         <p class="notice">
-          <% if commentable.is_a?(AdminPost) %>
+          <% if find_parent(commentable).is_a?(AdminPost) %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.admin_post") %>
-          <% else %>
+          <% else  %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.work") %>
           <% end %>
         </p>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -34,7 +34,7 @@
         <p class="notice">
           <% if find_parent(commentable).is_a?(AdminPost) %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.admin_post") %>
-          <% else  %>
+          <% else %>
             <%= t("comments.commentable.permissions.moderated_commenting.notice.work") %>
           <% end %>
         </p>

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -113,6 +113,27 @@ Feature: Commenting on admin posts
     Then I should see "Comment created!"
       And I should see "zug zug"
 
+  Scenario: Admin post with comment moderation
+    Given I have posted an admin post
+      And I am logged in as a "communications" admin
+    When I go to the admin-posts page
+      And I follow "Edit"
+      And I check "Enable comment moderation"
+    When I am logged out
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I fill in "comment[name]" with "tester"
+      And I fill in "comment[email]" with "tester@example.com"
+      And I fill in "comment[comment_content]" with "guz guz"
+      And I press "Comment"
+    When I follow "Reply"
+      And I fill in "comment[name]" with "tester"
+      And I fill in "comment[email]" with "tester@example.com"
+      And I fill in "comment[comment_content]" with "guz guz"
+      And I press "Comment"
+    Then I should see "Comments on this news post are moderated."
+
+
   Scenario: Modifying the comment permissions of an admin post with translations
     Given I have posted an admin post
       And basic languages

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -129,7 +129,7 @@ Feature: Commenting on admin posts
     When I am logged in as a "communications" admin
       And I go to the admin-posts page
       And I follow "Default Admin Post"
-      And I follow "Unreviewed Comments"
+      And I follow "Unreviewed Comments (1)"
       And I press "Approve"
     When I am logged out
       And I go to the admin-posts page

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -126,13 +126,20 @@ Feature: Commenting on admin posts
       And I fill in "comment[email]" with "tester@example.com"
       And I fill in "comment[comment_content]" with "guz guz"
       And I press "Comment"
+    When I am logged in as a "communications" admin
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I follow "Unreviewed Comments"
+      And I press "Approve"
+    When I am logged out
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
     When I follow "Reply"
       And I fill in "comment[name]" with "tester"
       And I fill in "comment[email]" with "tester@example.com"
       And I fill in "comment[comment_content]" with "guz"
       And I press "Comment"
     Then I should see "Comments on this news post are moderated."
-
 
   Scenario: Modifying the comment permissions of an admin post with translations
     Given I have posted an admin post

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -129,7 +129,7 @@ Feature: Commenting on admin posts
     When I follow "Reply"
       And I fill in "comment[name]" with "tester"
       And I fill in "comment[email]" with "tester@example.com"
-      And I fill in "comment[comment_content]" with "guz guz"
+      And I fill in "comment[comment_content]" with "guz"
       And I press "Comment"
     Then I should see "Comments on this news post are moderated."
 

--- a/features/comments_and_kudos/comments_adminposts.feature
+++ b/features/comments_and_kudos/comments_adminposts.feature
@@ -113,33 +113,14 @@ Feature: Commenting on admin posts
     Then I should see "Comment created!"
       And I should see "zug zug"
 
-  Scenario: Admin post with comment moderation
-    Given I have posted an admin post
-      And I am logged in as a "communications" admin
-    When I go to the admin-posts page
-      And I follow "Edit"
-      And I check "Enable comment moderation"
-    When I am logged out
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
-      And I fill in "comment[name]" with "tester"
-      And I fill in "comment[email]" with "tester@example.com"
-      And I fill in "comment[comment_content]" with "guz guz"
-      And I press "Comment"
-    When I am logged in as a "communications" admin
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
-      And I follow "Unreviewed Comments (1)"
-      And I press "Approve"
-    When I am logged out
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
-    When I follow "Reply"
-      And I fill in "comment[name]" with "tester"
-      And I fill in "comment[email]" with "tester@example.com"
-      And I fill in "comment[comment_content]" with "guz"
-      And I press "Comment"
-    Then I should see "Comments on this news post are moderated."
+  Scenario: Replying to a comment on an admin post with comment moderation shows a notice that news post comments are moderated
+    Given I have posted an admin post with guest comments enabled
+      And a guest comment on the admin post "Default Admin Post"
+      And comment moderation on the admin post "Default Admin Post" is enabled
+    When I view the latest comment
+      And I follow "Reply"
+    Then I should see "Comments on this news post are moderated." within "div[@title='Reply to this comment']"
+      And I should not see "This work's creator has chosen to moderate comments on the work."
 
   Scenario: Modifying the comment permissions of an admin post with translations
     Given I have posted an admin post

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -225,12 +225,25 @@ Given /^I have posted an admin post with guest comments disabled$/ do
   step %{I log out}
 end
 
+Given "I have posted an admin post with guest comments enabled" do
+  step %{I am logged in as a "communications" admin}
+  step %{I start to make an admin post}
+  choose("Registered users and guests can comment")
+  click_button("Post")
+  step %{I log out}
+end
+
 Given /^I have posted an admin post with comments disabled$/ do
   step %{I am logged in as a "communications" admin}
   step %{I start to make an admin post}
   choose("No one can comment")
   click_button("Post")
   step %{I log out}
+end
+
+Given "comment moderation on the admin post {string} is enabled" do |title|
+  admin_post = AdminPost.find_by!(title: title)
+  admin_post.update_attribute(:moderated_commenting_enabled, true)
 end
 
 Given "an abuse ticket ID exists" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6964

## Purpose

Display the notice for moderated comment replies based on the (ultimate) parent of the commentable instead of the commentable directly.

## References

Adopts #5141

## Credit

niic (he/him) (original PR)
sarken (original review)
Bilka