### PR TITLE
AO3-7512 Exclude banned users from total user count on the homepage

### DIFF
--- a/app/decorators/homepage.rb
+++ b/app/decorators/homepage.rb
@@ -7,7 +7,7 @@ class Homepage
 
   def rounded_counts
     @user_count = Rails.cache.fetch("/v1/home/counts/user", expires_in: 40.minutes) do
-      estimate_number(User.count)
+      estimate_number(User.where(banned: false).count)
     end
     @work_count = Rails.cache.fetch("/v1/home/counts/works", expires_in: 40.minutes) do
       estimate_number(Work.posted.count)

--- a/db/migrate/20260722105052_add_index_on_banned_to_users.rb
+++ b/db/migrate/20260722105052_add_index_on_banned_to_users.rb
@@ -1,0 +1,7 @@
+class AddIndexOnBannedToUsers < ActiveRecord::Migration[8.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    add_index :users, :banned
+  end
+end

--- a/spec/models/search/homepage_decorator_spec.rb
+++ b/spec/models/search/homepage_decorator_spec.rb
@@ -3,6 +3,24 @@ require "spec_helper"
 describe Homepage do
   let(:user) { create(:user) }
 
+  describe "#rounded_counts" do
+    it "counts users that are not banned" do
+      user
+      create(:user)
+
+      homepage = Homepage.new(user)
+      expect(homepage.rounded_counts.first).to eq(2)
+    end
+
+    it "excludes banned users from the user count" do
+      user
+      create(:user, banned: true)
+
+      homepage = Homepage.new(user)
+      expect(homepage.rounded_counts.first).to eq(1)
+    end
+  end
+
   describe "#readings" do
     it "includes user's toread readings" do
       reading1 = create(:reading, user: user, toread: true)


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7512

## Purpose

The registered-user total shown on the homepage previously counted every user. This changes it to count only users who are not permanently banned, so the displayed figure reflects the active userbase.

- Homepage#rounded_counts now counts User.where(banned: false) instead of User.count.
- Adds a database index on users.banned to keep this count performant. This is a departure migration — it uses pt-online-schema-change on staging/production.

 ⚠️ Deploy note: This has a departure migration that should be run before the deploy.

The homepage counts are cached for 40 minutes (/v1/home/counts/user), so the displayed total will self-correct within ~40 minutes of deploy.

## Testing Instructions

Per the Jira issue, this is hard to test on Staging, so it's covered by automated tests instead. No manual QA required.

New specs in spec/models/search/homepage_decorator_spec.rb under #rounded_counts:
- counts users that are not banned
- excludes banned users from the user count

bundle exec rspec spec/models/search/homepage_decorator_spec.rb

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

y7nieSEl5, she/her

If you have a Jira account, please include the same name in the "Full name"
field on your Jira profile, so we can assign you the issues you're working on.

*Please note that if you do not fill in this section, we will use your GitHub account name and
they/them pronouns.*
