### PR TITLE
AO3-7050 Restrict ability to send invitation to email address

### DIFF
--- a/app/controllers/admin/admin_invitations_controller.rb
+++ b/app/controllers/admin/admin_invitations_controller.rb
@@ -1,19 +1,19 @@
 class Admin::AdminInvitationsController < Admin::BaseController
-
   def index
+    authorize Invitation
   end
 
   def create
-    @invitation = current_admin.invitations.new(invitation_params)
+    @invitation = authorize current_admin.invitations.new(invitation_params)
 
     if @invitation.invitee_email.blank?
-      flash[:error] = t('no_email', default: "Please enter an email address.")
-      render action: 'index'
+      flash[:error] = t(".no_email")
+      render :index
     elsif @invitation.save
-      flash[:notice] = t('sent', default: "An invitation was sent to %{email_address}", email_address: @invitation.invitee_email)
+      flash[:notice] = t(".sent", email_address: @invitation.invitee_email)
       redirect_to admin_invitations_path
     else
-      render action: 'index'
+      render :index
     end
   end
 
@@ -35,7 +35,7 @@ class Admin::AdminInvitationsController < Admin::BaseController
     else
       Invitation.grant_empty(invitation_params[:number_of_invites].to_i)
     end
-    flash[:notice] = t('invites_created', default: 'Invitations successfully created.')
+    flash[:notice] = t(".invites_created")
     redirect_to admin_invitations_path
   end
 

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -2,6 +2,7 @@ class InvitationPolicy < ApplicationPolicy
   EXTRA_INFO_ROLES = %w[superadmin open_doors policy_and_abuse support tag_wrangling].freeze
   FIND_ROLES = %w[superadmin open_doors policy_and_abuse support].freeze
   CREATE_ROLES = %w[superadmin policy_and_abuse support tag_wrangling].freeze
+  INDEX_ROLES = FIND_ROLES | CREATE_ROLES
   INVITE_FROM_QUEUE_ROLES = %w[superadmin policy_and_abuse].freeze
   INVITE_ALL_ROLES = %w[superadmin].freeze
 
@@ -10,7 +11,7 @@ class InvitationPolicy < ApplicationPolicy
   end
 
   def index?
-    user_has_roles?(FIND_ROLES | CREATE_ROLES)
+    user_has_roles?(INDEX_ROLES)
   end
 
   def create?

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,11 +1,20 @@
 class InvitationPolicy < ApplicationPolicy
   EXTRA_INFO_ROLES = %w[superadmin open_doors policy_and_abuse support tag_wrangling].freeze
   FIND_ROLES = %w[superadmin open_doors policy_and_abuse support].freeze
+  CREATE_ROLES = %w[superadmin policy_and_abuse support tag_wrangling].freeze
   INVITE_FROM_QUEUE_ROLES = %w[superadmin policy_and_abuse].freeze
   INVITE_ALL_ROLES = %w[superadmin].freeze
 
   def access_invitee_details?
     user_has_roles?(EXTRA_INFO_ROLES)
+  end
+
+  def index?
+    user_has_roles?(FIND_ROLES | CREATE_ROLES)
+  end
+
+  def create?
+    user_has_roles?(CREATE_ROLES)
   end
 
   def find?

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -10,18 +10,20 @@
       </li>
     <% end %>
 
