### PR TITLE
AO3-4250 Made gift recipients update on blurbs on pseud/username changes

### DIFF
--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -83,6 +83,7 @@ class Pseud < ApplicationRecord
   after_update :reindex_user, if: :saved_change_to_name?
   before_destroy :remove_from_autocomplete
   after_destroy :reindex_user
+  after_destroy :expire_caches
   after_commit :reindex_creations, :touch_comments
 
   scope :alphabetical, -> { order(:name) }
@@ -420,10 +421,21 @@ class Pseud < ApplicationRecord
   end
 
   def expire_caches
-    if saved_change_to_name?
-      works.touch_all
-      series.each(&:expire_byline_cache)
-      chapters.each(&:expire_byline_cache)
+    return unless saved_change_to_name? || (destroyed? && !user.nil?)
+
+    pseud = destroyed? ? user.default_pseud : self
+    return if pseud.nil?
+
+
+    pseud.chapters.each(&:expire_byline_cache)
+    pseud.series.each(&:expire_byline_cache)
+    pseud.works.each do |work|
+      work.touch
+      work.expire_caches
+    end
+    pseud.gift_works.each do |work|
+      work.touch
+      work.expire_caches
     end
   end
 

--- a/app/models/pseud.rb
+++ b/app/models/pseud.rb
@@ -79,11 +79,10 @@ class Pseud < ApplicationRecord
   before_update :cleanup_autocomplete, if: :will_save_change_to_name?
   after_update :add_to_autocomplete, if: :saved_change_to_name?
   after_update :check_default_pseud
-  after_update :expire_caches
   after_update :reindex_user, if: :saved_change_to_name?
   before_destroy :remove_from_autocomplete
   after_destroy :reindex_user
-  after_destroy :expire_caches
+  after_commit :expire_caches, on: [:update, :destroy]
   after_commit :reindex_creations, :touch_comments
 
   scope :alphabetical, -> { order(:name) }
@@ -426,17 +425,10 @@ class Pseud < ApplicationRecord
     pseud = destroyed? ? user.default_pseud : self
     return if pseud.nil?
 
-
-    pseud.chapters.each(&:expire_byline_cache)
+    pseud.works.touch_all
     pseud.series.each(&:expire_byline_cache)
-    pseud.works.each do |work|
-      work.touch
-      work.expire_caches
-    end
-    pseud.gift_works.each do |work|
-      work.touch
-      work.expire_caches
-    end
+    pseud.chapters.each(&:expire_byline_cache)
+    pseud.gift_works.touch_all
   end
 
   def touch_comments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,10 +190,7 @@ class User < ApplicationRecord
       work.touch
       work.expire_caches
     end
-    self.gift_works.each do |work|
-      work.touch
-      work.expire_caches
-    end
+    self.gift_works.touch_all
   end
 
   def remove_user_from_kudos

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,10 @@ class User < ApplicationRecord
       work.touch
       work.expire_caches
     end
+    self.gift_works.each do |work|
+      work.touch
+      work.expire_caches
+    end
   end
 
   def remove_user_from_kudos

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -229,6 +229,8 @@ Feature: Delete pseud.
       And I am logged in as "giftee1"
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for me2 (giftee1)"
-    When "giftee1" deletes the pseud "me2"
+    # Delay before deleting to make sure the cache is expired
+    When it is currently 1 second from now
+      And "giftee1" deletes the pseud "me2"
       And I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -207,3 +207,35 @@ Feature: Delete pseud.
     Then I should see "My Collection Thing"
       And I should not see "other_pseud (myself)" within "#main"
       And I should see "myself" within "#main"
+
+  Scenario: Deleting a pseud updates series blurbs
+
+    Given I am logged in as "Myself"
+      And "Myself" has the pseud "me2"
+      And I add the work "Great Work" to series "Best Series" as "me2"
+    When I go to the dashboard page for user "Myself" with pseud "me2"
+      And I follow "Series"
+    Then I should see "Best Series by me2 (Myself)"
+
+    When "Myself" deletes the pseud "me2"
+      And I follow "Series"
+    Then I should see "Best Series by Myself"
+
+  Scenario: Deleting a pseud updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And a pseud exists with name: "me2", user_id: 2
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "me2 (giftee1)"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I go to giftee1's gifts page
+    Then I should see "GiftStory1 by gifter for me2 (giftee1)"
+    When "giftee1" deletes the pseud "me2"
+      And I go to giftee1's gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"

