### PR TITLE
AO3-7135 Record canonized/decanonized dates on tags

### DIFF
--- a/app/models/search/tag_indexer.rb
+++ b/app/models/search/tag_indexer.rb
@@ -23,6 +23,8 @@ class TagIndexer < Indexer
         },
         tag_type: { type: "keyword" },
         sortable_name: { type: "keyword" },
+        canonized_at: { type: "date" },
+        decanonized_at: { type: "date" },
         uses: { type: "integer" },
         unwrangled: { type: "boolean" }
       }
@@ -72,7 +74,7 @@ class TagIndexer < Indexer
       root: false,
       only: [
         :id, :name, :sortable_name, :merger_id, :canonical, :created_at,
-        :unwrangleable
+        :canonized_at, :decanonized_at, :unwrangleable
       ]
     ).merge(
       has_posted_works: object.has_posted_works?,

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -64,7 +64,10 @@ class TagQuery < Query
     end
     sort_hash = { column => { order: direction } }
 
-    sort_hash[column][:unmapped_type] = "date" if %w[created_at canonized_at decanonized_at].include?(column)
+    if %w[created_at canonized_at decanonized_at].include?(column)
+      sort_hash[column][:unmapped_type] = "date"
+      sort_hash[column][:missing] = "_last" unless column == "created_at"
+    end
 
     sort_by_id = { id: { order: direction } }
 

--- a/app/models/search/tag_query.rb
+++ b/app/models/search/tag_query.rb
@@ -52,15 +52,19 @@ class TagQuery < Query
     when "created_at"
       column = "created_at"
       direction ||= "desc"
+    when "canonized_at"
+      column = "canonized_at"
+      direction ||= "desc"
+    when "decanonized_at"
+      column = "decanonized_at"
+      direction ||= "desc"
     else
       column = "name.keyword"
       direction ||= "asc"
     end
     sort_hash = { column => { order: direction } }
 
-    if column == "created_at"
-      sort_hash[column][:unmapped_type] = "date"
-    end
+    sort_hash[column][:unmapped_type] = "date" if %w[created_at canonized_at decanonized_at].include?(column)
 
     sort_by_id = { id: { order: direction } }
 

--- a/app/models/search/tag_search_form.rb
+++ b/app/models/search/tag_search_form.rb
@@ -68,11 +68,13 @@ class TagSearchForm
     [
       %w[Name name],
       ["Date Created", "created_at"],
+      ["Date Canonized", "canonized_at"],
+      ["Date Decanonized", "decanonized_at"],
       %w[Uses uses]
     ]
   end
 
   def default_sort_direction
-    %w[created_at uses].include?(sort_column) ? "desc" : "asc"
+    %w[created_at canonized_at decanonized_at uses].include?(sort_column) ? "desc" : "asc"
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -255,6 +255,15 @@ class Tag < ApplicationRecord
     end
   end
 
+  before_save :set_canonization_date, if: :will_save_change_to_canonical?
+  def set_canonization_date
+    if canonical?
+      self.canonized_at = Time.current
+    else
+      self.decanonized_at = Time.current
+    end
+  end
+
   after_save :check_type_changes, if: :saved_change_to_type?
   def check_type_changes
     return if type_before_last_save.nil?

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -13,6 +13,16 @@
 
 <% if logged_in_as_admin? %>
   <p class="notes"><%= ts("Last updated by %{wrangler} on %{date}", wrangler: @tag.last_wrangler.try(:login) || '---', date: @tag.updated_at) %></p>
+  <% if @tag.canonized_at || @tag.decanonized_at %>
+    <p class="notes">
+      <% if @tag.canonized_at %>
+        <%= t(".last_canonized", date: @tag.canonized_at.utc.strftime("%Y-%m-%d %H:%M:%S")) %>
+      <% end %>
+      <% if @tag.decanonized_at %>
+        <%= t(".last_decanonized", date: @tag.decanonized_at.utc.strftime("%Y-%m-%d %H:%M:%S")) %>
+      <% end %>
+    </p>
+  <% end %>
 <% end %>
 
 <%= form_for @tag, as: :tag, url: { action: "update", id: @tag}, html: { method: :put } do |f| %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -3078,6 +3078,8 @@ en:
       wrangling_tools: Wrangling Tools
   tags:
     edit:
+      last_canonized: Last canonized on %{date} UTC.
+      last_decanonized: Last decanonized on %{date} UTC.
       save_changes: Save changes
       submit_legend: Submit
     index:

--- a/db/migrate/20260725153049_add_canonization_dates_to_tags.rb
+++ b/db/migrate/20260725153049_add_canonization_dates_to_tags.rb
@@ -1,0 +1,10 @@
+class AddCanonizationDatesToTags < ActiveRecord::Migration[8.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def change
+    change_table :tags, bulk: true do |t|
+      t.datetime :canonized_at, default: nil, null: true
+      t.datetime :decanonized_at, default: nil, null: true
+    end
+  end
+end

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -287,8 +287,12 @@ When /^I check the (?:mass )?wrangling option for "([^"]*)"$/ do |tagname|
   check("selected_tags_#{tag.id}")
 end
 
