### PR TITLE
AO3-7568 Fix error 500 when importing a work with a numeric date

### DIFF
--- a/app/models/story_parser.rb
+++ b/app/models/story_parser.rb
@@ -928,7 +928,7 @@ class StoryParser
       date = nil
       if date_string =~ /^(\d+)$/
         # probably seconds since the epoch
-        date = Time.at(Regex.last_match[1].to_i)
+        date = Time.zone.at(Regexp.last_match[1].to_i)
       end
       date ||= Date.parse(date_string)
       return '' if date > Date.current

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -5,13 +5,13 @@ describe StoryParser do
 
   # Temporarily make the methods we want to test public
   before(:all) do
-    class StoryParser
+    StoryParser.class_eval do
       public :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author, :convert_revised_at
     end
   end
 
   after(:all) do
-    class StoryParser
+    StoryParser.class_eval do
       protected :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author, :convert_revised_at
     end
   end

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -280,6 +280,24 @@ describe StoryParser do
     end
   end
 
+  describe "#convert_revised_at" do
+    it "converts an all-digit date to a Time" do
+      expect(@sp.send(:convert_revised_at, "300106").to_date).to eq(Date.new(1970, 1, 4))
+    end
+
+    it "converts a well-formed date to a Date" do
+      expect(@sp.send(:convert_revised_at, "2001-01-10 13:45")).to eq(Date.new(2001, 1, 10))
+    end
+
+    it "returns an empty string for a date in the future" do
+      expect(@sp.send(:convert_revised_at, "2100-01-01")).to eq("")
+    end
+
+    it "returns an empty string for an unparseable date" do
+      expect(@sp.send(:convert_revised_at, "not a date")).to eq("")
+    end
+  end
+
   # Let the test get at external sites, but stub out anything containing certain keywords
   def mock_external
     curly_quotes = "String with non-ASCII “Curly quotes” and apostrophes’"

--- a/spec/models/story_parser_spec.rb
+++ b/spec/models/story_parser_spec.rb
@@ -6,13 +6,13 @@ describe StoryParser do
   # Temporarily make the methods we want to test public
   before(:all) do
     class StoryParser
-      public :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author
+      public :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author, :convert_revised_at
     end
   end
 
   after(:all) do
     class StoryParser
-      protected :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author
+      protected :get_source_if_known, :check_for_previous_import, :parse_common, :parse_author, :convert_revised_at
     end
   end
 
@@ -282,19 +282,19 @@ describe StoryParser do
 
   describe "#convert_revised_at" do
     it "converts an all-digit date to a Time" do
-      expect(@sp.send(:convert_revised_at, "300106").to_date).to eq(Date.new(1970, 1, 4))
+      expect(@sp.convert_revised_at("300106").to_date).to eq(Date.new(1970, 1, 4))
     end
 
     it "converts a well-formed date to a Date" do
-      expect(@sp.send(:convert_revised_at, "2001-01-10 13:45")).to eq(Date.new(2001, 1, 10))
+      expect(@sp.convert_revised_at("2001-01-10 13:45")).to eq(Date.new(2001, 1, 10))
     end
 
     it "returns an empty string for a date in the future" do
-      expect(@sp.send(:convert_revised_at, "2100-01-01")).to eq("")
+      expect(@sp.convert_revised_at("2100-01-01")).to eq("")
     end
 
     it "returns an empty string for an unparseable date" do
-      expect(@sp.send(:convert_revised_at, "not a date")).to eq("")
+      expect(@sp.convert_revised_at("not a date")).to eq("")
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7568

## Purpose

Fixing the misspelled constant in `StoryParser#convert_revised_at` that returns an Error 500 when a work's date is a plain number.

The method treats an all-digit date as seconds since the epoch. That branch calls `Regex.last_match`, but the class is `Regexp`, so it raises `uninitialized constant StoryParser::Regex`. The method only rescues `ArgumentError` and `TypeError`, so the error escapes the import and the user gets a 500.

## Testing Instructions

Follow the reproduction steps on the Jira issue (Post > Import Work with the gist URL from the ticket, and any language):

* Before this change: Error 500 (`NameError: uninitialized constant StoryParser::Regex`).
* After this change: the work imports and you get the work preview.

The date shows as 1970-01-04, because the parser reads an all-numeric date as a Unix timestamp. That is existing behaviour and is not changed here, so it is expected.

Full testing instructions are also on the Jira ticket.

## References

Reported from Sentry, issue `AO3-STAGING-8Y`.

## Credit

Name: Woo Hayoung
Pronouns: she/her
