### PR TITLE
AO3-6184 Destroy taggings when admin post tag is deleted

### DIFF
--- a/app/models/admin_post_tag.rb
+++ b/app/models/admin_post_tag.rb
@@ -1,6 +1,6 @@
 class AdminPostTag < ApplicationRecord
   belongs_to :language
-  has_many :admin_post_taggings
+  has_many :admin_post_taggings, dependent: :destroy
   has_many :admin_posts, through: :admin_post_taggings
 
   validates_presence_of :name

--- a/spec/models/admin_post_tag_spec.rb
+++ b/spec/models/admin_post_tag_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe AdminPostTag do
+  describe "destroy" do
+    let(:admin_post_tag) { AdminPostTag.create!(name: "test-tag", language: Language.default) }
+    let(:admin_post) { create(:admin_post) }
+
+    before do
+      admin_post.admin_post_taggings.create!(admin_post_tag: admin_post_tag)
+    end
+
+    it "destroys associated admin post taggings" do
+      expect { admin_post_tag.destroy }
+        .to change { AdminPostTagging.count }
+        .by(-1)
+    end
+
+    it "does not destroy the admin post" do
+      expect { admin_post_tag.destroy }
+        .not_to change { AdminPost.count }
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6184

## Purpose

Adds `dependent: :destroy` to the `AdminPostTag#admin_post_taggings` association so that destroying an admin post tag also destroys its taggings. Without this, the orphaned taggings cause errors on the associated admin posts.

## Testing Instructions

Testing instructions are in the Jira issue.

## Credit

Pablo Monfort (he/him)