### PR TITLE
AO3-7574 Add ToS FAQ links to Content Policy

### DIFF
--- a/app/views/home/_content.html.erb
+++ b/app/views/home/_content.html.erb
@@ -89,7 +89,11 @@
 </p>
 
 <h4 class="heading" id="II.D"><span id="copyright"><%= t(".copyright_infringement.heading") %></span></h4>
-<p><%= t(".copyright_infringement.not_allowed") %></p>
+<p>
+  <%= t(".copyright_infringement.not_allowed_html",
+        the_right_to_upload_link: link_to(t(".copyright_infringement.the_right_to_upload"), tos_faq_path(anchor: "repost_credit")),
+        permission_link: link_to(t(".copyright_infringement.permission"), tos_faq_path(anchor: "obtain_permission"))) %>
+</p>
 <p><%= t(".copyright_infringement.epigraphs_small_quotations_allowed") %></p>
 <p>
   <%= t(".copyright_infringement.transformative_works_legal_html",

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1866,7 +1866,9 @@ en:
       copyright_infringement:
         epigraphs_small_quotations_allowed: Epigraphs and short quotations are allowed, as is Content that is set within or based on an existing work.
         heading: II.D. Copyright Infringement
-        not_allowed: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you the right to upload, podfic, or translate someone else's work without permission, regardless of whether the source is a fanwork or a professionally published work.
+        not_allowed_html: Reproductions of large excerpts of copyrighted works are not allowed without the consent of the copyright owner. This includes stories, artwork, songs, poems, transcripts, and other copyrighted material. Crediting the original creator does not give you %{the_right_to_upload_link}, podfic, or translate someone else's work without %{permission_link}, regardless of whether the source is a fanwork or a professionally published work.
+        permission: permission
+        the_right_to_upload: the right to upload
         tos_faq: FAQ for Section II.D
         tos_faq_in_parens_html: "(%{tos_faq_link})"
         tos_faq_link_label: Copyright Infringement and Plagiarism FAQ


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7574

## Purpose

Adds ToS FAQ links for "the right to upload" and "permission" to the Copyright Infringement section of the Content Policy, using properly localized `_html` keys and `link_to` interpolation in the view.

## Testing Instructions

Testing instructions are outlined in the Jira issue.

## Credit

UWNE

---
*Note: This is my first open source contribution ever, so please let me know if I missed any of AO3's guidelines or formatting conventions. I'd be happy to fix them!*
