### PR TITLE
AO3-7536 Expire creator comment caches when creatorships of anonymous work change

### DIFF
--- a/app/models/creatorship.rb
+++ b/app/models/creatorship.rb
@@ -73,11 +73,14 @@ class Creatorship < ApplicationRecord
   ########################################
 
   after_create :add_to_parents
+  after_create :bust_anonymous_comment_cache
   after_update :add_to_parents, if: :saved_change_to_approved?
+  after_update :bust_anonymous_comment_cache, if: :saved_change_to_approved?
 
   before_destroy :expire_caches
   before_destroy :check_not_last
   before_destroy :save_original_creator
+  after_destroy :bust_anonymous_comment_cache
   after_destroy :remove_from_children
 
   after_commit :update_indices
@@ -194,6 +197,16 @@ class Creatorship < ApplicationRecord
       CacheMaster.record(creation_id, "pseud", self.pseud_id)
       CacheMaster.record(creation_id, "user", self.pseud.user_id)
     end
+  end
+
+  # On anonymous works, adding or removing a creator changes whether their
+  # comments show their username or "Anonymous Creator". Refresh that user's
+  # cached bylines directly, since removed creators leave the work's creator list.
+  def bust_anonymous_comment_cache
+    return unless approved? && creation_type == "Work" && pseud.present?
+    return if creation.nil? || creation.destroyed? || !creation.anonymous?
+
+    creation.async(:poke_cached_creator_comments_for_user, pseud.user_id)
   end
 
   ########################################

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -764,6 +764,11 @@ class Work < ApplicationRecord
     self.creator_comments.each { |c| c.touch }
   end
 
+  def poke_cached_creator_comments_for_user(user_id)
+    pseud_ids = Pseud.where(user_id: user_id).pluck(:id)
+    find_all_comments.where(pseud_id: pseud_ids).find_each(&:touch)
+  end
+
   # Get the total number of chapters for a work
   def number_of_chapters
     Rails.cache.fetch(key_for_chapter_total_counting(self)) do

--- a/features/collections/collection_anonymity.feature
+++ b/features/collections/collection_anonymity.feature
@@ -252,6 +252,44 @@ Feature: Collection
     When I am logged out
     Then the author of "Cone of Silence" should be hidden from me
 
+  Scenario: Removing a co-creator from an anonymous work de-anonymizes their comments, and re-adding them re-anonymizes them (AO3-7536)
+    Given the following activated users exist
+        | login   | password | email           |
+        | author1 | password | author1@foo.com |
+        | author2 | password | author2@foo.com |
+      And I have the anonymous collection "Anonymous Together"
+      And I am logged in as "author1"
+      And I post the work "Shared Secret" to the collection "Anonymous Together"
+      And I add the co-author "author2" to the work "Shared Secret"
+
+    When I am logged in as "author2"
+      And I view the work "Shared Secret" with comments
+      And I post a comment "A very nice story"
+      And I am logged out
+      And I view the work "Shared Secret" with comments
+    Then I should see "A very nice story"
+      And I should see "Anonymous Creator"
+      And I should not see "author2"
+
+    When I am logged in as "author2"
+      And I wait 1 second
+      And I edit the work "Shared Secret"
+      And I press "Remove Me As Co-Creator"
+      And I am logged out
+      And I view the work "Shared Secret" with comments
+    Then I should see "A very nice story"
+      And I should see "author2"
+      And I should not see "Anonymous Creator"
+
+    When I am logged in as "author1"
+      And I wait 1 second
+      And I add the co-author "author2" to the work "Shared Secret"
+      And I am logged out
+      And I view the work "Shared Secret" with comments
+    Then I should see "A very nice story"
+      And I should see "Anonymous Creator"
+      And I should not see "author2"
+
   Scenario: A work is in two anonymous collections, and one is revealed
     Given I have the anonymous collection "Permanent Mice"
       And I have the anonymous collection "Temporary Mice"

--- a/spec/models/creatorship_spec.rb
+++ b/spec/models/creatorship_spec.rb
@@ -31,4 +31,47 @@ describe Creatorship do
       end
     end
   end
+
+  describe "busting anonymous creator comment caches (AO3-7536)" do
+    let(:work) do
+      create(:work, authors: [create(:pseud), create(:pseud)],
+                    collections: [create(:anonymous_collection)])
+    end
+    let(:creatorship) { work.creatorships.last }
+    let!(:comment) do
+      create(:comment, commentable: work.first_chapter, pseud: creatorship.pseud)
+    end
+
+    it "touches the removed creator's comments when their creatorship is destroyed" do
+      travel(1.second) do
+        expect { creatorship.destroy! }
+          .to change { comment.reload.updated_at }
+      end
+    end
+
+    it "touches the accepting creator's comments when an invite is approved" do
+      invited = create(:user)
+      invite = work.creatorships.create!(pseud: invited.default_pseud)
+      invite.update_column(:approved, false)
+      invited_comment = create(:comment, commentable: work.first_chapter,
+                                         pseud: invited.default_pseud)
+
+      travel(1.second) do
+        expect { invite.reload.accept! }
+          .to change { invited_comment.reload.updated_at }
+      end
+    end
+
+    it "does not touch comments when the work is not anonymous" do
+      plain_work = create(:work, authors: [create(:pseud), create(:pseud)])
+      plain_creatorship = plain_work.creatorships.last
+      plain_comment = create(:comment, commentable: plain_work.first_chapter,
+                                       pseud: plain_creatorship.pseud)
+
+      travel(1.second) do
+        expect { plain_creatorship.destroy! }
+          .not_to change { plain_comment.reload.updated_at }
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7536

## Purpose

Expiring the cached comment bylines when the creatorships of an anonymous work (a work in an anonymous collection) change, so comments by the affected user start or stop displaying as "Anonymous Creator" correctly.

As described in the Jira ticket, AO3-3712 (#1289) added cache busting for creator comments when a work is added to or removed from an anonymous collection, but there was no such thing for creatorship changes on a work that stays anonymous. So when a creator removed themselves via "*Remove Me As Co-Creator*" (or was re-added and accepted), their comments kept showing the wrong byline until the 1-week fragment cache expired.

This PR adds a `Creatorship` callback that enqueues a new `Work#poke_cached_creator_comments_for_user`, touching the affected user's comments on the work so their bylines re-render. The existing `Work#poke_cached_creator_comments` could not be reused here: it looks up the work's *current* creators, and a removed creator has already left that list by the time the background job runs so that their comments would be the ones skipped. Passing the user's id captured at the moment the creatorship changes covers both removal and re-adding.

The added feature scenario fails without the `Creatorship` and `Work` changes, and passes with them.

## Testing Instructions

Follow the reproduction steps on the Jira issue (post a work with a co-creator into an anonymous collection, comment as a creator, then remove yourself via Edit => "*Remove Me As Co-Creator*"):

* Before this change: the comment still shows "Anonymous Creator" after the removal (until the weekly cache expiry).
* After this change: refreshing shows the commenter's username once the background job has run.
* Afterwards, re-inviting the removed user and the user accepting the co-creator request *re-anonymizes* their comments to "Anonymous Creator".

Reproducing locally requires fragment caching to be enabled (`rails dev:cache`) and a Resque worker running.

You can also see the testing instructions are also on the Jira ticket.

## References

AO3-3712 (https://otwarchive.atlassian.net/browse/AO3-3712, #1289) introduced the equivalent cache busting for collection-anonymity changes; this PR follows the same pattern for creatorship changes and reuses its touch-based invalidation approach.

## Credit

Name: hayoung
Pronouns: she/her