### PR TITLE
AO3-6329 Fix cached work blurbs mixing time zones

### DIFF
--- a/app/views/works/_work_module.html.erb
+++ b/app/views/works/_work_module.html.erb
@@ -22,7 +22,7 @@
       <%= byline(work, visibility: "public") %>
 
 <% #### CACHE show/hide ####, if you update the key edit lib/tasks/memcached.rake %>
-<% cache("#{work.cache_key}-#{Work.work_blurb_version(work.id)}-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work)  ? 'nofreeform' : 'showfreeform'}-v11", skip_digest: true) do %>
+<% cache("#{work.cache_key}-#{Work.work_blurb_version(work.id)}-#{hide_warnings?(work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(work) ? 'nofreeform' : 'showfreeform'}-#{current_user&.preference&.time_zone}-v12", skip_digest: true) do %>
 
       <% tag_groups = work.tag_groups %>
 

--- a/spec/requests/work_blurb_timezone_spec.rb
+++ b/spec/requests/work_blurb_timezone_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Work blurb time zones" do
+  include LoginMacros
+
+  let(:author) { create(:user) }
+  let(:work) { create(:work, authors: [author.default_pseud], revised_at: 40.days.ago.utc.change(hour: 10)) }
+
+  before do
+    AdminSetting.first.update_attribute(:enable_test_caching, true)
+  end
+
+  it "shows the revision date in the viewer's time zone even when the blurb is cached" do
+    east_user = create(:user)
+    east_user.preference.update_attribute(:time_zone, "Auckland")
+    west_user = create(:user)
+    west_user.preference.update_attribute(:time_zone, "International Date Line West")
+
+    east_date = work.revised_at.in_time_zone("Auckland").to_date.to_formatted_s(:rfc822)
+    west_date = work.revised_at.in_time_zone("International Date Line West").to_date.to_formatted_s(:rfc822)
+    expect(east_date).not_to eq(west_date)
+
+    fake_login_known_user(east_user)
+    get user_path(author)
+    expect(response.body).to include(east_date)
+
+    fake_login_known_user(west_user)
+    get user_path(author)
+    expect(response.body).to include(west_date)
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6329

## Purpose

Makes work blurb caching timezone-aware, so revision dates always display in the viewer's timezone instead of whoever cached the blurb first.

## Testing Instructions

1. Set your timezone to GMT+13, post a work, and view it on your dashboard.
2. Change your timezone to GMT-12, post another work in the same fandom, and view your dashboard.
3. The first work's date should now display in GMT-12 instead of staying in GMT+13.


## Credit

**Evan W** (he/him) b1ume