--- a/features/other_a/pseud_delete.feature
+++ b/features/other_a/pseud_delete.feature
@@ -209,31 +209,24 @@ Feature: Delete pseud.
       And I should see "myself" within "#main"
 
   Scenario: Deleting a pseud updates series blurbs
-
     Given I am logged in as "Myself"
       And "Myself" has the pseud "me2"
       And I add the work "Great Work" to series "Best Series" as "me2"
     When I go to the dashboard page for user "Myself" with pseud "me2"
       And I follow "Series"
     Then I should see "Best Series by me2 (Myself)"
-
     When "Myself" deletes the pseud "me2"
       And I follow "Series"
     Then I should see "Best Series by Myself"
 
   Scenario: Deleting a pseud updates gift blurbs
-    Given I have no users
-      And the following activated users exist
-        | login      | password    | email                | id |
-        | gifter     | something   | gifter@example.com   | 1  |
-        | giftee1    | something   | giftee1@example.com  | 2  |
-      And a pseud exists with name: "me2", user_id: 2
+    Given "giftee1" has the pseud "me2"
       And the user "giftee1" allows gifts
-      And I am logged in as "gifter" with password "something"
+      And I am logged in as "gifter"
       And I set up the draft "GiftStory1"
       And I give the work to "me2 (giftee1)"
       And I press "Post"
-      And I am logged in as "giftee1" with password "something"
+      And I am logged in as "giftee1"
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for me2 (giftee1)"
     When "giftee1" deletes the pseud "me2"

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -268,6 +268,8 @@ Scenario: Edit pseud updates gift blurbs
     And I follow "Manage My Pseuds"
     And I follow "Edit Me2"
     And I fill in "Name" with "Me3"
+    # Delay before renaming to make sure the cache is expired
+    And it is currently 1 second from now
     And I press "Update"
   Then I should see "Pseud was successfully updated."
   When I go to giftee1's gifts page

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -255,18 +255,13 @@ Scenario: Edit pseud updates series blurbs
   Then I should see "Best Series by Me3 (Myself)"
 
 Scenario: Edit pseud updates gift blurbs
-  Given I have no users
-    And the following activated users exist
-      | login      | password    | email                | id |
-      | gifter     | something   | gifter@example.com   | 1  |
-      | giftee1    | something   | giftee1@example.com  | 2  |
-    And a pseud exists with name: "Me2", user_id: 2
+  Given "giftee1" has the pseud "Me2"
     And the user "giftee1" allows gifts
-    And I am logged in as "gifter" with password "something"
+    And I am logged in as "gifter"
     And I set up the draft "GiftStory1"
     And I give the work to "Me2 (giftee1)"
     And I press "Post"
-    And I am logged in as "giftee1" with password "something"
+    And I am logged in as "giftee1"
   When I go to giftee1's gifts page
   Then I should see "GiftStory1 by gifter for Me2 (giftee1)"
   When I view my profile

--- a/features/other_a/pseuds.feature
+++ b/features/other_a/pseuds.feature
@@ -254,6 +254,30 @@ Scenario: Edit pseud updates series blurbs
   When I follow "Series"
   Then I should see "Best Series by Me3 (Myself)"
 