-Given /^the tag "([^"]*)" was (canonized|decanonized) on "([^"]*)"$/ do |name, event, date|
-  Tag.find_by!(name: name).update_column("#{event}_at", date)
+Given "the tag {string} was canonized on {string}" do |name, date|
+  Tag.find_by!(name: name).update_column(:canonized_at, date)
+end
+
+Given "the tag {string} was decanonized on {string}" do |name, date|
+  Tag.find_by!(name: name).update_column(:decanonized_at, date)
 end
 
 When "I edit the tag {string}" do |tag|

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -287,6 +287,10 @@ When /^I check the (?:mass )?wrangling option for "([^"]*)"$/ do |tagname|
   check("selected_tags_#{tag.id}")
 end
 
+Given /^the tag "([^"]*)" was (canonized|decanonized) on "([^"]*)"$/ do |name, event, date|
+  Tag.find_by!(name: name).update_column("#{event}_at", date)
+end
+
 When "I edit the tag {string}" do |tag|
   tag = Tag.find_by!(name: tag)
   visit edit_tag_path(tag)

--- a/features/tags_and_wrangling/tag_search.feature
+++ b/features/tags_and_wrangling/tag_search.feature
@@ -250,6 +250,60 @@ Feature: Search Tags
       And the 3rd tag result should contain "created third"
       And the 4th tag result should contain "created fourth"
 
+  Scenario: Search and sort by Date Canonized in descending and ascending order
+    Given a freeform exists with name: "canonized first", canonical: true
+      And the tag "canonized first" was canonized on "2008-01-01 20:00:00 UTC"
+      And a freeform exists with name: "canonized second", canonical: true
+      And the tag "canonized second" was canonized on "2009-01-01 20:00:00 UTC"
+      And a freeform exists with name: "canonized third", canonical: true
+      And the tag "canonized third" was canonized on "2010-01-01 20:00:00 UTC"
+      And a freeform exists with name: "never canonized", canonical: false
+      And all indexing jobs have been run
+    When I am on the search tags page
+      And I fill in "Tag name" with "canonized"
+      And I select "Date Canonized" from "Sort by"
+      And I select "Descending" from "Sort direction"
+      And I press "Search Tags"
+    Then I should see "4 Found"
+      And the 1st tag result should contain "canonized third"
+      And the 2nd tag result should contain "canonized second"
+      And the 3rd tag result should contain "canonized first"
+      And the 4th tag result should contain "never canonized"
+    When I select "Ascending" from "Sort direction"
+      And I press "Search Tags"
+    Then I should see "4 Found"
+      And the 1st tag result should contain "canonized first"
+      And the 2nd tag result should contain "canonized second"
+      And the 3rd tag result should contain "canonized third"
+      And the 4th tag result should contain "never canonized"
+
+  Scenario: Search and sort by Date Decanonized in descending and ascending order
+    Given a freeform exists with name: "decanonized first", canonical: false
+      And the tag "decanonized first" was decanonized on "2008-01-01 20:00:00 UTC"
+      And a freeform exists with name: "decanonized second", canonical: false
+      And the tag "decanonized second" was decanonized on "2009-01-01 20:00:00 UTC"
+      And a freeform exists with name: "decanonized third", canonical: false
+      And the tag "decanonized third" was decanonized on "2010-01-01 20:00:00 UTC"
+      And a freeform exists with name: "never decanonized", canonical: true
+      And all indexing jobs have been run
+    When I am on the search tags page
+      And I fill in "Tag name" with "decanonized"
+      And I select "Date Decanonized" from "Sort by"
+      And I select "Descending" from "Sort direction"
+      And I press "Search Tags"
+    Then I should see "4 Found"
+      And the 1st tag result should contain "decanonized third"
+      And the 2nd tag result should contain "decanonized second"
+      And the 3rd tag result should contain "decanonized first"
+      And the 4th tag result should contain "never decanonized"
+    When I select "Ascending" from "Sort direction"
+      And I press "Search Tags"
+    Then I should see "4 Found"
+      And the 1st tag result should contain "decanonized first"
+      And the 2nd tag result should contain "decanonized second"
+      And the 3rd tag result should contain "decanonized third"
+      And the 4th tag result should contain "never decanonized"
+
   Scenario: Search and sort by Uses in descending and ascending order
     Given a set of tags for tag sort by use exists
     When I am on the search tags page

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -32,6 +32,36 @@ Feature: Tag wrangling
     Then I should not see "Amelie"
       And I should see "Amélie"
 
+  Scenario: Admin can see when a tag was last canonized and decanonized
+
+  Given I am logged in as a "tag_wrangling" admin
+    And a fandom exists with name: "Amelie", canonical: false
+  When I edit the tag "Amelie"
+  Then I should not see "Last canonized on"
+    And I should not see "Last decanonized on"
+  When I check "Canonical"
+    And I press "Save changes"
+    And I edit the tag "Amelie"
+  Then I should see "Last canonized on"
+    And I should not see "Last decanonized on"
+  When I uncheck "Canonical"
+    And I press "Save changes"
+    And I edit the tag "Amelie"
+  Then I should see "Last canonized on"
+    And I should see "Last decanonized on"
+
+  Scenario: Tag wrangler cannot see when a tag was last canonized or decanonized
+
+  Given I am logged in as a "tag_wrangling" admin
+    And a fandom exists with name: "Amelie", canonical: true
+  When I edit the tag "Amelie"
+    And I uncheck "Canonical"
+    And I press "Save changes"
+    And I am logged in as a tag wrangler
+    And I edit the tag "Amelie"
+  Then I should not see "Last canonized on"
+    And I should not see "Last decanonized on"
+
   Scenario: Admin can rename a tag using Eastern characters
 
   Given I am logged in as a "tag_wrangling" admin

--- a/features/tags_and_wrangling/tag_wrangling_admin.feature
+++ b/features/tags_and_wrangling/tag_wrangling_admin.feature
@@ -41,12 +41,10 @@ Feature: Tag wrangling
     And I should not see "Last decanonized on"
   When I check "Canonical"
     And I press "Save changes"
-    And I edit the tag "Amelie"
   Then I should see "Last canonized on"
     And I should not see "Last decanonized on"
   When I uncheck "Canonical"
     And I press "Save changes"
-    And I edit the tag "Amelie"
   Then I should see "Last canonized on"
     And I should see "Last decanonized on"
 

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -197,6 +197,16 @@ describe TagQuery do
       expect(q.generated_query[:sort]).to eq([{ "created_at" => { order: "asc", unmapped_type: "date" } }, { id: { order: "asc" } }])
     end
 
+    it "allows you to sort by Date Canonized" do
+      q = TagQuery.new(sort_column: "canonized_at")
+      expect(q.generated_query[:sort]).to eq([{ "canonized_at" => { order: "desc", unmapped_type: "date" } }, { id: { order: "desc" } }])
+    end
+
+    it "allows you to sort by Date Decanonized" do
+      q = TagQuery.new(sort_column: "decanonized_at")
+      expect(q.generated_query[:sort]).to eq([{ "decanonized_at" => { order: "desc", unmapped_type: "date" } }, { id: { order: "desc" } }])
+    end
+
     it "allows you to sort by Uses" do
       q = TagQuery.new(sort_column: "uses")
       expect(q.generated_query[:sort]).to eq([{ "uses" => { order: "desc" } }, { "name.keyword" => { order: "asc" } }, { id: { order: "desc" } }])

--- a/spec/models/search/tag_query_spec.rb
+++ b/spec/models/search/tag_query_spec.rb
@@ -199,12 +199,12 @@ describe TagQuery do
 
     it "allows you to sort by Date Canonized" do
       q = TagQuery.new(sort_column: "canonized_at")
-      expect(q.generated_query[:sort]).to eq([{ "canonized_at" => { order: "desc", unmapped_type: "date" } }, { id: { order: "desc" } }])
+      expect(q.generated_query[:sort]).to eq([{ "canonized_at" => { order: "desc", unmapped_type: "date", missing: "_last" } }, { id: { order: "desc" } }])
     end
 
     it "allows you to sort by Date Decanonized" do
       q = TagQuery.new(sort_column: "decanonized_at")
-      expect(q.generated_query[:sort]).to eq([{ "decanonized_at" => { order: "desc", unmapped_type: "date" } }, { id: { order: "desc" } }])
+      expect(q.generated_query[:sort]).to eq([{ "decanonized_at" => { order: "desc", unmapped_type: "date", missing: "_last" } }, { id: { order: "desc" } }])
     end
 
     it "allows you to sort by Uses" do

--- a/spec/models/tag_wrangling_spec.rb
+++ b/spec/models/tag_wrangling_spec.rb
@@ -18,6 +18,42 @@ describe Tag do
         end.to(add_to_reindex_queue(work, :background) &
                not_add_to_reindex_queue(work, :main))
       end
+
+      it "sets canonized_at" do
+        freeze_time do
+          fandom.update!(canonical: true)
+          expect(fandom.canonized_at).to eq(Time.current)
+          expect(fandom.decanonized_at).to be_nil
+        end
+      end
+    end
+
+    context "when a tag is created as canonical" do
+      it "sets canonized_at" do
+        freeze_time do
+          fandom = create(:canonical_fandom)
+          expect(fandom.canonized_at).to eq(Time.current)
+          expect(fandom.decanonized_at).to be_nil
+        end
+      end
+    end
+
+    context "when a tag is created as non-canonical" do
+      it "does not set canonized_at or decanonized_at" do
+        fandom = create(:fandom)
+        expect(fandom.canonized_at).to be_nil
+        expect(fandom.decanonized_at).to be_nil
+      end
+    end
+
+    context "when canonical does not change" do
+      it "does not change canonized_at or decanonized_at" do
+        fandom = create(:canonical_fandom)
+        expect do
+          fandom.update!(unwrangleable: false)
+        end.to avoid_changing { fandom.reload.canonized_at } &
+               avoid_changing { fandom.reload.decanonized_at }
+      end
     end
 
     context "when canonical becomes false" do
@@ -35,6 +71,13 @@ describe Tag do
           fandom.update!(canonical: false)
         end.to(add_to_reindex_queue(work, :background) &
                not_add_to_reindex_queue(work, :main))
+      end
+
+      it "sets decanonized_at" do
+        freeze_time do
+          fandom.update!(canonical: false)
+          expect(fandom.decanonized_at).to eq(Time.current)
+        end
       end
 
       it "removes favorite tags" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7135

## Purpose

Adds two new datetime columns (`canonized_at` and `decanonized_at`) to the `tags` table to record when a tag was most recently canonized or decanonized.

- A `before_save` callback sets `canonized_at` when a tag becomes canonical, and `decanonized_at` when it becomes non-canonical.
- The tag edit page displays "Last canonized on [datetime] UTC" and "Last decanonized on [datetime] UTC" to admins (superadmin, policy_and_abuse, tag_wrangling), directly below the "last edited" information. Sentences are omitted when the corresponding date is nil.
- Both fields are indexed in Elasticsearch and exposed as sort options ("Date Canonized", "Date Decanonized") in tag search.

## Testing Instructions

1. Log in as a tag wrangler.
2. Create a new tag (non-canonical). Edit it, you should **not** see "Last canonized on" or "Last decanonized on".
3. Create a new canonical tag. Edit it, you should **not** see the dates (wranglers don't see them).
4. Log out.
5. Log in as an admin with `superadmin`, `policy_and_abuse`, or `tag_wrangling` role.
6. Edit the non-canonical tag from step 2, you should **not** see any canonization dates.
7. Check "Canonical", save, and re-edit, you should see "Last canonized on [datetime] UTC"
8. Uncheck "Canonical", save, and re-edit, you should see both "Last canonized on" and "Las
9. Edit the canonical tag from step 3, you should see "Last canonized on [datetime] UTC" on
10. Find a tag that was canonized *before* this deployment and decanonize it, it should shotetime] UTC" only (no canonized date since that happened before the migration).
11. Log out.
12. Search > Tags, verify "Date Canonized" and "Date Decanonized" appear in the "Sort by" d
13. Sort by "Date Canonized" descending, recently canonized tags should appear first.
14. Sort by "Date Decanonized" descending, recently decanonized tags should appear first.

## Credit

Pablo Monfort (he/him)