### PR TITLE
AO3-7539 Bump websocket-driver from 0.8.0 to 0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,7 +683,7 @@ GEM
     webrick (1.9.1)
     webrobots (0.1.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7539

## Purpose

Bump the gem to fix some security issues that don't affect us.

## Credit

Bilka
