### PR TITLE
Set shorter timeouts for actions jobs

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -18,6 +18,7 @@ jobs:
   automated-tests:
     name: ${{ matrix.tests.command }} ${{ matrix.tests.arguments }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     env:
       CI: true
@@ -108,15 +109,18 @@ jobs:
 
       - name: Run apt-get update
         run: sudo apt-get update
+        timeout-minutes: 2
 
       - name: Install and start up redis servers
         run: |
           sudo apt-get install -y redis-server
           ./script/gh-actions/multiple_redis.sh
+        timeout-minutes: 5
 
       - name: Install ebook converters
         if: ${{ matrix.tests.ebook }}
         run: sudo apt-get install -y calibre zip
+        timeout-minutes: 5
 
       - name: Cache VCR cassettes
         if: ${{ matrix.tests.vcr }}
@@ -141,6 +145,7 @@ jobs:
       - name: Install libvips for image processing
         if: ${{ matrix.tests.libvips }}
         run: sudo apt-get install -y libvips-dev
+        timeout-minutes: 5
 
       - name: Set up Ruby and run bundle install
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/brakeman-scan.yml
+++ b/.github/workflows/brakeman-scan.yml
@@ -21,6 +21,7 @@ jobs:
   brakeman-scan:
     name: Brakeman Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ concurrency: one-deploy-at-a-time
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: ${{ inputs.environment || 'staging' }}
 
     env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
 
       - name: Content-Based

--- a/.github/workflows/phrase-export-checks.yml
+++ b/.github/workflows/phrase-export-checks.yml
@@ -10,6 +10,7 @@ jobs:
   en-keys-to-remove:
     if: github.head_ref == 'phrase-translations'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Check for outdated English keys in Phrase
 
     steps:
@@ -37,6 +38,7 @@ jobs:
   unused-keys:
     if: github.head_ref == 'phrase-translations'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: en-keys-to-remove
     name: Check unused keys for all locales
 
@@ -62,6 +64,7 @@ jobs:
   inconsistent-interpolations:
     if: github.head_ref == 'phrase-translations'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Check consistent interpolations for all locales
 
     steps:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,6 +11,7 @@ jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       BUNDLE_ONLY: linters
     steps:
@@ -33,6 +34,7 @@ jobs:
   erb_lint:
     name: ERB Lint runner
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       BUNDLE_ONLY: linters
     steps:


### PR DESCRIPTION
## Issue

N/A

## Purpose

Sets timeouts on all actions jobs so that fewer minutes are wasted if they get stuck. Also sets timeouts on all steps that use `apt` since it seems to be prone to hanging. The timeouts are fairly lenient so we shouldn't ever hit them in a normal situation.

## Testing Instructions

Automated tests should pass.

## Credit

marcus8448 (he/him)