### PR TITLE
AO3-7275 Add a delay to comment moderation test to help with flakiness

### DIFF
--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -349,16 +349,17 @@ Feature: Comment Moderation
 
   Scenario: Creator marks an unreviewed comment as spam and the count updates
     Given the moderated work "Spam Trap" by "spam_catcher"
-    When I post the comment "Fake spam" on the work "Spam Trap" as a guest
+      And I post the comment "Fake spam" on the work "Spam Trap" as a guest
     When I am logged in as "spam_catcher"
       And I view the work "Spam Trap"
     Then I should see "Unreviewed Comments (1)"
     When I follow "Unreviewed Comments"
+      And it is currently 1 second from now
       And I follow "Spam"
     Then I should see "Unreviewed Comments (0)"
       And I should not see "Fake spam"
-      And I am logged out
-    When I am logged in as an admin
+    When I am logged out
+      And I am logged in as an admin
       And I view the work "Spam Trap"
     Then I should see "Unreviewed Comments (1)"
     When I follow "Unreviewed Comments"


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7275

## Purpose

After merging, we found out the test was flaky; this adds a delay to help it pass consistently. I ran it a bunch of times; none of the failures are from this test: https://github.com/sarken/otwarchive/actions/workflows/automated-tests.yml

Also a few minor style tweaks.
