### PR TITLE
AO3-7506 Add backfill task for missing username pseuds

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -672,5 +672,29 @@ namespace :After do
   task(remove_noncanonical_fandom_wrangling_assignments: :environment) do
     WranglingAssignment.joins("LEFT JOIN tags ON (tags.id = wrangling_assignments.fandom_id)").where(tags: { canonical: false }).find_each(&:destroy!)
   end
+
+  desc "Backfill missing username-matching pseuds"
+  task(backfill_missing_pseuds: :environment) do
+    users = User.where(
+      "NOT EXISTS (SELECT 1 FROM pseuds WHERE pseuds.name = users.login AND pseuds.user_id = users.id LIMIT 1)"
+    )
+    total = users.count
+    puts "Backfilling pseuds: found #{total} #{'user'.pluralize(total)} missing a username-matching pseud"
+
+    created = 0
+    failed = 0
+    users.find_each do |user|
+      Pseud.create!(name: user.login, user_id: user.id)
+      created += 1
+      puts "  Created pseud \"#{user.login}\" for user #{user.id}"
+    rescue ActiveRecord::RecordInvalid => e
+      failed += 1
+      puts "  Failed to create pseud \"#{user.login}\" for user #{user.id}: #{e.message}"
+    end
+
+    puts "Done: #{created} created, #{failed} failed"
+    STDOUT.flush
+  end
+
   # This is the end that you have to put new tasks above.
 end

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -693,7 +693,7 @@ namespace :After do
     end
 
     puts "Done: #{created} created, #{failed} failed"
-    STDOUT.flush
+    $stdout.flush
   end
 
   # This is the end that you have to put new tasks above.

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -675,24 +675,35 @@ namespace :After do
 
   desc "Backfill missing username-matching pseuds"
   task(backfill_missing_pseuds: :environment) do
+    # BINARY: also include users whose only match differs by case/diacritics
     users = User.where(
-      "NOT EXISTS (SELECT 1 FROM pseuds WHERE pseuds.name = users.login AND pseuds.user_id = users.id LIMIT 1)"
+      "NOT EXISTS (SELECT 1 FROM pseuds WHERE BINARY pseuds.name = BINARY users.login AND pseuds.user_id = users.id LIMIT 1)"
     )
     total = users.count
-    puts "Backfilling pseuds: found #{total} #{'user'.pluralize(total)} missing a username-matching pseud"
+    puts "Backfilling pseuds: found #{total} #{'user'.pluralize(total)} missing an exact username-matching pseud"
 
     created = 0
+    updated = 0
     failed = 0
     users.find_each do |user|
-      Pseud.create!(name: user.login, user_id: user.id)
-      created += 1
-      puts "  Created pseud \"#{user.login}\" for user #{user.id}"
-    rescue ActiveRecord::RecordInvalid => e
+      # Collation-aware: matches ignoring case/diacritics
+      existing = user.pseuds.where(name: user.login).first
+      if existing
+        existing.name = user.login
+        existing.save!(validate: false)
+        updated += 1
+        puts "  Updated pseud to \"#{user.login}\" for user #{user.id}"
+      else
+        Pseud.create!(name: user.login, user_id: user.id)
+        created += 1
+        puts "  Created pseud \"#{user.login}\" for user #{user.id}"
+      end
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
       failed += 1
-      puts "  Failed to create pseud \"#{user.login}\" for user #{user.id}: #{e.message}"
+      puts "  Failed to backfill pseud \"#{user.login}\" for user #{user.id}: #{e.message}"
     end
 
-    puts "Done: #{created} created, #{failed} failed"
+    puts "Done: #{created} created, #{updated} updated, #{failed} failed"
     $stdout.flush
   end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -889,7 +889,8 @@ describe "rake After:backfill_missing_pseuds" do
     let!(:user) { create(:user) }
 
     it "does not create any pseuds" do
-      expect { subject.invoke }.not_to change { Pseud.count }
+      expect { subject.invoke }
+        .not_to change { Pseud.count }
     end
   end
 
@@ -901,7 +902,9 @@ describe "rake After:backfill_missing_pseuds" do
     end
 
     it "creates a pseud matching the username" do
-      expect { subject.invoke }.to change { user.pseuds.reload.count }.by(1)
+      expect { subject.invoke }
+        .to change { user.pseuds.reload.count }
+        .by(1)
       expect(user.pseuds.find_by(name: user.login)).to be_present
     end
   end
