### PR TITLE
AO3-7561 Fix 500 when trying to /comments/show_comments on nothing

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -612,7 +612,7 @@ class CommentsController < ApplicationController
     respond_to do |format|
       format.html do
         if @commentable.nil?
-          flash[:error] = t("comments.show.cannot_show_nothing")
+          flash[:error] = t(".error")
           redirect_back_or_to root_path
         else
           # if non-ajax it could mean sudden javascript failure OR being redirected from login

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -611,13 +611,18 @@ class CommentsController < ApplicationController
   def show_comments
     respond_to do |format|
       format.html do
-        # if non-ajax it could mean sudden javascript failure OR being redirected from login
-        # so we're being extra-nice and preserving any intention to comment along with the show comments option
-        options = {show_comments: true}
-        options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
-        options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
-        options[:page] = params[:page]
-        redirect_to_all_comments(@commentable, options)
+        if @commentable.nil?
+          flash[:error] = t("comments.show.cannot_show_nothing")
+          redirect_back_or_to root_path
+        else
+          # if non-ajax it could mean sudden javascript failure OR being redirected from login
+          # so we're being extra-nice and preserving any intention to comment along with the show comments option
+          options = { show_comments: true }
+          options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
+          options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
+          options[:page] = params[:page]
+          redirect_to_all_comments(@commentable, options)
+        end
       end
 
       format.js do

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -218,8 +218,9 @@ en:
     rate_limited:
       error: You have made too many requests in a short time period. Please wait a while before trying again. If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
     show:
-      cannot_show_nothing: What did you want to show comments on?
       page_title: Comment %{comment_id} on %{name}
+    show_comments:
+      error: What did you want to show comments on?
     unfreeze:
       error: Sorry, that comment thread could not be unfrozen.
       permission_denied: Sorry, you don't have permission to unfreeze that comment thread.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -218,6 +218,7 @@ en:
     rate_limited:
       error: You have made too many requests in a short time period. Please wait a while before trying again. If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
     show:
+      cannot_show_nothing: What did you want to show comments on?
       page_title: Comment %{comment_id} on %{name}
     unfreeze:
       error: Sorry, that comment thread could not be unfrozen.

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -69,9 +69,11 @@ describe CommentsController do
       end
     end
 
-    it "redirects with a flash error when no commentable is given" do
-      get :show_comments
-      it_redirects_to_with_error("/where_i_came_from", "What did you want to show comments on?")
+    context "when no commentable is given" do
+      it "redirects back with a flash error" do
+        get :show_comments
+        it_redirects_to_with_error("/where_i_came_from", "What did you want to show comments on?")
+      end
     end
   end
 

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -68,6 +68,11 @@ describe CommentsController do
         end
       end
     end
+
+    it "redirects with a flash error when no commentable is given" do
+      get :show_comments
+      it_redirects_to_with_error("/where_i_came_from", "What did you want to show comments on?")
+    end
   end
 
   describe "GET #hide_comments" do


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7561

## Purpose

Fixes a 500 when attempting to view comments without passing any query parameters. With this change, the user is instead redirected back from whence they came, with a flash error noting that you can't view comments on nothing.

## Testing Instructions

Navigate to http://archiveofourown.org/comments/show_comments. Without this change, will 500. With this change, will redirect to the homepage with an error flash.

## References

https://otwarchive.atlassian.net/browse/AO3-7556 is a similar issue in a different route, with a similar fix. Assuming I didn't screw up this one, I can send a followup PR with that fix too.

## Credit

David Anderson (he/him)

## Misc notes

This is my first PR to otwarchive. There were no [first timer issues](https://otwarchive.atlassian.net/issues/?filter=13119) open, so I picked a recent Difficulty=Easy bug instead to get my feet wet and figure out the dev workflow.

I chose to handle the nil in the show_comments logic, rather than in the redirect_to_all_comments helper where the 500 triggered. This seems to match the local coding style for handling nil commentables (e.g. `new` and `create`), and the helper is also called from places where the commentable is a DB object or similar, and silently swallowing an error in those codepaths didn't seem right.

