### PR TITLE
AO3-7543 NoMethodError when using mark_as_spam on comments with deleted commenters

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -123,7 +123,7 @@ class Comment < ApplicationRecord
       comment_author = name
     else
       user_role = "user"
-      comment_author = user.login
+      comment_author = user.try(:login)
     end
 
     attributes = {

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -962,6 +962,31 @@ describe Comment do
         comment.mark_as_spam!
       end
     end
+
+    context "when the commenter is deleted" do
+      let(:user) { create(:user) }
+      let(:comment) { create(:comment, pseud: user.default_pseud, approved: true, spam: false) }
+
+      before { user.delete }
+
+      it "flags the comment as spam" do
+        comment.mark_as_spam!
+        comment.reload
+        expect(comment.approved).to be_falsey
+        expect(comment.spam).to be_truthy
+      end
+
+      it "submits the comment to Akismet" do
+        expect(AkismetClient).to receive(:submit_spam)
+
+        comment.mark_as_spam!
+      end
+
+      it "has nil as name and email in akismet_attributes" do
+        expect(comment.akismet_attributes[:comment_author]).to eq(nil)
+        expect(comment.akismet_attributes[:comment_author_email]).to eq(nil)
+      end
+    end
   end
 
   describe "#mark_as_ham!" do


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7543

## Purpose

Tries the login method on user so it doesn't raise `NoMethodError` if the user doesn't exist

## Credit

ömer faruk (he/him)