-    <li class="dropdown">
-      <%= link_to t(".nav.invitations.invitations"), admin_invitations_path %>
-      <ul class="menu">
-        <li><%= link_to t(".nav.invitations.new"), admin_invitations_path %></li>
-        <% if policy(UserInviteRequest).index? %>
-          <li><%= link_to t(".nav.invitations.requests"), user_invite_requests_path %></li>
-        <% end %>
-        <% if policy(InviteRequest).can_manage? %>
-          <li><%= link_to t(".nav.invitations.queue"), manage_invite_requests_path %></li>
-        <% end %>
-      </ul>
-    </li>
+    <% if policy(Invitation).index? %>
+      <li class="dropdown">
+        <%= link_to t(".nav.invitations.invitations"), admin_invitations_path %>
+        <ul class="menu">
+          <li><%= link_to t(".nav.invitations.new"), admin_invitations_path %></li>
+          <% if policy(UserInviteRequest).index? %>
+            <li><%= link_to t(".nav.invitations.requests"), user_invite_requests_path %></li>
+          <% end %>
+          <% if policy(InviteRequest).can_manage? %>
+            <li><%= link_to t(".nav.invitations.queue"), manage_invite_requests_path %></li>
+          <% end %>
+        </ul>
+      </li>
+    <% end %>
     <li class="dropdown">
       <%= link_to t(".nav.posts.admin_posts"), admin_posts_path %>
       <ul class="menu">

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -10,7 +10,7 @@
       </li>
     <% end %>
 
-    <% if policy(Invitation).index? %>
+    <% if policy(Invitation).index? || policy(UserInviteRequest).index? || policy(InviteRequest).can_manage? %>
       <li class="dropdown">
         <%= link_to t(".nav.invitations.invitations"), admin_invitations_path %>
         <ul class="menu">

--- a/app/views/admin/admin_invitations/index.html.erb
+++ b/app/views/admin/admin_invitations/index.html.erb
@@ -33,17 +33,19 @@
   <% end %>
 <% end %>
 
-<%= form_tag url_for(controller: "admin/admin_invitations", action: :create), class: "invitation simple post", autocomplete: "off" do %>
-  <fieldset class="simple">
-    <h3 class="heading"><%= t(".send_to_email.heading") %></h3>
-    <p>
-      <%= t(".send_to_email.description") %>
-      <%= text_field_tag "invitation[invitee_email]",
-            (@invitation.try(:invitee_email) || ""),
-            title: t(".send_to_email.invite_by_email_title") %>
-      <span class="submit actions"><%= submit_tag t(".send_to_email.invite_user") %></span>
-    </p>
-  </fieldset>
+<% if policy(Invitation).create? %>
+  <%= form_tag url_for(controller: "admin/admin_invitations", action: :create), class: "invitation simple post", autocomplete: "off" do %>
+    <fieldset class="simple">
+      <h3 class="heading"><%= t(".send_to_email.heading") %></h3>
+      <p>
+        <%= t(".send_to_email.description") %>
+        <%= text_field_tag "invitation[invitee_email]",
+              (@invitation.try(:invitee_email) || ""),
+              title: t(".send_to_email.invite_by_email_title") %>
+        <span class="submit actions"><%= submit_tag t(".send_to_email.invite_user") %></span>
+      </p>
+    </fieldset>
+  <% end %>
 <% end %>
 
 <% if policy(Invitation).invite_from_queue? %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -127,10 +127,6 @@ ignore_missing:
   - comments.set_page_subtitle.page_title
   ## All of the following keys are using default values defined in the respective .rb files
   ## TODO: Move the default values to the .yml files
-  # File: app/controllers/admin/admin_invitations_controller.rb
-  - invites_created # should be admin.admin_invitations.grant_invites_to_users.invites_created
-  - no_email # should be admin.admin_invitations.create.no_email
-  - sent # should be admin.admin_invitations.create.sent
   # File: app/controllers/challenge_assignments_controller.rb
   - challenge_assignments.assignments_not_sent
   - challenge_assignments.assignments_sent
@@ -163,8 +159,6 @@ ignore_missing:
   - skins.approval_queue
   - skins.approved_skins
   - skins.rejected_skins
-  # File: app/views/comments/show.html.erb
-  - comments.show.comment_on
   # File: app/views/external_authors/_external_author_name.html.erb
   - external_authors.external_author_name.label_external_author_name
   # File: app/views/external_authors/edit.html.erb

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -6,8 +6,13 @@ en:
       not_admin_denied: Please log in as admin
       page_access_denied: Sorry, only an authorized admin can access the page you were trying to reach.
     admin_invitations:
