### PR TITLE
AO3-2312 Add kudos to admin posts

### DIFF
--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -28,6 +28,7 @@ class AdminPostsController < Admin::BaseController
       @previous_admin_post = admin_posts.posted.order(published_at: :desc).where("published_at < ?", @admin_post.published_at).first
       @next_admin_post = admin_posts.posted.order(published_at: :asc).where("published_at > ?", @admin_post.published_at).first
       @page_subtitle = @admin_post.title.html_safe
+      @kudos = @admin_post.kudos.with_user.includes(:user).order(created_at: :desc)
     else
       @admin_posts = admin_posts.unposted.order(created_at: :desc).limit(8)
       @previous_admin_post = admin_posts.unposted.order(created_at: :desc).where("created_at < ?", @admin_post.created_at).first

--- a/app/controllers/admin_posts_controller.rb
+++ b/app/controllers/admin_posts_controller.rb
@@ -28,13 +28,13 @@ class AdminPostsController < Admin::BaseController
       @previous_admin_post = admin_posts.posted.order(published_at: :desc).where("published_at < ?", @admin_post.published_at).first
       @next_admin_post = admin_posts.posted.order(published_at: :asc).where("published_at > ?", @admin_post.published_at).first
       @page_subtitle = @admin_post.title.html_safe
-      @kudos = @admin_post.kudos.with_user.includes(:user).order(created_at: :desc)
     else
       @admin_posts = admin_posts.unposted.order(created_at: :desc).limit(8)
       @previous_admin_post = admin_posts.unposted.order(created_at: :desc).where("created_at < ?", @admin_post.created_at).first
       @next_admin_post = admin_posts.unposted.order(created_at: :asc).where("created_at > ?", @admin_post.created_at).first
       @page_subtitle = t(".page_title_draft", title: @admin_post.title.html_safe)
     end
+    @kudos = @admin_post.kudos.with_user.includes(:user).order(created_at: :desc)
     respond_to do |format|
       format.html # show.html.erb
       format.js

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -4,16 +4,21 @@ class KudosController < ApplicationController
   before_action :admin_logout_required, only: [:create]
 
   def load_parent
-    @work = Work.find(params[:work_id])
+    return @work = Work.find(params[:work_id]) if params[:work_id]
+
+    @admin_post = AdminPost.find(params[:admin_post_id])
   end
 
   def check_parent_visible
-    check_visibility_for(@work)
+    check_visibility_for(@work) if @work
+
+    access_denied(redirect: root_path) if @admin_post&.draft?
   end
 
   def index
-    @kudos = @work.kudos.includes(:user).with_user
-    @guest_kudos_count = @work.kudos.by_guest.count
+    kudos_target = @work || @admin_post
+    @kudos = kudos_target.kudos.includes(:user).with_user
+    @guest_kudos_count = kudos_target.kudos.by_guest.count
 
     respond_to do |format|
       format.html do

--- a/app/helpers/kudos_helper.rb
+++ b/app/helpers/kudos_helper.rb
@@ -34,7 +34,7 @@ module KudosHelper
       # Add the link to show more at the end of the list:
       kudos_links << link_to(
         t("kudos.user_links.more_link", count: collapsed_count),
-        work_kudos_path(commentable, before: kudos_to_display.last.id),
+        polymorphic_path([commentable, :kudos], before: kudos_to_display.last.id),
         id: "kudos_more_link", remote: true
       )
 
@@ -47,6 +47,6 @@ module KudosHelper
       end
     end
 
-    kudos_links.to_sentence(connectors).html_safe
+    [kudos_links.to_sentence(connectors).html_safe, total_count]
   end
 end

--- a/app/helpers/kudos_helper.rb
+++ b/app/helpers/kudos_helper.rb
@@ -1,5 +1,6 @@
 module KudosHelper
