### PR TITLE
AO3-6001 Derive subscribable type from param name server-side

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -24,7 +24,10 @@ class SubscriptionsController < ApplicationController
   # POST /subscriptions
   # POST /subscriptions.xml
   def create
-    @subscription = @user.subscriptions.build(subscription_params)
+    @subscribable = load_subscribable
+    return if performed?
+
+    @subscription = @user.subscriptions.build(subscribable: @subscribable)
 
     success_message = ts("You are now following %{name}. If you'd like to stop receiving email updates, you can unsubscribe from <a href=\"#{user_subscriptions_path}\">your Subscriptions page</a>.", name: @subscription.name).html_safe
     if @subscription.save
@@ -86,10 +89,25 @@ class SubscriptionsController < ApplicationController
     @subscribable_type = params[:type].pluralize.downcase if params[:type] && Subscription::VALID_SUBSCRIBABLES.include?(params[:type].singularize.titleize)
   end
 
-  def subscription_params
-    params.require(:subscription).permit(
-      :subscribable_id, :subscribable_type
-    )
-  end
+  SUBSCRIBABLE_PARAMS = {
+    work_id: Work,
+    series_id: Series,
+    user_id: User
+  }.freeze
 
+  def load_subscribable
+    sub_params = params[:subscription] || {}
+    matched = SUBSCRIBABLE_PARAMS.filter_map do |key, klass|
+      id = sub_params[key]
+      [klass, id] if id.present?
+    end
+
+    if matched.size != 1
+      head :unprocessable_entity
+      return
+    end
+
+    klass, id = matched.first
+    klass.find(id)
+  end
 end

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -1,14 +1,15 @@
 <% # expects subscription and current_user %>
 <%= form_for([current_user, subscription],
   method: subscription.new_record? ? 'post' : 'delete',
-  html: { 
-    class: 'ajax-create-destroy', 
-    data: { 
+  html: {
+    class: "ajax-create-destroy",
+    data: {
       create_value: ts('Subscribe'),
       destroy_value: ts('Unsubscribe')
     }
   }) do |f| %>
-  <%= f.hidden_field :subscribable_id %>
-  <%= f.hidden_field :subscribable_type %>
+  <% if subscription.new_record? %>
+    <%= hidden_field_tag "subscription[#{subscription.subscribable_type.underscore}_id]", subscription.subscribable_id %>
+  <% end %>
   <%= f.submit subscription.new_record? ? ts('Subscribe') : ts('Unsubscribe') %>
 <% end %>

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -91,6 +91,84 @@ describe SubscriptionsController do
     end
   end
 
+  describe "POST #create" do
+    before { fake_login_known_user(user) }
+
+    context "when subscribing to a work" do
+      let(:work) { create(:work) }
+
+      it "creates a subscription and redirects with a success notice" do
+        post :create, params: { user_id: user.login, subscription: { work_id: work.id } }
+        expect(user.subscriptions.where(subscribable: work)).to exist
+        expect(flash[:notice]).to include("You are now following #{work.title}")
+      end
+    end
+
+    context "when subscribing to a series" do
+      let(:series) { create(:series) }
+
+      it "creates a subscription and redirects with a success notice" do
+        post :create, params: { user_id: user.login, subscription: { series_id: series.id } }
+        expect(user.subscriptions.where(subscribable: series)).to exist
+        expect(flash[:notice]).to include("You are now following #{series.title}")
+      end
+    end
+
+    context "when subscribing to a user" do
+      let(:author) { create(:user) }
+
+      it "creates a subscription and redirects with a success notice" do
+        post :create, params: { user_id: user.login, subscription: { user_id: author.id } }
+        expect(user.subscriptions.where(subscribable: author)).to exist
+        expect(flash[:notice]).to include("You are now following #{author.login}")
+      end
+    end
+
+    context "when no subscribable ID is provided" do
+      it "returns 422" do
+        post :create, params: { user_id: user.login, subscription: {} }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when multiple subscribable IDs are provided" do
+      let(:work) { create(:work) }
+      let(:series) { create(:series) }
+
+      it "returns 422" do
+        post :create, params: { user_id: user.login, subscription: { work_id: work.id, series_id: series.id } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the subscribable does not exist" do
+      it "raises a not found error" do
+        expect do
+          post :create, params: { user_id: user.login, subscription: { work_id: -1 } }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when subscribable_type is provided instead of a type-specific ID" do
+      let(:work) { create(:work) }
+
+      it "returns 422 because the type param is ignored" do
+        post :create, params: { user_id: user.login, subscription: { subscribable_type: "Work", subscribable_id: work.id } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(user.subscriptions).to be_empty
+      end
+    end
+
+    context "when a browser-translated subscribable_type is sent alongside a valid ID" do
+      let(:work) { create(:work) }
+
+      it "ignores the translated type and creates the subscription" do
+        post :create, params: { user_id: user.login, subscription: { work_id: work.id, subscribable_type: "用户" } }
+        expect(user.subscriptions.where(subscribable: work)).to exist
+      end
+    end
+  end
+
   describe "DELETE #destroy" do
     let(:work) { create(:work) }
     let!(:subscription) { create(:subscription, user: user, subscribable: work) }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6001

## Purpose

When a browser auto-translates a page, hidden fields containing class names like `"User"` can be translated (e.g. `"用户"` in Chinese), causing a `NameError` crash when the form is submitted.

This PR removes `subscribable_type` and `subscribable_id` from the subscription form's hidden fields and replaces them with a single type-specific ID field (`work_id`, `series_id`, or `user_id`). The controller derives the subscribable type from the parameter name using a `SUBSCRIBABLE_PARAMS` mapping, so no user-supplied class name ever reaches the server.

### Changes

- **Controller:** Replace `subscription_params` mass-assignment with `load_subscribable`, which maps `work_id` → `Work`, `series_id` → `Series`, `user_id` → `User`. Returns 422 if zero or multiple IDs are provided. Remove unused `subscription_params` method.
- **Form:** Send a single `hidden_field_tag` with the type-specific param name (e.g. `subscription[work_id]`) only for new subscriptions. No hidden fields are sent for unsubscribe (the subscription ID is in the URL).
- **Specs:** Add 8 controller specs for `POST #create` covering all three subscribable types, missing/multiple/nonexistent IDs, legacy `subscribable_type` params, and the specific regression case (valid `work_id` alongside a browser-translated `subscribable_type`).

## Testing Instructions

1. Log in and navigate to a work, series, or user page.
2. Inspect the Subscribe button, verify the hidden field is `subscription[work_id]` (or `series_id`/`user_id`) with a numeric value, and that no `subscribable_type` or `subscribable_id` fields exist.
3. Click Subscribe, it should work normally.
4. Use browser translation (or manually edit the DOM) to field with a translated value like `"用户"` alongside the valid `work_id` subscribing should still succeed.
5. Remove the type-specific ID field entirely and submit(no 500 error).

## Credit

Pablo Monfort (he/him)