### PR TITLE
AO3-6925 Remove Open Challenges link from Subcollections page

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,6 +27,8 @@ linters:
         Enabled: false
       Layout/TrailingWhitespace:
         Enabled: false
+      Layout/CommentIndentation:
+        Enabled: false
       Naming/FileName:
         Enabled: false
       Style/FrozenStringLiteralComment:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,8 +27,6 @@ linters:
         Enabled: false
       Layout/TrailingWhitespace:
         Enabled: false
-      Layout/CommentIndentation:
-        Enabled: false
       Naming/FileName:
         Enabled: false
       Style/FrozenStringLiteralComment:

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,24 +23,23 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= t(".navigation.landmark_heading") %></h3>
 <ul class="navigation actions">
-  <%# Collections and Open Challenges link unless on a user's collections page or collection's subcollections page %>
-  <% unless @user || @collection  %>
+  <% if @collection %>
+    <%# Collection subcollections index gets link for Subcollections %>
+    <li><%= span_if_current t(".navigation.actions.subcollections"), collection_collections_path(@collection) %></li>
+  <% elsif @user %>
+    <%# User collections index gets link for user Collections %>
+    <li><%= span_if_current t(".navigation.actions.collections"), user_collections_path(@user) %></li>
+    <%# Logged in user on own collections index gets link for Manage Collections Item %>
+    <% if logged_in? && @user == current_user %>
+      <li><%= link_to t(".navigation.actions.manage_items"), user_collection_items_path(@user) %></li>
+    <% end %>
+  <% else %>
+    <%# Collections and Open Challenges link unless on a user's collections page or collection's subcollections page %>
     <li><%= span_if_current t(".navigation.actions.collections"), collections_path %></li>
     <li><%= link_to t(".navigation.actions.open_challenges"), list_challenges_collections_path %></li>
   <% end %>
-  <% if @collection %>
-    <li><%= span_if_current t(".navigation.actions.subcollections"), collection_collections_path(@collection) %></li>
-  <% end %>
-  <% if @user %>
-    <%# User collections index gets link for user Collections %>
-    <li><%= span_if_current t(".navigation.actions.collections"), user_collections_path(@user) %></li>
-    <%# Logged in user on own collections index gets link for Manage Collections Item %>z
-    <% if logged_in? && @user && @user == current_user %>
-      <li><%= link_to t(".navigation.actions.manage_items"), user_collection_items_path(@user) %></li>
-    <% end %>
-  <% end %>
-  <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
   <% if logged_in? %>
+    <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to t(".navigation.actions.new_subcollection"), new_collection_collection_path(@collection) %></li>
     <% else %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,13 +23,13 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= t(".navigation.landmark_heading") %></h3>
 <ul class="navigation actions">
-  <%# Collections link unless a logged in user viewing own collections page %>
-  <% unless @user %>
+  <%# Collections and Open Challenges link unless on a user's collections page or collection's subcollections page %>
+  <% unless @user || @collection  %>
     <li><%= span_if_current t(".navigation.actions.collections"), collections_path %></li>
-  <% end %>
-  <%# Open Challenges link unless viewing a user collections page or on an individual collection page %>
-  <% unless @user || @collection %>
     <li><%= link_to t(".navigation.actions.open_challenges"), list_challenges_collections_path %></li>
+  <% end %>
+  <% if @collection %>
+    <li><%= span_if_current t(".navigation.actions.subcollections"), collection_collections_path(@collection) %></li>
   <% end %>
   <% if @user %>
     <%# User collections index gets link for user Collections %>
@@ -39,7 +39,7 @@
       <li><%= link_to t(".navigation.actions.manage_items"), user_collection_items_path(@user) %></li>
     <% end %>
   <% end %>
-  <%# New Collection/Subcollection links for logged in users %>
+  <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
   <% if logged_in? %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to t(".navigation.actions.new_subcollection"), new_collection_collection_path(@collection) %></li>
@@ -60,9 +60,7 @@
   <!--main content-->
   <h3 class="landmark heading"><%= t(".main_content.landmark_heading") %></h3>
   <ul class="collection picture index group">
-    <% @collections.each do |collection| %>
-      <%= render "collection_blurb", collection: collection %>
-    <% end %>
+    <%= render partial: "collection_blurb", collection: @collections, as: :collection %>
   </ul>
 <% end %>
 

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -23,18 +23,24 @@
 <!--Subnavigation, sorting and actions-->
 <h3 class="landmark heading"><%= t(".navigation.landmark_heading") %></h3>
 <ul class="navigation actions">