-  # Returns a comma-separated list of kudos. Restricts the list to the first
+  # Returns an array containing two items: a comma-separated list of kudos
+  # and the total kudos count. Restricts the list to the first
   # ArchiveConfig.MAX_KUDOS_TO_SHOW entries, with a link to view more.
   #
   # When showing_more is true, returns a list with a connector at the front,

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -94,7 +94,7 @@ class AdminPost < ApplicationRecord
       errors.add(:translated_post_id, "does not exist")
     end
   end
-  
+
   def guest_kudos_count
     Rails.cache.fetch "admin_posts/#{id}/guest_kudos_count-v2" do
       kudos.by_guest.count

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -8,6 +8,8 @@ class AdminPost < ApplicationRecord
     disable_all: 2
   }, default: :disable_anon, suffix: :comments, validate: { message: :invalid_permissions }
 
+  has_many :kudos, as: :commentable, inverse_of: :commentable, dependent: :destroy
+
   belongs_to :language
   belongs_to :translated_post, class_name: "AdminPost"
   has_many :translations, class_name: "AdminPost", foreign_key: "translated_post_id", dependent: :destroy
@@ -90,6 +92,18 @@ class AdminPost < ApplicationRecord
   def translated_post_must_exist
     if translated_post_id.present? && AdminPost.find_by(id: translated_post_id).nil?
       errors.add(:translated_post_id, "does not exist")
+    end
+  end
+  
+  def guest_kudos_count
+    Rails.cache.fetch "admin_posts/#{id}/guest_kudos_count-v2" do
+      kudos.by_guest.count
+    end
+  end
+
+  def all_kudos_count
+    Rails.cache.fetch "admin_posts/#{id}/kudos_count-v2" do
+      kudos.count
     end
   end
 

--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -96,13 +96,13 @@ class AdminPost < ApplicationRecord
   end
 
   def guest_kudos_count
-    Rails.cache.fetch "admin_posts/#{id}/guest_kudos_count-v2" do
+    Rails.cache.fetch "admin_posts/#{id}/guest_kudos_count" do
       kudos.by_guest.count
     end
   end
 
   def all_kudos_count
-    Rails.cache.fetch "admin_posts/#{id}/kudos_count-v2" do
+    Rails.cache.fetch "admin_posts/#{id}/kudos_count" do
       kudos.count
     end
   end

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -67,8 +67,8 @@ class Kudo < ApplicationRecord
   after_create :after_create, :update_work_stats
   def after_create
     return unless self.commentable.respond_to?(:pseuds)
-    
-    users = self.commentable.pseuds.map(&:user).uniq 
+
+    users = self.commentable.pseuds.map(&:user).uniq
 
     users.each do |user|
       RedisMailQueue.queue_kudo(user, self) if notify_user_by_email?(user)

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -1,7 +1,7 @@
 class Kudo < ApplicationRecord
   include Responder
 
-  VALID_COMMENTABLE_TYPES = %w[Work].freeze
+  VALID_COMMENTABLE_TYPES = %w[Work AdminPost].freeze
 
   belongs_to :user
   belongs_to :commentable, polymorphic: true
@@ -66,12 +66,12 @@ class Kudo < ApplicationRecord
   after_destroy :update_work_stats
   after_create :after_create, :update_work_stats
   def after_create
-    users = self.commentable.pseuds.map(&:user).uniq
+    return unless self.commentable.respond_to?(:pseuds)
+    
+    users = self.commentable.pseuds.map(&:user).uniq 
 
     users.each do |user|
-      if notify_user_by_email?(user)
-        RedisMailQueue.queue_kudo(user, self)
-      end
+      RedisMailQueue.queue_kudo(user, self) if notify_user_by_email?(user)
     end
   end
 
@@ -82,6 +82,13 @@ class Kudo < ApplicationRecord
       Rails.cache.delete("works/#{commentable_id}/kudos_count-v2")
       # If it's a guest kudo, also expire the work's cached guest kudos count.
       Rails.cache.delete("works/#{commentable_id}/guest_kudos_count-v2") if user_id.nil?
