### PR TITLE
AO3-7506 Set default pseud when backfilling

### DIFF
--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -694,7 +694,7 @@ namespace :After do
         updated += 1
         puts "  Updated pseud to \"#{user.login}\" for user #{user.id}"
       else
-        Pseud.create!(name: user.login, user_id: user.id)
+        Pseud.create!(name: user.login, user_id: user.id, is_default: !user.default_pseud)
         created += 1
         puts "  Created pseud \"#{user.login}\" for user #{user.id}"
       end

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -909,6 +909,26 @@ describe "rake After:backfill_missing_pseuds" do
         .by(1)
       expect(user.pseuds.find_by(name: user.login)).to be_present
     end
+
+    it "marks the created pseud as default" do
+      subject.invoke
+      expect(user.reload.default_pseud).to be_present
+      expect(user.default_pseud.name).to eq(user.login)
+    end
+  end
+
+  context "when a user is missing a username-matching pseud but has another default pseud" do
+    let!(:user) { create(:user) }
+    let!(:other_pseud) { create(:pseud, user: user, is_default: true) }
+
+    before do
+      user.pseuds.find_by(name: user.login).delete
+    end
+
+    it "does not change the existing default pseud" do
+      subject.invoke
+      expect(user.reload.default_pseud).to eq(other_pseud)
+    end
   end
 
   context "when another user has a pseud with the same name as the affected user's login" do


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7506

## Purpose

Fixes a bug found during QA of PR #5936. When the backfill rake task creates a new pseud for a user who has no default pseud (e.g. their default pseud was deleted), the created pseud was not marked as `is_default: true`. This left `user.desing 500 errors on actions that expect it to exist (e.g. muting auser).

The fix sets `is_default: true` on the created pseud only when the useefault pseud.

## Testing Instructions

1. As a database admin, find a user's default pseud and delete it
2. Confirm `user.reload.default_pseud` returns `nil`
3. Run the rake task: `bundle exec rake After:backfill_missing_pseuds`
4. Confirm the recreated pseud is marked as default: `user.reload.defahe new pseud
5. Confirm the user can be muted without errors

## References

- Original PR: #5936

## Credit

Pablo Monfort (he/him)