+      create:
+        no_email: Please enter an email address.
+        sent: An invitation was sent to %{email_address}
       find:
         user_not_found: No results were found. Try another search.
+      grant_invites_to_users:
+        invites_created: Invitations successfully created.
       invite_from_queue:
         success:
           one: "%{count} person from the invite queue is being invited."

--- a/features/admins/admin_invitations.feature
+++ b/features/admins/admin_invitations.feature
@@ -254,8 +254,13 @@ Feature: Admin Actions to Manage Invitations
       And I should not see "Create an Account!"
       And I should not see "Joining the Archive currently requires an invitation; however, we are not accepting new invitation requests at this time."
 
-  Scenario: An admin can send an invitation to a user via email
+  Scenario: An admin without a role has no Invitations entry in the admin header
     Given I am logged in as an admin
+    Then I should not see "Invite New Users"
+      And I should not see "Invitations"
+
+  Scenario: An admin can send an invitation to a user via email
+    Given I am logged in as a "tag_wrangling" admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I fill in "invitation[invitee_email]" with "fred@bedrock.com"
@@ -264,7 +269,7 @@ Feature: Admin Actions to Manage Invitations
       And 1 email should be delivered
 
   Scenario: An admin can't create an invite with invalid email
-    Given I am logged in as an admin
+    Given I am logged in as a "tag_wrangling" admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I fill in "invitation[invitee_email]" with "abcdefgh"
@@ -273,7 +278,7 @@ Feature: Admin Actions to Manage Invitations
       And 0 emails should be delivered
 
   Scenario: An admin can't create an invite without an email address.
-    Given I am logged in as an admin
+    Given I am logged in as a "tag_wrangling" admin
       And all emails have been delivered
     When I follow "Invite New Users"
       And I press "Invite user"

--- a/spec/controllers/admin/admin_invitations_controller_spec.rb
+++ b/spec/controllers/admin/admin_invitations_controller_spec.rb
@@ -6,39 +6,40 @@ describe Admin::AdminInvitationsController do
   include LoginMacros
   include RedirectExpectationHelper
 
+  index_roles = %w[superadmin open_doors policy_and_abuse support tag_wrangling].freeze
+
   describe "GET #index" do
-    let(:admin) { create(:admin) }
+    subject { get :index }
+    let(:success) do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("index")
+    end
+
+    it_behaves_like "an action only authorized admins can access", authorized_roles: index_roles
 
     it "denies non-admins access to index" do
       fake_login
-      get :index
-      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
-    end
+      subject
 
-    it "allows admins to access index" do
-      fake_login_admin(admin)
-      get :index
-      expect(response).to have_http_status(:success)
+      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end
   end
 
+  create_roles = %w[superadmin policy_and_abuse support tag_wrangling].freeze
+
   describe "POST #create" do
-    let(:admin) { create(:admin) }
-
-    it "does not allow non-admins to create invites" do
-      email = "test_email@example.com"
-      fake_login
-      post :create, params: { invitation: { invitee_email: email } }
-
-      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
+    subject { post :create, params: { invitation: { invitee_email: "test_email@example.com" } } }
+    let(:success) do
+      it_redirects_to_with_notice(admin_invitations_path, "An invitation was sent to test_email@example.com")
     end
 
-    it "allows admins to create invites" do
-      email = "test_email@example.com"
-      fake_login_admin(admin)
-      post :create, params: { invitation: { invitee_email: email } }
+    it_behaves_like "an action only authorized admins can access", authorized_roles: create_roles
 
-      it_redirects_to_with_notice(admin_invitations_path, "An invitation was sent to #{email}")
+    it "does not allow non-admins to create invites" do
+      fake_login
+      subject
+
+      it_redirects_to_with_notice(root_path, "I'm sorry, only an admin can look at that area")
     end
   end
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7050

## Purpose

Restrict access to `AdminInvitationsController` `create` and `index` to the correct admin roles. I also did some cleanup of the controller.

## References

PR limit does not apply to volunteers with write access to the repository.

## Credit

Bilka
