### PR TITLE
AO3-7524 Site skin dropdown shows Default when using a parent-only skin

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -41,10 +41,8 @@ class PreferencesController < ApplicationController
   private
 
   def available_skins
-    skins = (@user.skins.site_skins.usable +
-             Skin.approved_skins.site_skins.usable).uniq
-    current_skin = @user.preference.skin
-    skins << current_skin if current_skin && current_skin.type.nil? && skins.exclude?(current_skin)
-    skins
+    (@user.skins.site_skins.usable +
+    Skin.approved_skins.site_skins.usable +
+    [@user.preference.skin]).compact.uniq
   end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -41,7 +41,10 @@ class PreferencesController < ApplicationController
   private
 
   def available_skins
-    (@user.skins.site_skins.usable +
-    Skin.approved_skins.site_skins.usable).uniq
+    skins = (@user.skins.site_skins.usable +
+             Skin.approved_skins.site_skins.usable).uniq
+    current_skin = @user.preference.skin
+    skins << current_skin if current_skin&.type.nil? && skins.exclude?(current_skin)
+    skins
   end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -44,7 +44,7 @@ class PreferencesController < ApplicationController
     skins = (@user.skins.site_skins.usable +
              Skin.approved_skins.site_skins.usable).uniq
     current_skin = @user.preference.skin
-    skins << current_skin if current_skin&.type.nil? && skins.exclude?(current_skin)
+    skins << current_skin if current_skin && current_skin.type.nil? && skins.exclude?(current_skin)
     skins
   end
 end

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -44,6 +44,15 @@ describe PreferencesController do
 
         expect(assigns(:available_skins)).to include(parent_only_skin)
       end
+
+      it "does not add a nil entry when the user's skin has been deleted" do
+        user.preference.update(skin_id: 9999)
+
+        get :index, params: { user_id: user.login }
+
+        expect(assigns(:available_skins)).not_to include(nil)
+        expect(response).to be_successful
+      end
     end
 
     context "as a guest" do

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -35,6 +35,15 @@ describe PreferencesController do
         expect(assigns(:available_skins)).to include(usable_skin)
         expect(assigns(:available_skins)).not_to include(parent_only_skin)
       end
+
+      it "includes the user's current skin even if it is parent-only" do
+        parent_only_skin = create(:skin, author: user, unusable: true)
+        user.preference.update(skin_id: parent_only_skin.id)
+
+        get :index, params: { user_id: user.login }
+
+        expect(assigns(:available_skins)).to include(parent_only_skin)
+      end
     end
 
     context "as a guest" do

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -46,7 +46,7 @@ describe PreferencesController do
       end
 
       it "does not add a nil entry when the user's skin has been deleted" do
-        user.preference.update(skin_id: 9999)
+        user.preference.update_column(:skin_id, 9999)
 
         get :index, params: { user_id: user.login }
 

--- a/spec/controllers/preferences_controller_spec.rb
+++ b/spec/controllers/preferences_controller_spec.rb
@@ -38,7 +38,7 @@ describe PreferencesController do
 
       it "includes the user's current skin even if it is parent-only" do
         parent_only_skin = create(:skin, author: user, unusable: true)
-        user.preference.update(skin_id: parent_only_skin.id)
+        user.preference.update!(skin_id: parent_only_skin.id)
 
         get :index, params: { user_id: user.login }
 


### PR DESCRIPTION
# Pull Request Checklist

- [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
- [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
- [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
- [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7524

## Purpose

The "Your site skin" dropdown shows "Default" whenever your current skin is parent-only, even though you're actually using a different one.

Parent-only skins get filtered out of the dropdown options, but your preference can still point to one. Since it's not in the list, the browser just shows the first option ("Default").

Fix: include your current skin in the dropdown even when it's parent-only.

## Testing Instructions

1. Log in and create a site skin with some valid CSS (e.g. `a { color: #639; }`).
2. Open the "Edit skin" page for the skin in a new tab.
3. Open Advanced skin options, enable the "Parent only" condition, and submit.
4. Return to the first tab and click "Use".
5. Go to Preferences (Hi, username! > My Preferences).
6. Verify the "Your site skin" select shows the skin being used, not "Default".
7. Verify selecting a different skin from the dropdown and saving still works as before.

## Credit

**Evan W (he/him) [b1ume]**

