### PR TITLE
AO3-7222 Check can_change_username to show Rename button for admin

### DIFF
--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -15,9 +15,11 @@
     <li>
       <%= button_to t(".navigation.activate"), { action: "activate", id: @user }, disabled: @user.active? %>
     </li>
-    <li>
-      <%= link_to t(".navigation.rename"), change_username_user_path(@user) %>
-    </li>
+    <% if policy(User).can_change_username? %>
+      <li>
+        <%= link_to t(".navigation.rename"), change_username_user_path(@user) %>
+      </li>
+    <% end %>
     <li>
       <%= link_to t(".navigation.roles"), { action: "index", user_id: @user.id } %>
     </li>

--- a/features/admins/users/admin_manage_users.feature
+++ b/features/admins/users/admin_manage_users.feature
@@ -137,3 +137,16 @@ Feature: Admin Actions to manage users
       And I should see "1 Comment" within "#comments-summary"
       And I should see "Comment on the work Creepy Gift" within "#comments-summary"
       And I should see "<p>Neener</p>" within "#comments-summary"
+
+  Scenario: An admin only sees the Rename button if they can rename users
+    Given the user "new_user" exists and is activated
+
+    # Admins who can rename users see the Rename button
+    When I am logged in as a "policy_and_abuse" admin
+      And I go to the user administration page for "new_user"
+    Then I should see a link "Rename"
+
+    # Admins who can't rename users don't see the Rename button
+    When I am logged in as a "support" admin
+      And I go to the user administration page for "new_user"
+    Then I should not see a link "Rename"


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

[AO3-7222](https://otwarchive.atlassian.net/browse/AO3-7222)

## Purpose

Add a check of can_rename_user to show Rename button on user administration page so it is only shown to admins with permission to rename users

## Testing Instructions

See Jira

## Credit

Rose Hardy - she/her


[AO3-7222]: https://otwarchive.atlassian.net/browse/AO3-7222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