### PR TITLE
AO3-7575 Remove shadow on news meta in certain skins

### DIFF
--- a/lib/skin_wizard.rb
+++ b/lib/skin_wizard.rb
@@ -166,6 +166,10 @@ module SkinWizard
         .listbox .index {
           box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.5);
         }
+
+        .news .wrapper {
+          box-shadow: none;
+        }
       "
     else
       ""

--- a/public/stylesheets/masters/dark_mode/dark_mode_site_screen_.css
+++ b/public/stylesheets/masters/dark_mode/dark_mode_site_screen_.css
@@ -537,6 +537,10 @@ dl.meta .wrapper {
   border-bottom-color: #2a2a2a;
 }
 
+.news .wrapper {
+    box-shadow: none;
+}
+
 /* 13-GROUP-BLURB */
 
 li.blurb,

--- a/public/stylesheets/masters/reversi/reversi_site_screen_.css
+++ b/public/stylesheets/masters/reversi/reversi_site_screen_.css
@@ -337,7 +337,8 @@ fieldset.listbox .heading,
 fieldset fieldset,
 .mce-container button,
 .filters .expander,
-.actions .disabled select {
+.actions .disabled select,
+.news .wrapper {
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7575

## Purpose

Removes a shadow on news post meta in Reversi, Dark Mode, and wizard skins.

## Testing Instructions

Refer to Jira