### PR TITLE
AO3-7445 Forbid guest comments from using misleading names

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -26,6 +26,19 @@ class Comment < ApplicationRecord
 
   attr_accessor :cloudflare_bot_score, :cloudflare_ja3_hash, :cloudflare_ja4, :request_host
 
+  validate :guest_name_not_misleading, if: :will_save_change_to_name?
+  def guest_name_not_misleading
+    errors.add(:name, :forbidden) if misleading_guest_name?
+  end
+
+  # Whether the comment's guest name is potentially misleading, e.g. trying to impersonate a protected user
+  def misleading_guest_name?
+    return false if name.blank?
+
+    u = User.find_by(login: name)
+    !u.nil? && (u.official || u.protected_user || u == User.orphan_account)
+  end
+
   # Whether the writer of the comment this is replying to allows guest replies
   validate :guest_can_reply, if: :reply_comment?, unless: :pseud_id, on: :create
   def guest_can_reply

--- a/factories/users.rb
+++ b/factories/users.rb
@@ -52,5 +52,9 @@ FactoryBot.define do
     factory :protected_user do
       roles { [Role.find_or_create_by(name: "protected_user")] }
     end
+
+    factory :orphan_user do
+      login { "orphan_account" }
+    end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,28 +22,75 @@ describe Comment do
   end
 
   describe "validations" do
-    context "with a forbidden guest name" do
+    describe "guest name" do
+      shared_examples "prevents commenting with a forbidden name" do
+        it { is_expected.not_to allow_values(forbidden_name).for(:name) }
+
+        it "does not prevent saving when the name is unchanged" do
+          subject.name = forbidden_name
+          subject.save!(validate: false)
+          expect(subject.save).to be_truthy
+        end
+
+        it "does not prevent deletion" do
+          subject.name = forbidden_name
+          subject.save!(validate: false)
+          subject.destroy
+          expect { subject.reload }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "allows changing to an allowed name" do
+          subject.name = forbidden_name
+          subject.save!(validate: false)
+          subject.name = acceptable_name
+          expect(subject.save).to be_truthy
+        end
+      end
+
       subject { build(:comment, email: Faker::Internet.email) }
-      let(:forbidden_name) { Faker::Lorem.characters(number: 8) }
+      let(:acceptable_name) { Faker::Lorem.characters(number: 8) }
 
-      before do
-        allow(ArchiveConfig).to receive(:FORBIDDEN_USERNAMES).and_return([forbidden_name])
+      context "is forbidden by config" do
+        let(:forbidden_name) { Faker::Lorem.characters(number: 8) }
+
+        before do
+          allow(ArchiveConfig).to receive(:FORBIDDEN_USERNAMES).and_return([forbidden_name])
+        end
+
+        it_behaves_like "prevents commenting with a forbidden name"
+
+        it { is_expected.not_to allow_values(forbidden_name.swapcase).for(:name) }
       end
 
-      it { is_expected.not_to allow_values(forbidden_name, forbidden_name.swapcase).for(:name) }
-
-      it "does not prevent saving when the name is unchanged" do
-        subject.name = forbidden_name
-        subject.save!(validate: false)
-        expect(subject.save).to be_truthy
+      context "impersonating an official account" do
+        let(:forbidden_name) { create(:official_user).login }
+        it_behaves_like "prevents commenting with a forbidden name"
       end
 
-      it "does not prevent deletion" do
-        subject.name = forbidden_name
-        subject.save!(validate: false)
-        subject.destroy
-        expect { subject.reload }
-          .to raise_error(ActiveRecord::RecordNotFound)
+      context "impersonating a protected account" do
+        let(:forbidden_name) { create(:protected_user).login }
+        it_behaves_like "prevents commenting with a forbidden name"
+      end
+
+      context "impersonating the orphan_account" do
+        let(:forbidden_name) { create(:orphan_user).login }
+
+        context "when orphaning is enabled" do
+          before do
+            allow(ArchiveConfig).to receive(:ORPHANING_ALLOWED).and_return(true)
+          end
+
+          it_behaves_like "prevents commenting with a forbidden name"
+        end
+
+        context "when orphaning is disabled" do
+          before do
+            allow(ArchiveConfig).to receive(:ORPHANING_ALLOWED).and_return(false)
+          end
+
+          it { is_expected.to allow_values(forbidden_name).for(:name) }
+        end
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7445

## Purpose

Prevents guest comments from using potentially misleading names, specifically: login names of official accounts, protected accounts, and of the orphan account if work orphaning is enabled in site config.

## References

This issue is also listed at https://github.com/otwcode/otwarchive/wiki/Issues-seeking-coders, which is how I found it.

## Credit

David Anderson (he/him)