@@ -916,7 +919,9 @@ describe "rake After:backfill_missing_pseuds" do
     end
 
     it "still creates a pseud for the affected user" do
-      expect { subject.invoke }.to change { affected_user.pseuds.reload.count }.by(1)
+      expect { subject.invoke }
+        .to change { affected_user.pseuds.reload.count }
+        .by(1)
       expect(affected_user.pseuds.find_by(name: affected_user.login)).to be_present
     end
   end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -883,3 +883,41 @@ describe "rake After:remove_noncanonical_fandom_wrangling_assignments" do
     expect(WranglingAssignment.all).to include(assignment2)
   end
 end
+
+describe "rake After:backfill_missing_pseuds" do
+  context "when all users have a username-matching pseud" do
+    let!(:user) { create(:user) }
+
+    it "does not create any pseuds" do
+      expect { subject.invoke }.not_to change { Pseud.count }
+    end
+  end
+
+  context "when a user is missing a username-matching pseud" do
+    let!(:user) { create(:user) }
+
+    before do
+      user.pseuds.find_by(name: user.login).delete
+    end
+
+    it "creates a pseud matching the username" do
+      expect { subject.invoke }.to change { user.pseuds.reload.count }.by(1)
+      expect(user.pseuds.find_by(name: user.login)).to be_present
+    end
+  end
+
+  context "when another user has a pseud with the same name as the affected user's login" do
+    let!(:affected_user) { create(:user) }
+    let!(:other_user) { create(:user) }
+
+    before do
+      affected_user.pseuds.find_by(name: affected_user.login).delete
+      create(:pseud, user: other_user, name: affected_user.login)
+    end
+
+    it "still creates a pseud for the affected user" do
+      expect { subject.invoke }.to change { affected_user.pseuds.reload.count }.by(1)
+      expect(affected_user.pseuds.find_by(name: affected_user.login)).to be_present
+    end
+  end
+end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -925,4 +925,34 @@ describe "rake After:backfill_missing_pseuds" do
       expect(affected_user.pseuds.find_by(name: affected_user.login)).to be_present
     end
   end
+
+  # Scenarios from before AO3-6359 / PR #5534: username rename left a pseud that
+  # matched only by case or diacritics, so the exact-match delete guard failed.
+  context "when the user has a pseud matching the username except for capitalization" do
+    let!(:user) { create(:user, login: "Name") }
+
+    before do
+      user.pseuds.find_by(name: "Name").update_column(:name, "name")
+    end
+
+    it "updates the pseud name to exactly match the username" do
+      expect { subject.invoke }
+        .not_to change { user.pseuds.reload.count }
+      expect(user.pseuds.reload.map(&:name)).to contain_exactly("Name")
+    end
+  end
+
+  context "when the user has a pseud matching the username except for diacritics" do
+    let!(:user) { create(:user, login: "Name") }
+
+    before do
+      user.pseuds.find_by(name: "Name").update_column(:name, "Näme")
+    end
+
+    it "updates the pseud name to exactly match the username" do
+      expect { subject.invoke }
+        .not_to change { user.pseuds.reload.count }
+      expect(user.pseuds.reload.map(&:name)).to contain_exactly("Name")
+    end
+  end
 end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -955,4 +955,18 @@ describe "rake After:backfill_missing_pseuds" do
       expect(user.pseuds.reload.map(&:name)).to contain_exactly("Name")
     end
   end
+
+  context "when the pseud fails to save" do
+    let!(:user) { create(:user) }
+
+    before do
+      user.pseuds.find_by(name: user.login).delete
+      allow(Pseud).to receive(:create!).and_raise(ActiveRecord::RecordNotSaved.new("Validation failed"))
+    end
+
+    it "reports the failure and does not crash" do
+      expect { subject.invoke }
+        .to output(/Failed to backfill pseud/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7506

## Purpose

Adds an `After:backfill_missing_pseuds` rake task that finds users who don't have a pseud matching their current username and creates one.

This covers the ~100 users who deleted their username-matching pseud before the fix in AO3-6359 (PR #5534) was deployed.

One difference from the SQL in the ticket: I added `AND pseuds.user_id = users.id` to the subquery. Without it, if another user happens to have a pseud with the same name as the affected user's login, the query would miss that user.

## Testing Instructions

Testing instructions are in the Jira issue.

## References

- AO3-6359 / #5534 — the fix that prevents deleting the username-matching pseud

## Credit

Pablo Monfort (he/him)