### PR TITLE
AO3-7382 Making the history page for a nonexistent user show an error 404 instead of redirecting

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -5,7 +5,7 @@ class ReadingsController < ApplicationController
   before_action :check_history_enabled
 
   def load_user
-    @user = User.find_by(login: params[:user_id])
+    @user = User.find_by!(login: params[:user_id])
     @check_ownership_of = @user
   end
 

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -66,7 +66,7 @@ class ReadingsController < ApplicationController
   def check_history_enabled
     return if current_user.preference.history_enabled?
     
-    flash[:notice] = t(".history_disabled_warning")
+    flash[:notice] = t("readings.check_history_enabled.history_disabled_warning")
     redirect_to user_preferences_path(current_user)
   end
 end

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -23,7 +23,7 @@ class ReadingsController < ApplicationController
   def destroy
     @reading = @user.readings.find(params[:id])
     if @reading.destroy
-      success_message = ts('Work successfully deleted from your history.')
+      success_message = t(".success")
       respond_to do |format|
         format.html { redirect_back_or_to(user_readings_path(current_user, page: params[:page]), notice: success_message) }
         format.json { render json: { item_success_message: success_message }, status: :ok }
@@ -65,7 +65,7 @@ class ReadingsController < ApplicationController
   # checks if user has history enabled and redirects to preferences if not, so they can potentially change it
   def check_history_enabled
     unless current_user.preference.history_enabled?
-      flash[:notice] = ts("You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.")
+      flash[:notice] = t(".history_disabled_warning")
       redirect_to user_preferences_path(current_user)
     end
   end

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -12,7 +12,7 @@ class ReadingsController < ApplicationController
   def index
     @readings = @user.readings.visible
     @page_subtitle = t(".history_page_title", username: @user.login)
-    if params[:show] == 'to-read'
+    if params[:show] == "to-read"
       @readings = @readings.where(toread: true)
       @page_subtitle = t(".marked_for_later_page_title", username: @user.login)
     end
@@ -64,10 +64,9 @@ class ReadingsController < ApplicationController
 
   # checks if user has history enabled and redirects to preferences if not, so they can potentially change it
   def check_history_enabled
-    unless current_user.preference.history_enabled?
-      flash[:notice] = t(".history_disabled_warning")
-      redirect_to user_preferences_path(current_user)
-    end
+    return if current_user.preference.history_enabled?
+    
+    flash[:notice] = t(".history_disabled_warning")
+    redirect_to user_preferences_path(current_user)
   end
-
 end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -334,9 +334,13 @@ en:
     update_positions:
       success: Question order has been successfully updated.
   readings:
+    check_history_enabled:
+      history_disabled_warning: You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.
     clear:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
+    destroy:
+      success: Work successfully deleted from your history.
     index:
       history_page_title: "%{username} - History"
       marked_for_later_page_title: "%{username} - Marked for Later"

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -334,14 +334,13 @@ en:
     update_positions:
       success: Question order has been successfully updated.
   readings:
-    check_history_enabled:
-      history_disabled_warning: You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.
     clear:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
     destroy:
       success: Work successfully deleted from your history.
     index:
+      history_disabled_warning: You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.
       history_page_title: "%{username} - History"
       marked_for_later_page_title: "%{username} - Marked for Later"
   related_works:

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -334,13 +334,14 @@ en:
     update_positions:
       success: Question order has been successfully updated.
   readings:
+    check_history_enabled:
+      history_disabled_warning: You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.
     clear:
       error: There were problems deleting your history. Please try again later.
       success: Your history is now cleared.
     destroy:
       success: Work successfully deleted from your history.
     index:
-      history_disabled_warning: You have reading history disabled in your preferences. Change it below if you'd like us to keep track of it.
       history_page_title: "%{username} - History"
       marked_for_later_page_title: "%{username} - Marked for Later"
   related_works:

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -31,6 +31,15 @@ describe ReadingsController do
         end
       end
 
+      context "when the target user does not exist" do
+        it "raises a 404 error" do
+          fake_login
+          expect do
+            get :index, params: { user_id: "nonexistent_user" }
+          end.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
       context "when logged in as the user" do
         it "includes user's readings sorted by last_viewed" do
           reading1 = create(:reading, user: user, last_viewed: 2.days.ago)


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7382

## Purpose

When visiting the history page of a nonexistent user, it used to redirect you to a page saying "Sorry, you don't have permission...", but since the page is in fact nonexistent, it now instead redirects to a 404 page, and only existing users you don't have permission to view redirect to the "Sorry, you don't have permission..." page.

I also i18n-ed the history page's controller while I was at it.

## Testing Instructions

In addition to the test in Jira:
1. Log in as a non-admin user
2. Go to a different user's history page
3. You should see a "Sorry, you don't have permission..." error
4. Go to your own history page
5. You should see the normal page

## Credit

FlyingFalcon (they/them)