### PR TITLE
AO3-7559 Bump loofah to 2.25.2 and rails-html-sanitizer to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (1.22.0)
       addressable
     csv (3.3.5)
@@ -358,7 +358,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.24.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -506,8 +506,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.2.1)
       actionpack (= 8.1.2.1)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7559

## Purpose

Update gems to address some vulnerabilities.

## References

PR limit does not apply to volunteers with write access to the repository.

## Credit

Bilka
