### PR TITLE
AO3-7557 Fix 500 error due to pagy overflow in admin posts index

### DIFF
--- a/app/views/admin_posts/index.html.erb
+++ b/app/views/admin_posts/index.html.erb
@@ -4,33 +4,33 @@
   <% else %>
     <div class="primary header module">
       <!--Descriptive page name, messages and instructions-->
-      <h2 class="heading"><%= link_to ts("AO3 News"), admin_posts_path %></h2>
+      <h2 class="heading"><%= link_to t(".page_heading"), admin_posts_path %></h2>
       <div class="icon"></div>
       <!--/descriptions-->
 
       <!--subnav-->
-      <ul class="navigation actions" role="navigation">
-        <li><%= render 'filters' %></li>
+      <ul class="navigation actions">
+        <li><%= render "filters" %></li>
         <li><%= link_to_rss admin_posts_path(:rss, language_id: @language&.short) %></li>
       </ul>
       <!--/subnav-->
     </div>
     <!--main content-->
-    <% @admin_posts.each do |admin_post| %>
-      <div class="news module group" role="article">
-        <%= render "admin_post", admin_post: admin_post %>
-        <!-- BEGIN comment section -->
-        <h3 class="landmark heading"><%= ts("Comment") %></h3>
-        <ul class="actions" role="navigation">
-          <% if admin_post.count_visible_comments > 0 %>
-            <li><%= link_to (admin_post.count_visible_comments == 1 ? 
-                            ts("Read %{comment_count} Comment", comment_count: admin_post.count_visible_comments.to_s) : 
-                            ts("Read %{comment_count} Comments", comment_count: admin_post.count_visible_comments.to_s)),
-                            admin_post_path(id: admin_post.id, anchor: "comments", show_comments: true) %></li>
-          <% end %>
-        </ul>
-        <!-- END comment section -->
-      </div>
+    <% if @admin_posts.present? %>
+      <% @admin_posts.each do |admin_post| %>
+        <div class="news module group" role="article">
+          <%= render "admin_post", admin_post: admin_post %>
+          <!-- BEGIN comment section -->
+          <h3 class="landmark heading"><%= t(".landmark") %></h3>
+          <ul class="actions">
+            <% if admin_post.count_visible_comments > 0 %>
+              <li><%= link_to t(".read_comments", count: admin_post.count_visible_comments),
+                        admin_post_path(id: admin_post.id, anchor: "comments", show_comments: true) %></li>
+            <% end %>
+          </ul>
+          <!-- END comment section -->
+        </div>
+      <% end %>
     <% end %>
     <!--/content-->
     <hr class="clear" />

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -539,7 +539,12 @@ en:
       page_heading: AO3 News Drafts
       page_title: AO3 News Drafts
     index:
+      landmark: Comment
+      page_heading: AO3 News
       page_title: AO3 News
+      read_comments:
+        one: Read %{count} Comment
+        other: Read %{count} Comments
     posting_fieldset:
       actions:
         cancel: Cancel

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -129,6 +129,20 @@ Feature: Admin Actions to Post News
       And "quotes" should be selected within "Tag"
       And "Deutsch" should be selected within "Language"
 
+  Scenario: Admin post list is empty if page parameter is too large
+    Given the admin post "first"
+      And it is currently 1 second from now
+      And the admin post "second"
+      And there is 1 admin post per page
+    When I go to the admin-posts page
+    Then I should see "second"
+      And I should see "2" within ".pagination"
+      But I should not see "first"
+    When there are 20 admin posts per page
+      And I follow "2" within ".pagination"
+    Then I should see "AO3 News"
+      But I should not see "first"
+
   Scenario: Translation of an admin post keeps tags of original post
     Given I have posted an admin post with tags "original1, original2"
       And basic languages

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -246,6 +246,10 @@ Given "comment moderation on the admin post {string} is enabled" do |title|
   admin_post.update_attribute(:moderated_commenting_enabled, true)
 end
 
+When "there is/are {int} admin post(s) per page" do |amount|
+  allow_any_instance_of(ApplicationController).to receive(:pagy_get_limit).and_return(amount)
+end
+
 Given "an abuse ticket ID exists" do
   ticket = {
     "departmentId" => ArchiveConfig.ABUSE_ZOHO_DEPARTMENT_ID,


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7557

## Purpose

When `pagy` overflows, it assigns `nil` to the collection variable. Handle that correctly.

Test pushed first to show that it tests the right thing.

## References

PR limit does not apply to volunteers with write access to the repository.

## Credit

Bilka