+    end
+
+    if commentable_type == "AdminPost"
+      # Expire the admin post's cached total kudos count.
+      Rails.cache.delete("admin_posts/#{commentable_id}/kudos_count-v2")
+      # If it's a guest kudo, also expire the admin post's cached guest kudos count.
+      Rails.cache.delete("admin_posts/#{commentable_id}/guest_kudos_count-v2") if user_id.nil?
     end
 
     # Expire the cached kudos section under the work.

--- a/app/models/kudo.rb
+++ b/app/models/kudo.rb
@@ -86,12 +86,12 @@ class Kudo < ApplicationRecord
 
     if commentable_type == "AdminPost"
       # Expire the admin post's cached total kudos count.
-      Rails.cache.delete("admin_posts/#{commentable_id}/kudos_count-v2")
+      Rails.cache.delete("admin_posts/#{commentable_id}/kudos_count")
       # If it's a guest kudo, also expire the admin post's cached guest kudos count.
-      Rails.cache.delete("admin_posts/#{commentable_id}/guest_kudos_count-v2") if user_id.nil?
+      Rails.cache.delete("admin_posts/#{commentable_id}/guest_kudos_count") if user_id.nil?
     end
 
-    # Expire the cached kudos section under the work.
+    # Expire the cached kudos section under the work/admin post.
     ActionController::Base.new.expire_fragment("#{commentable.cache_key}/kudos-v4")
   end
 

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -77,7 +77,7 @@
   <div id="kudos_message"></div>
   <%= flash_div :kudos_error, :kudos_notice %>
 
-  <% if kudos_target && (@chapter.blank? || @chapter.posted? || @admin_post&.posted?) %>
+  <% if kudos_target && (@chapter.blank? || @chapter.posted?) %>
     <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => kudos_target.guest_kudos_count, :commentable => kudos_target %>
   <% end %>
 

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -34,11 +34,12 @@
       <% end %>
     <% end %>
 
-    <% if @work && !is_author_of?(@work) && !blocked_by?(@work) && !logged_in_as_admin? %>
+    <% kudos_target = @admin_post || @work  %>
+    <% if !logged_in_as_admin? && (@admin_post || (@work && !is_author_of?(@work) && !blocked_by?(@work))) %>
       <li>
         <%= form_for(:kudo, url: kudos_path, html: { method: 'post', id: 'new_kudo' }) do |kudo_form| %>
-          <%= kudo_form.hidden_field :commentable_id, :value => @work.id %>
-          <%= kudo_form.hidden_field :commentable_type, :value => 'Work' %>
+          <%= kudo_form.hidden_field :commentable_id, :value => kudos_target.id %>
+          <%= kudo_form.hidden_field :commentable_type, :value => @admin_post ? 'AdminPost' : 'Work' %>
           <%= kudo_form.submit ts("Kudos ♥"), :id => 'kudo_submit' %>
         <% end %>
       </li>
@@ -76,8 +77,8 @@
   <div id="kudos_message"></div>
   <%= flash_div :kudos_error, :kudos_notice %>
 
-  <% if @work && (@chapter.blank? || @chapter.posted?) %>
-    <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => @work.guest_kudos_count, :commentable => @work %>
+  <% if kudos_target && (@chapter.blank? || @chapter.posted? || @admin_post&.posted?) %>
+    <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => kudos_target.guest_kudos_count, :commentable => kudos_target %>
   <% end %>
 
 

--- a/app/views/comments/_commentable.html.erb
+++ b/app/views/comments/_commentable.html.erb
@@ -34,13 +34,13 @@
       <% end %>
     <% end %>
 
-    <% kudos_target = @admin_post || @work  %>
+    <% kudos_target = @admin_post || @work %>
     <% if !logged_in_as_admin? && (@admin_post || (@work && !is_author_of?(@work) && !blocked_by?(@work))) %>
       <li>