-  <%# Collections and Open Challenges links unless a logged in user viewing own collections page %>
-  <% unless logged_in? && @user && @user == current_user %>
+  <%# Collections link unless a logged in user viewing own collections page %>
+  <% unless @user %>
     <li><%= span_if_current t(".navigation.actions.collections"), collections_path %></li>
+  <% end %>
+  <%# Open Challenges link unless viewing a user collections page or on an individual collection page %>
+  <% unless @user || @collection %>
     <li><%= link_to t(".navigation.actions.open_challenges"), list_challenges_collections_path %></li>
   <% end %>
-  <% if logged_in? %>
-    <%# Logged in user on own collections index gets links for user Collections and Manage Collection Items %>
-    <% if @user && @user == current_user %>
-      <li><%= span_if_current t(".navigation.actions.collections"), user_collections_path(@user) %></li>
+  <% if @user %>
+    <%# User collections index gets link for user Collections %>
+    <li><%= span_if_current t(".navigation.actions.collections"), user_collections_path(@user) %></li>
+    <%# Logged in user on own collections index gets link for Manage Collections Item %>z
+    <% if logged_in? && @user && @user == current_user %>
       <li><%= link_to t(".navigation.actions.manage_items"), user_collection_items_path(@user) %></li>
     <% end %>
-    <%# Logged in collection maintainer on own collection gets link for New Subcollection and all other logged in users get New Collection link %>
+  <% end %>
+  <%# New Collection/Subcollection links for logged in users %>
+  <% if logged_in? %>
     <% if @collection && !@collection.parent && @collection.user_is_maintainer?(current_user) %>
       <li><%= link_to t(".navigation.actions.new_subcollection"), new_collection_collection_path(@collection) %></li>
     <% else %>
@@ -55,14 +61,14 @@
   <h3 class="landmark heading"><%= t(".main_content.landmark_heading") %></h3>
   <ul class="collection picture index group">
     <% @collections.each do |collection| %>
-      <%= render :partial => "collection_blurb", :locals => {:collection => collection} %>
+      <%= render "collection_blurb", collection: collection %>
     <% end %>
   </ul>
 <% end %>
 
 <% if @sort_and_filter %>
   <!--filters subnav-->
-  <%= render 'collections/filters' %>
+  <%= render "collections/filters" %>
   <!---/subnav-->
 <% end %>
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -879,6 +879,7 @@ en:
           new_collection: New Collection
           new_subcollection: New Subcollection
           open_challenges: Open Challenges
+          subcollections: Subcollections
         landmark_heading: Navigation
       page_heading:
         challenges_subcollections_in: Challenges/Subcollections in %{collection}

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -14,13 +14,36 @@ Feature: Collection
     Then I should see "Open Challenges"
       And I should not see "New Collection"
 
-  Scenario: Open Challenges link should not appear on subcollections page
+  Scenario: Open Challenges and overall Collections link should not appear on subcollections page
     Given I have a collection "Some Test Collection" with name "sometest"
     When I am logged in as the owner of "Some Test Collection"
       And I add the subcollection "Subcollection" to the parent collection named "sometest"
       And all indexing jobs have been run
       And I go to the "Some Test Collection" subcollections page
-    Then I should not see "Open Challenges"
+    Then I should not see "Open Challenges" within "#main .navigation.actions"
+      And I should not see "Collections" within "#main .navigation.actions"
+      But I should see "New Subcollection" within "#main .navigation.actions"
+      And I should see "Subcollections" within "#main .navigation.actions"
+
+  Scenario: Open Challenges and overall Collections link should not appear on user's collections page
+    Given I have a collection "Some Test Collection" with name "sometest"
+    When I go to moderator's collections page
+    Then I should not see "Open Challenges" within "#main .navigation.actions"
+      And I should not see a page link to the collections page within "#main .navigation.actions"
+      But I should see "Collections" within "#main .navigation.actions"
+    When I am logged in as "onlooker"
+      And I go to moderator's collections page
+    Then I should not see "Open Challenges" within "#main .navigation.actions"
+      And I should not see a page link to the collections page within "#main .navigation.actions"
+      But I should see "Collections" within "#main .navigation.actions"
+      And I should see "New Collection" within "#main .navigation.actions"
+    When I am logged in as "moderator"
+      And I go to moderator's collections page
+    Then I should not see "Open Challenges" within "#main .navigation.actions"
+      And I should not see a page link to the collections page within "#main .navigation.actions"
+      But I should see "Collections" within "#main .navigation.actions"
+      And I should see "Manage Collection Items" within "#main .navigation.actions"
+      And I should see "New Collection" within "#main .navigation.actions"
 
   Scenario: Filter collections index to only show prompt memes
 

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -18,7 +18,6 @@ Feature: Collection
     Given I have a collection "Some Test Collection" with name "sometest"
     When I am logged in as the owner of "Some Test Collection"
       And I add the subcollection "Subcollection" to the parent collection named "sometest"
