### PR TITLE
AO3-7432 Fix 500 error when leaving kudos with JavaScript disabled

### DIFF
--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -41,8 +41,7 @@ class KudosController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:kudos_notice] = t(".success")
-          redirect_path = url_from(request.referer) || polymorphic_path(@kudo.commentable)
-          redirect_to "#{redirect_path}#kudos_message" and return
+          redirect_to kudos_redirect_path(@kudo.commentable) and return
         end
 
         format.js do
@@ -59,8 +58,7 @@ class KudosController < ApplicationController
           return if check_user_status
 
           flash[:kudos_error] = error_message
-          redirect_path = url_from(request.referer) || polymorphic_path(@kudo.commentable || root_path)
-          redirect_to "#{redirect_path}#kudos_message" and return
+          redirect_to kudos_redirect_path(@kudo.commentable || root_path) and return
         end
 
         format.js do
@@ -78,8 +76,7 @@ class KudosController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:kudos_error] = error_message
-        redirect_path = url_from(request.referer) || polymorphic_path(@kudo&.commentable || root_path)
-        redirect_to "#{redirect_path}#kudos_message" and return
+        redirect_to kudos_redirect_path(@kudo&.commentable || root_path) and return
       end
 
       format.js do
@@ -89,6 +86,11 @@ class KudosController < ApplicationController
   end
 
   private
+
+  def kudos_redirect_path(commentable)
+    redirect_path = url_from(request.referer.to_s.split("#", 2).first)
+    redirect_path ? "#{redirect_path}#kudos_message" : polymorphic_path(commentable, anchor: "kudos_message")
+  end
 
   def kudo_params
     params.require(:kudo).permit(:commentable_id, :commentable_type)

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -41,8 +41,7 @@ class KudosController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:kudos_notice] = t(".success")
-          redirect_path = url_from(request.referer) || polymorphic_path(@kudo.commentable)
-          redirect_to "#{redirect_path}#kudos_message" and return
+          redirect_to kudos_redirect_path(@kudo.commentable) and return
         end
 
         format.js do
@@ -59,8 +58,7 @@ class KudosController < ApplicationController
           return if check_user_status
 
           flash[:kudos_error] = error_message
-          redirect_path = url_from(request.referer) || polymorphic_path(@kudo.commentable || root_path)
-          redirect_to "#{redirect_path}#kudos_message" and return
+          redirect_to kudos_redirect_path(@kudo.commentable || root_path) and return
         end
 
         format.js do
@@ -78,8 +76,7 @@ class KudosController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:kudos_error] = error_message
-        redirect_path = url_from(request.referer) || polymorphic_path(@kudo&.commentable || root_path)
-        redirect_to "#{redirect_path}#kudos_message" and return
+        redirect_to kudos_redirect_path(@kudo&.commentable || root_path) and return
       end
 
       format.js do
@@ -89,6 +86,11 @@ class KudosController < ApplicationController
   end
 
   private
+
+  def kudos_redirect_path(commentable)
+    redirect_path = url_from(request.referer) || polymorphic_path(commentable)
+    "#{redirect_path.split('#', 2).first}#kudos_message"
+  end
 
   def kudo_params
     params.require(:kudo).permit(:commentable_id, :commentable_type)

--- a/spec/controllers/kudos_controller_spec.rb
+++ b/spec/controllers/kudos_controller_spec.rb
@@ -19,6 +19,12 @@ describe KudosController do
             it_redirects_to_with_kudos_notice(referer, "Thank you for leaving kudos!")
           end
 
+          it "redirects without a duplicate anchor when the referer already has an anchor" do
+            request.headers["HTTP_REFERER"] = work_path(work, anchor: "bookmark-form")
+            post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" } }
+            it_redirects_to_with_kudos_notice(work_path(work, anchor: "kudos_message"), "Thank you for leaving kudos!")
+          end
+
           it "does not save user on kudos" do
             post :create, params: { kudo: { commentable_id: work.id, commentable_type: "Work" } }
             expect(assigns(:kudo)).to be_persisted


### PR DESCRIPTION
# Pull Request Checklist

- [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
- [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
- [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
- [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7432

## Purpose

Leaving kudos with JavaScript disabled can 500 if the page you're on already has an anchor in the URL (e.g. you're at the bookmark form, so the URL ends in `#bookmark-form`).

The kudos redirect just glued `#kudos_message` onto the referer URL, which gives you something like `...#bookmark-form#kudos_message`. Ruby's URI parser rejects the `#` inside the fragment, so Rails' open redirect protection throws `OpenRedirectError` and you get a 500.

Fix: strip any existing anchor from the redirect target before adding `#kudos_message`.

## Testing Instructions

Smoke test as per the Jira issue:
1. Disable JavaScript in your browser.
2. Go to a work.
3. Press the Kudos button.
4. You should be redirected to the work with `#kudos_message` at the end of the URL, taking you to the success or error message.
5. Repeat while scrolled to the bookmark form (URL ends in `#bookmark-form`) to confirm no 500.

## Credit

**Evan W (he/him) [b1ume]**