-        <%= form_for(:kudo, url: kudos_path, html: { method: 'post', id: 'new_kudo' }) do |kudo_form| %>
-          <%= kudo_form.hidden_field :commentable_id, :value => kudos_target.id %>
-          <%= kudo_form.hidden_field :commentable_type, :value => @admin_post ? 'AdminPost' : 'Work' %>
-          <%= kudo_form.submit ts("Kudos ♥"), :id => 'kudo_submit' %>
+        <%= form_for(:kudo, url: kudos_path, html: { method: "post", id: "new_kudo" }) do |kudo_form| %>
+          <%= kudo_form.hidden_field :commentable_id, value: kudos_target.id %>
+          <%= kudo_form.hidden_field :commentable_type, value: @admin_post ? "AdminPost" : "Work" %>
+          <%= kudo_form.submit t(".kudos"), id: "kudo_submit" %>
         <% end %>
       </li>
     <% end %>
@@ -78,7 +78,7 @@
   <%= flash_div :kudos_error, :kudos_notice %>
 
   <% if kudos_target && (@chapter.blank? || @chapter.posted?) %>
-    <%= render "kudos/kudos", :kudos => @kudos, :guest_kudos_count => kudos_target.guest_kudos_count, :commentable => kudos_target %>
+    <%= render "kudos/kudos", kudos: @kudos, guest_kudos_count: kudos_target.guest_kudos_count, commentable: kudos_target %>
   <% end %>
 
 

--- a/app/views/home/_news_module.html.erb
+++ b/app/views/home/_news_module.html.erb
@@ -16,7 +16,10 @@
               <%= t(".news.published_html", publication_date: time_in_zone(admin_post.published_at)) %>
             </span>
             <span class="comments">
-              <%= ts('Comments:') %> <%= link_to(admin_post.count_visible_comments, polymorphic_path(admin_post, show_comments: true, anchor: :comments)) %>
+              <%= t(".news.comments_html", comments: link_to(number_with_delimiter(admin_post.count_visible_comments), admin_post_path(admin_post, show_comments: true, anchor: :comments))) %>
+            </span>
+            <span class="kudos">
+              <%= t(".news.kudos_html", kudos: link_to(number_with_delimiter(admin_post.all_kudos_count), admin_post_path(admin_post, anchor: "kudos"))) %>
             </span>
           </p>
         </div>

--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -14,7 +14,7 @@
           <% end %>
           <%= ts(pluralize(guest_kudos_count, "guest")) %>
         <% end %>
-        <%= ts(" left kudos on this work!") %>
+        <%= ts(" left kudos on this #{commentable.is_a?(AdminPost) ? "post" : "work"}!") %>
       </p>
     <% end %>
   <% end %>

--- a/app/views/kudos/_kudos.html.erb
+++ b/app/views/kudos/_kudos.html.erb
@@ -5,16 +5,20 @@
   <% if has_user_kudos || guest_kudos_count > 0 %>
     <% cache "#{commentable.cache_key}/kudos-v4", expires_in: ArchiveConfig.MINUTES_UNTIL_COMMENTABLE_KUDOS_LISTS_EXPIRE.minutes, race_condition_ttl: 10.seconds, skip_digest: true do %>
       <p class="kudos">
+        <% total_count = guest_kudos_count %>
         <% if has_user_kudos %>
-          <%= kudos_user_links(commentable, kudos, showing_more: false) %>
+          <% givers, user_kudos_count = kudos_user_links(commentable, kudos, showing_more: false) %>
+          <% total_count += user_kudos_count %>
+          <% givers = t("kudos.left_kudos.user_and_guest_html", users: givers, count: guest_kudos_count) unless guest_kudos_count.zero? %>
+        <% else %>
+          <% givers = t("kudos.left_kudos.guest_only", count: guest_kudos_count) %>
         <% end %>
-        <% if guest_kudos_count > 0 %>
-          <% if has_user_kudos %>
-            <%= ts(" as well as ") %>
-          <% end %>
-          <%= ts(pluralize(guest_kudos_count, "guest")) %>
+
+        <% if commentable.is_a?(Work) %>
+          <%= t("kudos.left_kudos.work_html", givers_list: givers, count: total_count) %>
+        <% else %>
+          <%= t("kudos.left_kudos.admin_post_html", givers_list: givers, count: total_count) %>
         <% end %>