-      And all indexing jobs have been run
       And I go to the "Some Test Collection" subcollections page
     Then I should not see "Open Challenges" within "#main .navigation.actions"
       And I should not see "Collections" within "#main .navigation.actions"

--- a/features/collections/collection_browse.feature
+++ b/features/collections/collection_browse.feature
@@ -5,15 +5,22 @@ Feature: Collection
   I want to locate and browse an existing collection
 
   Scenario: Collections index should have different links for logged in and logged out users
+    Given I am logged in as "onlooker"
+    When I go to the collections page
+    Then I should see "Open Challenges"
+      And I should see "New Collection"
+    When I log out
+      And I go to the collections page
+    Then I should see "Open Challenges"
+      And I should not see "New Collection"
 
-  Given I am logged in as "onlooker"
-  When I go to the collections page
-  Then I should see "Open Challenges"
-    And I should see "New Collection"
-  When I log out
-    And I go to the collections page
-  Then I should see "Open Challenges"
-    And I should not see "New Collection"
+  Scenario: Open Challenges link should not appear on subcollections page
+    Given I have a collection "Some Test Collection" with name "sometest"
+    When I am logged in as the owner of "Some Test Collection"
+      And I add the subcollection "Subcollection" to the parent collection named "sometest"
+      And all indexing jobs have been run
+      And I go to the "Some Test Collection" subcollections page
+    Then I should not see "Open Challenges"
 
   Scenario: Filter collections index to only show prompt memes
 

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -177,7 +177,7 @@ module NavigationHelpers
       collection_path(Collection.find_by(title: $1))
     when /^"(.*)" collection edit page$/i
       edit_collection_path(Collection.find_by(title: $1))
-    when /^the "(.*)" subcollections page$/i                         # e.g. when I go to the "Collection name" subcollections page
+    when /^the "(.*)" subcollections page$/i                   # e.g. when I go to the "Collection name" subcollections page
       collection_collections_path(Collection.find_by(title: Regexp.last_match(1)))
     when /^the "(.*)" signups page$/i                          # e.g. when I go to the "Collection name" signup page
       collection_signups_path(Collection.find_by(title: $1))

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -178,6 +178,7 @@ module NavigationHelpers
     when /^"(.*)" collection edit page$/i
       edit_collection_path(Collection.find_by(title: $1))
     when /^the "(.*)" subcollections page$/i                   # e.g. when I go to the "Collection name" subcollections page
+      step %{all indexing jobs have been run}
       collection_collections_path(Collection.find_by(title: Regexp.last_match(1)))
     when /^the "(.*)" signups page$/i                          # e.g. when I go to the "Collection name" signup page
       collection_signups_path(Collection.find_by(title: $1))

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -177,6 +177,8 @@ module NavigationHelpers
       collection_path(Collection.find_by(title: $1))
     when /^"(.*)" collection edit page$/i
       edit_collection_path(Collection.find_by(title: $1))
+    when /^the "(.*)" subcollections page$/i                         # e.g. when I go to the "Collection name" subcollections page
+      collection_collections_path(Collection.find_by(title: Regexp.last_match(1)))
     when /^the "(.*)" signups page$/i                          # e.g. when I go to the "Collection name" signup page
       collection_signups_path(Collection.find_by(title: $1))
     when /^the "(.*)" requests page$/i                         # e.g. when I go to the "Collection name" signup page


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-6925

## Purpose

Remove the Open Challenges and Collections links from the Subcollections page. Add a new Subcollections link which always appears as pressed. Fixes some inconsistencies around the user collections index as well.

## References

Adopts #5222
PR limit does not apply to volunteers with write access to the repository.

## Credit

gelphcore, they/them (original code)
sarken (original review)
Bilka (original review)
Bilka