+Scenario: Edit pseud updates gift blurbs
+  Given I have no users
+    And the following activated users exist
+      | login      | password    | email                | id |
+      | gifter     | something   | gifter@example.com   | 1  |
+      | giftee1    | something   | giftee1@example.com  | 2  |
+    And a pseud exists with name: "Me2", user_id: 2
+    And the user "giftee1" allows gifts
+    And I am logged in as "gifter" with password "something"
+    And I set up the draft "GiftStory1"
+    And I give the work to "Me2 (giftee1)"
+    And I press "Post"
+    And I am logged in as "giftee1" with password "something"
+  When I go to giftee1's gifts page
+  Then I should see "GiftStory1 by gifter for Me2 (giftee1)"
+  When I view my profile
+    And I follow "Manage My Pseuds"
+    And I follow "Edit Me2"
+    And I fill in "Name" with "Me3"
+    And I press "Update"
+  Then I should see "Pseud was successfully updated."
+  When I go to giftee1's gifts page
+  Then I should see "GiftStory1 by gifter for Me3 (giftee1)"
+
 Scenario: Change details as an admin
 
   Given "someone" has the pseud "alt"

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -129,3 +129,26 @@ Scenario: Delete a user who has coauthored a work
       And I fill in "Password:" with "password" within "#small_login"
       And I press "Log In" within "#small_login"
     Then I should not see "You have successfully deleted your account"
+
+  Scenario: Deleting a user updates gift blurbs
+    Given I have no users
+      And I have no works or comments
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | something   | giftee1@example.com  | 2  |
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And I am logged in as "giftee1" with password "something"
+    When I am on gifter's works page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I try to delete my account as giftee1
+    Then I should see "You have successfully deleted your account."
+      And a user account should not exist for "giftee1"
+      And I should be logged out
+    When I am on gifter's works page
+    Then I should see "GiftStory1 by gifter"
+      And I should not see "GiftStory1 by gifter for giftee1"

--- a/features/users/user_delete.feature
+++ b/features/users/user_delete.feature
@@ -131,18 +131,16 @@ Scenario: Delete a user who has coauthored a work
     Then I should not see "You have successfully deleted your account"
 
   Scenario: Deleting a user updates gift blurbs
-    Given I have no users
-      And I have no works or comments
-      And the following activated users exist
-        | login      | password    | email                | id |
-        | gifter     | something   | gifter@example.com   | 1  |
-        | giftee1    | something   | giftee1@example.com  | 2  |
+    Given the following activated users exist
+        | login   |
+        | gifter  |
+        | giftee1 |
       And the user "giftee1" allows gifts
-      And I am logged in as "gifter" with password "something"
+      And I am logged in as "gifter"
       And I set up the draft "GiftStory1"
       And I give the work to "giftee1"
       And I press "Post"
-      And I am logged in as "giftee1" with password "something"
+      And I am logged in as "giftee1"
     When I am on gifter's works page
     Then I should see "GiftStory1 by gifter for giftee1"
     When I try to delete my account as giftee1

--- a/features/users/user_edit.feature
+++ b/features/users/user_edit.feature
@@ -251,7 +251,7 @@ Feature:
       And I view the 3rd chapter
     Then I should see "Chapter by after"
 
-  Scenario: Changing only username updates gift blurbs
+  Scenario: Changing username to match an existing non-default pseud updates gift blurbs
     Given "giftee1" has the pseud "newusername"
       And the user "giftee1" allows gifts
       And I am logged in as "gifter"
@@ -262,7 +262,9 @@ Feature:
       And I am logged in as "giftee1" with password "password"
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"
-    When I change my username to "newusername"
+    # Delay before renaming to make sure the cache is expired
+    When it is currently 1 second from now
+      And I change my username to "newusername"
     Then I should see "Hi, newusername"
     When I go to newusername's gifts page
     Then I should see "GiftStory1 by gifter for giftee1 (newusername)"
@@ -281,7 +283,9 @@ Feature:
       And I am logged in as "giftee1" with password "password"
     When I go to giftee1's gifts page
     Then I should see "GiftStory1 by gifter for giftee1"
-    When I change my username to "newusername"
+    # Delay before renaming to make sure the cache is expired
+    When it is currently 1 second from now
+      And I change my username to "newusername"
     Then I should see "Hi, newusername"
     When I go to newusername's gifts page
     Then I should see "GiftStory1 by gifter for newusername"

--- a/features/users/user_edit.feature
+++ b/features/users/user_edit.feature
@@ -210,7 +210,7 @@ Feature:
       And I should see "after" within "#main"
       And I should not see "before" within "#main"
 
