### PR TITLE
AO3-7156 Add scheduled task to delete unused admin post tags

### DIFF
--- a/app/models/admin_post_tag.rb
+++ b/app/models/admin_post_tag.rb
@@ -1,4 +1,7 @@
 class AdminPostTag < ApplicationRecord
+  include AsyncWithResque
+  @queue = :utilities
+
   belongs_to :language
   has_many :admin_post_taggings
   has_many :admin_posts, through: :admin_post_taggings
@@ -18,4 +21,7 @@ class AdminPostTag < ApplicationRecord
     tag.valid? ? tag : nil
   end
 
+  def self.delete_unused
+    left_outer_joins(:admin_post_taggings).where(admin_post_taggings: { id: nil }).delete_all
+  end
 end

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -114,6 +114,13 @@ cleanup_work_original_creators:
     Remove original_creators for works orphaned/moved more than
     ORIGINAL_CREATOR_TTL_HOURS hours ago.
 
+delete_unused_admin_post_tags:
+  cron: "0 0 * * 0"
+  class: "AdminPostTag"
+  queue: utilities
+  args: delete_unused
+  description: "Delete admin post tags not used on any admin post."
+
 disable_admin_post_comments:
   every: 1d
   class: "AdminPost"

--- a/factories/admin_post_tags.rb
+++ b/factories/admin_post_tags.rb
@@ -1,0 +1,8 @@
+require "faker"
+
+FactoryBot.define do
+  factory :admin_post_tag do
+    name { Faker::Lorem.unique.word }
+    language { Language.default }
+  end
+end

--- a/lib/tasks/tag_tasks.rake
+++ b/lib/tasks/tag_tasks.rake
@@ -86,7 +86,7 @@ namespace :Tag do
 
   desc "Delete unused admin post tags"
   task(delete_unused_admin_post_tags: :environment) do
-    AdminPostTag.joins("LEFT JOIN `admin_post_taggings` ON admin_post_taggings.admin_post_tag_id = admin_post_tags.id").where("admin_post_taggings.id IS NULL").destroy_all
+    AdminPostTag.delete_unused
   end
 
   desc "Clean up orphaned taggings"

--- a/spec/models/admin_post_tag_spec.rb
+++ b/spec/models/admin_post_tag_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe AdminPostTag do
+  describe ".delete_unused" do
+    let!(:admin_post) { create(:admin_post) }
+    let!(:tag) { create(:admin_post_tag) }
+
+    context "when a tag is used on an admin post" do
+      before do
+        admin_post.admin_post_taggings.create!(admin_post_tag: tag)
+      end
+
+      it "does not delete the tag" do
+        expect { AdminPostTag.delete_unused }
+          .not_to change { AdminPostTag.count }
+      end
+    end
+
+    context "when a tag is not used on any admin post" do
+      it "deletes the tag" do
+        expect { AdminPostTag.delete_unused }
+          .to change { AdminPostTag.count }
+          .by(-1)
+        expect(AdminPostTag.find_by(name: tag.name)).to be_nil
+      end
+    end
+
+    context "when both used and unused tags exist" do
+      let!(:unused_tag) { create(:admin_post_tag) }
+
+      before do
+        admin_post.admin_post_taggings.create!(admin_post_tag: tag)
+      end
+
+      it "only deletes the unused tag" do
+        expect { AdminPostTag.delete_unused }
+          .to change { AdminPostTag.count }
+          .by(-1)
+        expect(AdminPostTag.find_by(name: tag.name)).to be_present
+        expect(AdminPostTag.find_by(name: unused_tag.name)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7156

## Purpose

Adds a weekly scheduled Resque job that automatically deletes admin post tags not used on any admin post. The logic is extracted into `AdminPostTag.delete_unused`, which the existing rake task (`Tag:delete_unused_admin_post_tags`) now delegates to as well.

## Testing Instructions

1. Create some admin post tags (via admin posts in the admin panel)
2. Remove the tags from the posts so they become unused
3. Run `rake Tag:delete_unused_admin_post_tags` from the console
4. Verify that only unused tags are deleted

## References

The existing rake task used raw SQL for the LEFT JOIN. This PR replaces it with `left_outer_joins`, which is more idiomatic Rails.

## Credit

Pablo Monfort (he/him)