-        <%= ts(" left kudos on this #{commentable.is_a?(AdminPost) ? "post" : "work"}!") %>
       </p>
     <% end %>
   <% end %>

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -1,5 +1,6 @@
 <h2 class="heading">
-  <%= search_header(@kudos, nil, "User") %> Who Left Kudos on <%= link_to(@work.title, @work) %>
+  <% kudos_target = @work || @admin_post %>
+  <%= search_header(@kudos, nil, "User") %> Who Left Kudos on <%= link_to(kudos_target.title, kudos_target) %>
 </h2>
 
 <% if @guest_kudos_count.positive? %>
@@ -13,8 +14,11 @@
 
   <div id="kudos">
     <p class="kudos">
-      <%= @kudos.map { |kudo| link_to kudo.user.login, kudo.user }.to_sentence.html_safe %>
-      <%= ts(" left kudos on this work!") %>
+      <% if @work %>
+        <%= t("kudos.left_kudos.work_html", givers_list: to_sentence(@kudos.map { |kudo| link_to kudo.user.login, kudo.user }), count: @kudos.length) %>
+      <% else %>
+        <%= t("kudos.left_kudos.admin_post_html", givers_list: to_sentence(@kudos.map { |kudo| link_to kudo.user.login, kudo.user }), count: @kudos.length) %>
+      <% end %>
     </p>
   </div>
 

--- a/app/views/kudos/index.js.erb
+++ b/app/views/kudos/index.js.erb
@@ -1,2 +1,2 @@
 $j("#kudos_more_connector").remove();
-$j("#kudos_more_link").replaceWith("<%= j kudos_user_links(@work, @kudos) %>");
+$j("#kudos_more_link").replaceWith("<%= j kudos_user_links(@work || @admin_post, @kudos).first %>");

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2511,6 +2511,19 @@ en:
       more_link:
         one: "%{count} more user"
         other: "%{count} more users"
+    left_kudos:
+      admin_post_html:
+        one: "%{givers_list} left kudos on this post!"
+        other: "%{givers_list} left kudos on this post!"
+      work_html:
+        one: "%{givers_list} left kudos on this work!"
+        other: "%{givers_list} left kudos on this work!"
+      user_and_guest_html:
+        one: "%{users} as well as %{count} guest"
+        other: "%{users} as well as %{count} guests"
+      guest_only:
+        one: "%{count} guest"
+        other: "%{count} guests"
   languages:
     form:
       abuse_support_available: Abuse support available

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1996,6 +1996,8 @@ en:
       parent_org_intro_html: The Archive of Our Own (AO3) is a project of the %{parent_org_link}.
     news_module:
       news:
+        comments_html: 'Comments: %{comments}'
+        kudos_html: 'Kudos: %{kudos}'
         published_html: 'Published: %{publication_date}'
     privacy:
       account_termination:
@@ -2507,23 +2509,23 @@ en:
     guest_header:
       one: "%{count} guest has also left kudos"
       other: "%{count} guests have also left kudos"
-    user_links:
-      more_link:
-        one: "%{count} more user"
-        other: "%{count} more users"
     left_kudos:
       admin_post_html:
         one: "%{givers_list} left kudos on this post!"
         other: "%{givers_list} left kudos on this post!"
-      work_html:
-        one: "%{givers_list} left kudos on this work!"
-        other: "%{givers_list} left kudos on this work!"
-      user_and_guest_html:
-        one: "%{users} as well as %{count} guest"
-        other: "%{users} as well as %{count} guests"
       guest_only:
         one: "%{count} guest"
         other: "%{count} guests"