-  Scenario: Changing only username updates series blurbs
+  Scenario: Changing username to match an existing non-default pseud updates series blurbs
     Given I am logged in as "oldusername" with password "password"
       And "oldusername" has the pseud "newusername"
       And I add the work "Great Work" to series "Best Series"

--- a/features/users/user_edit.feature
+++ b/features/users/user_edit.feature
@@ -211,12 +211,8 @@ Feature:
       And I should not see "before" within "#main"
 
   Scenario: Changing only username updates series blurbs
-    Given I have no users
-      And the following activated user exists
-        | login         | password | id |
-        | oldusername   | password | 1  |
-      And a pseud exists with name: "newusername", user_id: 1
-      And I am logged in as "oldusername"
+    Given I am logged in as "oldusername" with password "password"
+      And "oldusername" has the pseud "newusername"
       And I add the work "Great Work" to series "Best Series"
     When I go to the dashboard page for user "oldusername" with pseud "oldusername"
       And I follow "Series"
@@ -227,8 +223,7 @@ Feature:
     Then I should see "Best Series by oldusername (newusername)"
 
   Scenario: Changing username and pseud updates series blurbs
-    Given I have no users
-      And I am logged in as "oldusername" with password "password"
+    Given I am logged in as "oldusername" with password "password"
       And I add the work "Great Work" to series "Best Series"
     When I go to the dashboard page for user "oldusername" with pseud "oldusername"
       And I follow "Series"
@@ -257,14 +252,9 @@ Feature:
     Then I should see "Chapter by after"
 
   Scenario: Changing only username updates gift blurbs
-    Given I have no users
-      And the following activated users exist
-        | login      | password    | email                | id |
-        | gifter     | something   | gifter@example.com   | 1  |
-        | giftee1    | password    | giftee1@example.com  | 2  |
-      And a pseud exists with name: "newusername", user_id: 2
+    Given "giftee1" has the pseud "newusername"
       And the user "giftee1" allows gifts
-      And I am logged in as "gifter" with password "something"
+      And I am logged in as "gifter"
       And I set up the draft "GiftStory1"
       And I give the work to "giftee1"
       And I press "Post"
@@ -278,13 +268,12 @@ Feature:
     Then I should see "GiftStory1 by gifter for giftee1 (newusername)"
 
   Scenario: Changing username and pseud updates gift blurbs
-    Given I have no users
-      And the following activated users exist
-        | login      | password    | email                | id |
-        | gifter     | something   | gifter@example.com   | 1  |
-        | giftee1    | password    | giftee1@example.com  | 2  |
+    Given the following activated users exist
+        | login      |
+        | gifter     |
+        | giftee1    |
       And the user "giftee1" allows gifts
-      And I am logged in as "gifter" with password "something"
+      And I am logged in as "gifter"
       And I set up the draft "GiftStory1"
       And I give the work to "giftee1"
       And I press "Post"
@@ -299,8 +288,7 @@ Feature:
       And I should not see "GiftStory1 by gifter for giftee1"
 
   Scenario: Changing the username from a forbidden name to non-forbidden
-    Given I have no users
-      And the following activated user exists
+    Given the following activated user exists
         | login     | password |
         | forbidden | secret12 |
       And the username "forbidden" is on the forbidden list

--- a/features/users/user_edit.feature
+++ b/features/users/user_edit.feature
@@ -210,21 +210,34 @@ Feature:
       And I should see "after" within "#main"
       And I should not see "before" within "#main"
 
-  Scenario: Changing username updates series blurbs
+  Scenario: Changing only username updates series blurbs
+    Given I have no users
+      And the following activated user exists
+        | login         | password | id |
+        | oldusername   | password | 1  |
+      And a pseud exists with name: "newusername", user_id: 1
+      And I am logged in as "oldusername"
+      And I add the work "Great Work" to series "Best Series"
+    When I go to the dashboard page for user "oldusername" with pseud "oldusername"
+      And I follow "Series"
+    Then I should see "Best Series by oldusername"
+    When I change my username to "newusername"
+    Then I should see "Hi, newusername"
+    When I follow "Series"
+    Then I should see "Best Series by oldusername (newusername)"
+
+  Scenario: Changing username and pseud updates series blurbs
     Given I have no users
       And I am logged in as "oldusername" with password "password"
       And I add the work "Great Work" to series "Best Series"
     When I go to the dashboard page for user "oldusername" with pseud "oldusername"
       And I follow "Series"
     Then I should see "Best Series by oldusername"
