### PR TITLE
AO3-6910 Report Elasticsearch syntax errors to Sentry

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -110,7 +110,8 @@ class AutocompleteController < ApplicationController
         body: { size: "100", query: { bool: { filter: [{ match: { tag_type: params[:type].capitalize } }, { match: { canonical: false } }], must: search_list } } }
       )
       render_output((match + search_results["hits"]["hits"].first(10).map { |t| t["_source"]["name"] }).uniq)
-    rescue Elastic::Transport::Transport::Errors::BadRequest
+    rescue Elastic::Transport::Transport::Errors::BadRequest => e
+      Sentry.capture_exception(e) if defined?(Sentry)
       render_output(match)
     end
   end

--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -14,7 +14,8 @@ class Query
         body: generated_query,
         track_total_hits: true
       )
-    rescue Elastic::Transport::Transport::Errors::BadRequest
+    rescue Elastic::Transport::Transport::Errors::BadRequest => e
+      Sentry.capture_exception(e) if defined?(Sentry)
       { error: "Your search failed because of a syntax error. Please try again." }
     end
   end

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -10,9 +10,15 @@ describe AutocompleteController do
           .and_raise(Elastic::Transport::Transport::Errors::BadRequest)
       end
 
-      it "returns an empty result" do
+      it "returns an empty result when there is no exact match" do
         get :noncanonical_tag, params: { term: "test", type: "freeform", format: :json }
         expect(JSON.parse(response.body)).to eq([])
+      end
+
+      it "falls back to the exact database match" do
+        create(:freeform, name: "test", canonical: false)
+        get :noncanonical_tag, params: { term: "test", type: "freeform", format: :json }
+        expect(JSON.parse(response.body)).to eq([{ "id" => "test", "name" => "test" }])
       end
 
       it "reports the exception to Sentry" do

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -3,6 +3,27 @@ require "spec_helper"
 describe AutocompleteController do
   include LoginMacros
 
+  describe "GET #noncanonical_tag" do
+    context "when Elasticsearch raises a BadRequest error" do
+      before do
+        allow($elasticsearch).to receive(:search)
+          .and_raise(Elastic::Transport::Transport::Errors::BadRequest)
+      end
+
+      it "returns an empty result" do
+        get :noncanonical_tag, params: { term: "test", type: "freeform", format: :json }
+        expect(JSON.parse(response.body)).to eq([])
+      end
+
+      it "reports the exception to Sentry" do
+        sentry = class_double("Sentry", capture_exception: nil).as_stubbed_const
+        get :noncanonical_tag, params: { term: "test", type: "freeform", format: :json }
+        expect(sentry).to have_received(:capture_exception)
+          .with(instance_of(Elastic::Transport::Transport::Errors::BadRequest))
+      end
+    end
+  end
+
   describe "tag" do
     let!(:tag1) { create(:canonical_fandom, name: "Match") }
     let!(:tag2) { create(:canonical_fandom, name: "Blargh") }

--- a/spec/models/search/query_spec.rb
+++ b/spec/models/search/query_spec.rb
@@ -1,6 +1,27 @@
 require 'spec_helper'
 
 describe Query do
+  describe "#search" do
+    context "when Elasticsearch raises a BadRequest error" do
+      before do
+        allow($elasticsearch).to receive(:search)
+          .and_raise(Elastic::Transport::Transport::Errors::BadRequest)
+      end
+
+      it "returns an error hash" do
+        result = Query.new.search
+        expect(result).to eq(error: "Your search failed because of a syntax error. Please try again.")
+      end
+
+      it "reports the exception to Sentry" do
+        sentry = class_double("Sentry", capture_exception: nil).as_stubbed_const
+        Query.new.search
+        expect(sentry).to have_received(:capture_exception)
+          .with(instance_of(Elastic::Transport::Transport::Errors::BadRequest))
+      end
+    end
+  end
+
   describe '#split_query_text_phrases' do
     it "should add quoted phrases to a query string" do
       q = Query.new


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6910

## Purpose

When an Elasticsearch `BadRequest` error occurs (e.g. from a search syntax error), the exception is rescued and a user-facing banner is shown, but nothing is reported to Sentry. This makes it difficult to debug what caused the error.

This PR adds `Sentry.capture_exception` calls in the two places where `Elastic::Transport::Transport::Errors::BadRequest` is rescued:

- `Query#search` the main search path (works, bookmarks, tags, etc.)
- `AutocompleteController#noncanonical_tag` noncanonical tag autocomplete

Both use `if defined?(Sentry)` since the Sentry gems are only loaded in staging/production.

## Testing Instructions

1. Go to https://archiveofourown.org/works?work_search[sort_column]=null&work_search[other_tag_names]=null&work_search[excluded_tag_names]=null&work_search[crossover]=null&work_search[complete]=null&work_search[words_from]=null&work_search[words_to]=null&work_search[date_from]=null&work_search[date_to]=null&work_search[query]=null&work_search[language_id]=null&commit=Sort%20and%20Filter&tag_id=Older%20Man*s*Younger%20Woman&page=2
2. Verify the user still sees the syntax error banner
3. Ask a Systems or Senior AD&T member to check Sentry for the new `Elassport::Errors::BadRequest` issue

## Credit

Pablo Monfort (he/him)