### PR TITLE
AO3-7565 On Fulfilled Claims page, "Fulfilled Claims" button doesn't appear pressed

### DIFF
--- a/app/views/challenge_claims/_user_index.html.erb
+++ b/app/views/challenge_claims/_user_index.html.erb
@@ -9,7 +9,7 @@
       <%= span_if_current ts("Unfulfilled Claims"), user_claims_path(current_user), params[:posted].blank? %>
     </li>
     <li id="posted-link">
-      <%= span_if_current ts("Fulfilled Claims"), user_claims_path(current_user, :posted => true), params[:posted].present? %>
+      <%= span_if_current ts("Fulfilled Claims"), user_claims_path(current_user, posted: true), params[:posted].present? %>
     </li>
 	</ul>
 <% end %>

--- a/app/views/challenge_claims/_user_index.html.erb
+++ b/app/views/challenge_claims/_user_index.html.erb
@@ -4,11 +4,11 @@
 
 <!--subnav-->
 <% unless params[:for_user] %>
-	<ul class="navigation actions" role="navigation">
-    <li id="unposted-link">
+  <ul class="navigation actions">
+    <li>
       <%= span_if_current t(".navigation.unfulfilled"), user_claims_path(current_user), params[:posted].blank? %>
     </li>
-    <li id="posted-link">
+    <li>
       <%= span_if_current t(".navigation.fulfilled"), user_claims_path(current_user, posted: true), params[:posted].present? %>
     </li>
 	</ul>

--- a/app/views/challenge_claims/_user_index.html.erb
+++ b/app/views/challenge_claims/_user_index.html.erb
@@ -9,7 +9,7 @@
       <%= span_if_current ts("Unfulfilled Claims"), user_claims_path(current_user), params[:posted].blank? %>
     </li>
     <li id="posted-link">
-      <%= span_if_current ts("Fulfilled Claims"), user_claims_path(current_user, :posted => true) %>
+      <%= span_if_current ts("Fulfilled Claims"), user_claims_path(current_user, :posted => true), params[:posted].present? %>
     </li>
 	</ul>
 <% end %>

--- a/app/views/challenge_claims/_user_index.html.erb
+++ b/app/views/challenge_claims/_user_index.html.erb
@@ -6,10 +6,10 @@
 <% unless params[:for_user] %>
 	<ul class="navigation actions" role="navigation">
     <li id="unposted-link">
-      <%= span_if_current ts("Unfulfilled Claims"), user_claims_path(current_user), params[:posted].blank? %>
+      <%= span_if_current t(".navigation.unfulfilled"), user_claims_path(current_user), params[:posted].blank? %>
     </li>
     <li id="posted-link">
-      <%= span_if_current ts("Fulfilled Claims"), user_claims_path(current_user, posted: true), params[:posted].present? %>
+      <%= span_if_current t(".navigation.fulfilled"), user_claims_path(current_user, posted: true), params[:posted].present? %>
     </li>
 	</ul>
 <% end %>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -747,6 +747,9 @@ en:
     user_index:
       assignments: My Assignments
       assignments_note_html: Looking for assignments you were given for a gift exchange? Try %{assignments_link}.
+      navigation:
+        fulfilled: Fulfilled Claims
+        unfulfilled: Unfulfilled Claims
   challenge_signups:
     signup_form:
       notice:


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7565 

## Purpose

What does this PR do?
This PR makes the "fulfilled claims" button on the "claims" page appear selected when clicked. 

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?
You can follow the instructions from the Jira ticket for setup.
Once the "Fulfilled claims" button has been selected, add "&foo=bar" to the end of the url and press enter. If this is done without the changes added here, "Fulfilled Claims" appears unselected after the refresh. With these changes in place, the button remains selected after the refresh. 
These instructions will be added to the Jira ticket


## Credit
Scott Venkataraman he/him
