### PR TITLE
AO3-7558 Fix 500 error due to pagy overflow in user assignment index

### DIFF
--- a/app/views/challenge_assignments/_user_index.html.erb
+++ b/app/views/challenge_assignments/_user_index.html.erb
@@ -32,11 +32,7 @@
 <%== pagy_nav @pagy %>
 
 <dl class="assignment index group">
-
-  <% @challenge_assignments.each do |assignment| %>
-    <%= render "assignment_blurb", assignment: assignment %>
-  <% end %>
-
+  <%= render partial: "assignment_blurb", collection: @challenge_assignments, as: :assignment %>
 </dl>
 
 <%== pagy_nav @pagy %>

--- a/features/gift_exchanges/challenge_giftexchange.feature
+++ b/features/gift_exchanges/challenge_giftexchange.feature
@@ -824,6 +824,10 @@ Feature: Gift Exchange Challenge
     Then I should see "collection_1"
     When I follow "2" within ".pagination"
     Then I should see "collection_2"
+    When there are 20 assignments per page
+      And I reload the page
+    Then I should see "My Assignments"
+      But I should not see "collection_2"
 
   Scenario: Mod can approve a posted assignment in a moderated gift exchange
     Given everyone has their assignments for "Awesome Gift Exchange"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7558

## Purpose

When `pagy` overflows, it assigns `nil` to the collection variable. Handle that correctly.

Test pushed first to show that it tests the right thing.

## References

PR limit does not apply to volunteers with write access to the repository.

## Credit

Bilka