+      user_and_guest_html:
+        one: "%{users} as well as %{count} guest"
+        other: "%{users} as well as %{count} guests"
+      work_html:
+        one: "%{givers_list} left kudos on this work!"
+        other: "%{givers_list} left kudos on this work!"
+    user_links:
+      more_link:
+        one: "%{count} more user"
+        other: "%{count} more users"
   languages:
     form:
       abuse_support_available: Abuse support available

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -930,6 +930,7 @@ en:
       draft_news_index: Back to AO3 News Drafts
       guest_comments_disabled: Sorry, the Archive doesn't allow guests to comment right now.
       invite_to_collections_link: Invite To Collections
+      kudos: Kudos ♥
       logged_as_admin: Please log out of your admin account to comment.
       news_index: Back to AO3 News Index
       permissions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,6 +182,7 @@ Rails.application.routes.draw do
       put :post
       get :preview
     end
+    resources :kudos, only: [:index]
   end
 
   namespace :admin do

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -263,9 +263,8 @@ Feature: Kudos
   Scenario: Leave kudos on an admin post when logged in
     Given I have posted an admin post
       And I am logged in as "happyuser"
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
       And all emails have been delivered
+      And I go to the "Default Admin Post" admin post page
       And I press "Kudos ♥"
     Then I should see "Thank you for leaving kudos!"
       And I should see "happyuser left kudos on this post!"
@@ -276,8 +275,8 @@ Feature: Kudos
 
   Scenario: Leave kudos on an admin post when logged out
     Given I have posted an admin post
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I go to the "Default Admin Post" admin post page
       And I press "Kudos ♥"
     Then I should see "Thank you for leaving kudos!"
       And I should see "1 guest left kudos on this post!"
@@ -290,9 +289,8 @@ Feature: Kudos
   Scenario: Leave kudos on an admin post via JS when logged in
     Given I have posted an admin post
       And I am logged in as "happyuser"
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
       And all emails have been delivered
+      And I go to the "Default Admin Post" admin post page
       And I press "Kudos ♥"
     Then I should see "Thank you for leaving kudos!"
       And I should see "happyuser left kudos on this post!"
@@ -302,8 +300,8 @@ Feature: Kudos
   @javascript
   Scenario: Leave kudos on an admin post via JS when logged out
     Given I have posted an admin post
-      And I go to the admin-posts page
-      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I go to the "Default Admin Post" admin post page
       And I press "Kudos ♥"
     Then I should see "Thank you for leaving kudos!"
       And I should see "1 guest left kudos on this post!"

--- a/features/comments_and_kudos/kudos.feature
+++ b/features/comments_and_kudos/kudos.feature
@@ -259,3 +259,53 @@ Feature: Kudos
     When I view the work "Awesome Story"
       And I press "Kudos ♥"
     Then I should see "Please log out of your archivist account!"
+
+  Scenario: Leave kudos on an admin post when logged in
+    Given I have posted an admin post
+      And I am logged in as "happyuser"
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "happyuser left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+    When kudos are sent
+    Then 0 emails should be delivered
+
+  Scenario: Leave kudos on an admin post when logged out
+    Given I have posted an admin post
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "1 guest left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+    When kudos are sent
+    Then 0 emails should be delivered
+
+  @javascript
+  Scenario: Leave kudos on an admin post via JS when logged in
+    Given I have posted an admin post
+      And I am logged in as "happyuser"
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And all emails have been delivered
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "happyuser left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"
+
+  @javascript
+  Scenario: Leave kudos on an admin post via JS when logged out
+    Given I have posted an admin post
+      And I go to the admin-posts page
+      And I follow "Default Admin Post"
+      And I press "Kudos ♥"
+    Then I should see "Thank you for leaving kudos!"
+      And I should see "1 guest left kudos on this post!"
+    When I press "Kudos ♥"
+    Then I should see "You have already left kudos here. :)"

--- a/features/comments_and_kudos/kudos_pagination.feature
+++ b/features/comments_and_kudos/kudos_pagination.feature
@@ -65,3 +65,25 @@ Feature: Kudos Pagination
     When I follow "Next"
     Then I should see "7 - 9 of 9 Users Who Left Kudos on Popular (9)"
       And I should see "fan3, fan2, and fan1 left kudos on this work!"
