### PR TITLE
AO3-7541 Declare Elasticsearch requirements in request specs

### DIFF
--- a/spec/requests/blocked_users_n_plus_one_spec.rb
+++ b/spec/requests/blocked_users_n_plus_one_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "n+1 queries in the blocked users controller" do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true, pseud_search: true do
     context "with a logged in user who has blocked someone" do
       let!(:blocker) { create(:user) }
 

--- a/spec/requests/collection_items_n_plus_one_spec.rb
+++ b/spec/requests/collection_items_n_plus_one_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "n+1 queries in the collection items controller" do
   include LoginMacros
 
-  describe "#index" do
+  describe "#index", work_search: true, bookmark_search: true, collection_search: true do
     context "when viewing collection items for a specific user", n_plus_one: true do
       let!(:user) { create(:user) }
 

--- a/spec/requests/collections_n_plus_one_spec.rb
+++ b/spec/requests/collections_n_plus_one_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "n+1 queries in the collections controller" do
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true do
     populate do |n|
       CollectionIndexer.prepare_for_testing
       create_list(:collection, n, challenge: create(:gift_exchange))

--- a/spec/requests/homepage_inbox_n_plus_one_spec.rb
+++ b/spec/requests/homepage_inbox_n_plus_one_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "n+1 queries in the inbox module on the homepage: " do
   include LoginMacros
 
-  describe "#show", n_plus_one: true do
+  describe "#show", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true do
     context "displaying a user's unread messages on the homepage" do
       let!(:user) { create(:user) }
 

--- a/spec/requests/inbox_n_plus_one_spec.rb
+++ b/spec/requests/inbox_n_plus_one_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "n+1 queries in the InboxController" do
   include LoginMacros
 
-  describe "#show" do
+  describe "#show", work_search: true, bookmark_search: true, collection_search: true do
     let!(:user) { create(:user) }
 
     shared_examples "a constant number of queries" do

--- a/spec/requests/muted_users_n_plus_one_spec.rb
+++ b/spec/requests/muted_users_n_plus_one_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "n+1 queries in the muted users controller" do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true, pseud_search: true do
     context "with a logged in user who has muted someone" do
       let!(:muter) { create(:user) }
 

--- a/spec/requests/people_n_plus_one_spec.rb
+++ b/spec/requests/people_n_plus_one_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "n+1 queries in the people controller" do
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true, pseud_search: true do
     context "when viewing people in a collection" do
       let!(:collection) { create(:collection) }
 
@@ -26,7 +26,7 @@ describe "n+1 queries in the people controller" do
     end
   end
 
-  describe "#search", n_plus_one: true do
+  describe "#search", n_plus_one: true, pseud_search: true, collection_search: true do
     context "when there are search results" do
       populate do |n|
         PseudIndexer.prepare_for_testing

--- a/spec/requests/pseuds_n_plus_one_spec.rb
+++ b/spec/requests/pseuds_n_plus_one_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "n+1 queries in the user pseuds controller" do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true, pseud_search: true do
     let!(:user) { create(:user) }
 
     populate do |n|

--- a/spec/requests/readings_n_plus_one_spec.rb
+++ b/spec/requests/readings_n_plus_one_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "n+1 queries in the readings controller" do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true do
     context "when displaying a user's reading history" do
       let!(:user) { create(:user) }
 

--- a/spec/requests/skins_n_plus_one_spec.rb
+++ b/spec/requests/skins_n_plus_one_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "n+1 queries in the skins controller" do
   include LoginMacros
 
-  describe "#index", n_plus_one: true do
+  describe "#index", n_plus_one: true, work_search: true, bookmark_search: true, collection_search: true do
     context "when displaying a user's work skins" do
       let!(:user) { create(:user) }
 

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -50,7 +50,7 @@ describe "n+1 queries in the WorksController" do
     end
   end
 
-  describe "#index" do
+  describe "#index", work_search: true, bookmark_search: true do
     context "when viewing the works for a tag" do
       subject do
         proc do
@@ -116,7 +116,7 @@ describe "n+1 queries in the WorksController" do
     end
   end
 
-  describe "#collected" do
+  describe "#collected", work_search: true, bookmark_search: true do
     subject do
       proc do
         get collected_user_works_path(user)
@@ -138,7 +138,7 @@ describe "n+1 queries in the WorksController" do
     end
   end
 
-  describe "#drafts" do
+  describe "#drafts", work_search: true, bookmark_search: true do
     subject do
       proc do
         fake_login_known_user(user.reload)

--- a/spec/requests/works_n_plus_one_spec.rb
+++ b/spec/requests/works_n_plus_one_spec.rb
@@ -154,7 +154,7 @@ describe "n+1 queries in the WorksController" do
     it_behaves_like "displaying multiple works efficiently", queries_per_work: 1
   end
 
-  describe "#search" do
+  describe "#search", work_search: true, bookmark_search: true do
     subject do
       proc do
         get search_works_path(work_search: { query: fandom.name })


### PR DESCRIPTION
# Pull Request Checklist

- [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
- [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
- [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
- [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
- [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7541

## Purpose

Some `spec/requests` specs render pages that query Elasticsearch but never say so. If a spec that *does* declare it (e.g. `work_search: true`) runs first, its cleanup deletes the indexes and the request specs blow up with `index_not_found_exception`.

Added the applicable search metadata (`work_search`, `bookmark_search`, `collection_search`, `pseud_search`) to the affected request specs so the indexes they need always exist, regardless of run order.

## Testing Instructions

From the Jira issue:

```
bundle exec rspec spec/controllers/challenge_requests_controller_spec.rb spec/models/search/user_indexer_spec.rb spec/models/search/pseud_indexer_spec.rb spec/requests
```

All specs should pass. Also verify `bundle exec rspec spec/requests` passes on its own.

## Credit

**Evan W (he/him) [b1ume]**