-    When I visit the change username page for oldusername
-      And I fill in "New username" with "newusername"
-      And I fill in "Password" with "password"
-      And I press "Change Username"
-    Then I should get confirmation that I changed my username
-      And I should see "Hi, newusername"
+    When I change my username to "newusername"
+    Then I should see "Hi, newusername"
     When I follow "Series"
     Then I should see "Best Series by newusername"
+      And I should not see "Best Series by oldusername"
 
   Scenario: Changing username updates chapter bylines
     Given the work "Title" by "pikachu" with chapter two co-authored with "before"
@@ -243,19 +256,61 @@ Feature:
       And I view the 3rd chapter
     Then I should see "Chapter by after"
 
-    Scenario: Changing the username from a forbidden name to non-forbidden
-      Given I have no users
-        And the following activated user exists
-          | login     | password |
-          | forbidden | secret12 |
-        And the username "forbidden" is on the forbidden list
-      When I am logged in as "forbidden" with password "secret12"
-        And I visit the change username page for forbidden
-        And I fill in "New username" with "notforbidden"
-        And I fill in "Password" with "secret12"
-        And I press "Change Username"
-      Then I should get confirmation that I changed my username
-        And I should see "Hi, notforbidden"
+  Scenario: Changing only username updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | password    | giftee1@example.com  | 2  |
+      And a pseud exists with name: "newusername", user_id: 2
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And all emails have been delivered
+      And I am logged in as "giftee1" with password "password"
+    When I go to giftee1's gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I change my username to "newusername"
+    Then I should see "Hi, newusername"
+    When I go to newusername's gifts page
+    Then I should see "GiftStory1 by gifter for giftee1 (newusername)"
+
+  Scenario: Changing username and pseud updates gift blurbs
+    Given I have no users
+      And the following activated users exist
+        | login      | password    | email                | id |
+        | gifter     | something   | gifter@example.com   | 1  |
+        | giftee1    | password    | giftee1@example.com  | 2  |
+      And the user "giftee1" allows gifts
+      And I am logged in as "gifter" with password "something"
+      And I set up the draft "GiftStory1"
+      And I give the work to "giftee1"
+      And I press "Post"
+      And all emails have been delivered
+      And I am logged in as "giftee1" with password "password"
+    When I go to giftee1's gifts page
+    Then I should see "GiftStory1 by gifter for giftee1"
+    When I change my username to "newusername"
+    Then I should see "Hi, newusername"
+    When I go to newusername's gifts page
+    Then I should see "GiftStory1 by gifter for newusername"
+      And I should not see "GiftStory1 by gifter for giftee1"
+
+  Scenario: Changing the username from a forbidden name to non-forbidden
+    Given I have no users
+      And the following activated user exists
+        | login     | password |
+        | forbidden | secret12 |
+      And the username "forbidden" is on the forbidden list
+    When I am logged in as "forbidden" with password "secret12"
+      And I visit the change username page for forbidden
+      And I fill in "New username" with "notforbidden"
+      And I fill in "Password" with "secret12"
+      And I press "Change Username"
+    Then I should get confirmation that I changed my username
+      And I should see "Hi, notforbidden"
 
   Scenario: Tag wrangling supervisors are emailed about tag wrangler username changes
     Given the user "before" exists and is activated


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-4250

## Purpose

Made it so that changing a pseud or username, deleting a pseud, or deleting a user account will expire the cache for all gift works (so that the byline will no longer display the old pseud or username.)

For deleting a pseud, this is done by expiring the cache on all gifts for the default pseud (since gifts are reassigned to the default pseud.) This will clear more caches than necessary - technically we only need to expire the cache for the gifts that were previously assigned to pseud being deleted.

## References

Adopts #5063
PR limit does not apply to volunteers with write access to the repository.

## Credit

Stephen Lewis, he/him (original code)
Brian Austin (original review)
Bilka (original review)
Bilka