+
+  @javascript
+  Scenario: Multiple pages of kudos on an admin post
+    Given an admin post "Popular Update (4)" with 4 kudos
+    When I go to the "Popular Update (4)" admin post page
+    Then I should see "fan4, fan3, fan2, and 1 more user left kudos on this post!"
+    When I follow "1 more user"
+    Then I should see "fan4, fan3, fan2, and fan1 left kudos on this post!"
+
+  Scenario: Three pages of kudos without javascript on an admin post
+    Given an admin post "Popular Update (9)" with 9 kudos
+    When I go to the "Popular Update (9)" admin post page
+    Then I should see "fan9, fan8, fan7, and 6 more users left kudos on this post!"
+    When I follow "6 more users"
+    Then I should see "1 - 3 of 9 Users Who Left Kudos on Popular Update (9)"
+      And I should see "fan9, fan8, and fan7 left kudos on this post!"
+    When I follow "Next"
+    Then I should see "4 - 6 of 9 Users Who Left Kudos on Popular Update (9)"
+      And I should see "fan6, fan5, and fan4 left kudos on this post!"
+    When I follow "Next"
+    Then I should see "7 - 9 of 9 Users Who Left Kudos on Popular Update (9)"
+      And I should see "fan3, fan2, and fan1 left kudos on this post!"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -145,6 +145,7 @@ end
 Given /^I have posted an admin post$/ do
   step(%{I am logged in as a "communications" admin})
   step("I make an admin post")
+  step("I am on the homepage")
   step("I log out")
 end
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -145,7 +145,6 @@ end
 Given /^I have posted an admin post$/ do
   step(%{I am logged in as a "communications" admin})
   step("I make an admin post")
-  step("I am on the homepage")
   step("I log out")
 end
 

--- a/features/step_definitions/kudos_steps.rb
+++ b/features/step_definitions/kudos_steps.rb
@@ -12,6 +12,16 @@ Given "a work {string} with {int} kudo(s)" do |title, count|
   end
 end
 
+Given "an admin post {string} with {int} kudo(s)" do |title, count|
+  admin_post = FactoryBot.create(:admin_post, title: title)
+
+  count.times do |i|
+    user = User.find_by(login: "fan#{i + 1}") ||
+           FactoryBot.create(:user, login: "fan#{i + 1}")
+    admin_post.kudos.create(user: user)
+  end
+end
+
 Given "the maximum number of kudos to show is {int}" do |count|
   allow(ArchiveConfig).to receive(:MAX_KUDOS_TO_SHOW).and_return(count)
 end

--- a/spec/controllers/kudos_controller_spec.rb
+++ b/spec/controllers/kudos_controller_spec.rb
@@ -248,5 +248,26 @@ describe KudosController do
         it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
       end
     end
+
+    context "denies access for admin post that is a draft" do
+      let(:admin_post) { create(:admin_post, :draft) }
+
+      it "redirects guests" do
+        get :index, params: { admin_post_id: admin_post }
+        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+
+      it "redirects users" do
+        fake_login
+        get :index, params: { admin_post_id: admin_post }
+        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach.")
+      end
+
+      it "redirects admin" do
+        fake_login_admin(create(:admin))
+        get :index, params: { admin_post_id: admin_post }
+        it_redirects_to_with_error(root_path, "Sorry, you don't have permission to access the page you were trying to reach. Please log in.")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-2312

## Purpose

Adds kudos to news posts. They can be given at the bottom of the post, similar to works and are shown there. They have the same restrictions as work kudos (not on drafts, not by admins, not by official accounts etc). They use the same pagination mechanism as work kudos. They're shown on the blurb on the homepage, next to the comments count, but they are not shown in the sidebar of AdminPostsController#index.

## Testing Instructions

TBD

## References

Adopted #3082

PR Limit: 6 out of 5
Using reviewer bonus:
#5012
#4991

## Credit

tuff (original PR)
ariana-paris (original PR review)
james_ (original PR review)
sarken (original PR review)
Bilka (original PR review)
Bilka