### PR TITLE
AO3-6015 Add script to provide user data for guests

### DIFF
--- a/lib/email_data_report.rb
+++ b/lib/email_data_report.rb
@@ -1,11 +1,18 @@
 # Collects the GDPR/support data associated with an email address: guest
 # activity, plus account history through indexed lookups (a LIKE scan on
 # audits is too expensive, see AO3-6015 / PR #4997).
+#
+# Deleted accounts only survive in audits; deep_search: true opts into a
+# chunked scan of that table.
 class EmailDataReport
   include Rails.application.routes.url_helpers
 
-  def initialize(email)
+  # Bounds each deep-search query to a primary-key range.
+  AUDIT_SCAN_BATCH_SIZE = 1_000_000
+
+  def initialize(email, deep_search: false)
     @email = email.to_s.strip.downcase
+    @deep_search = deep_search
   end
 
   def to_s
@@ -43,12 +50,37 @@ class EmailDataReport
     @next_of_kin_for ||= User.where(id: FannishNextOfKin.where(kin_email: @email).select(:user_id)).pluck(:login)
   end
 
-  # Living accounts that have this as their current, unconfirmed, or past email.
   def user_ids
     @user_ids ||= begin
       ids = User.where(email: @email).or(User.where(unconfirmed_email: @email)).pluck(:id)
       ids |= UserPastEmail.where(email_address: @email).pluck(:user_id)
+      ids |= deleted_user_ids if @deep_search
       ids
+    end
+  end
+
+  # LIKE matches substrings, so candidates are verified against the exact
+  # email before being included.
+  def deleted_user_ids
+    max_id = Audited::Audit.maximum(:id)
+    return [] if max_id.nil?
+
+    ids = []
+    (Audited::Audit.minimum(:id)..max_id).step(AUDIT_SCAN_BATCH_SIZE) do |start|
+      candidates = Audited::Audit.where(auditable_type: "User")
+        .where(id: start...(start + AUDIT_SCAN_BATCH_SIZE))
+        .where("audited_changes LIKE ?", "%#{Audited::Audit.sanitize_sql_like(@email)}%")
+        .pluck(:auditable_id, :audited_changes)
+      ids.concat(candidates.filter_map { |id, changes| id if email_in_changes?(changes) })
+    end
+    ids.uniq
+  end
+
+  def email_in_changes?(changes)
+    return false unless changes.is_a?(Hash)
+
+    changes.values_at("email", "unconfirmed_email").any? do |value|
+      value == @email || (value.is_a?(Array) && value.include?(@email))
     end
   end
 
@@ -66,11 +98,19 @@ class EmailDataReport
       # Audits of admin actions are excluded to avoid revealing admins' IPs.
       # Unlike get_user_data.rb, destroy is included for deleted accounts.
       audits = Audited::Audit.where(auditable_type: "User", auditable_id: user_ids)
-        .pluck(:action, :audited_changes, :remote_address)
-      audits.each do |action, changes, ip|
+        .pluck(:action, :audited_changes, :remote_address, :user_type)
+      audits.each do |action, changes, ip, actor_type|
+        # Admin-made changes record the admin's IP, not the user's.
+        ip = nil if actor_type == "Admin"
         # Created or deleted account
         if %w[create destroy].include?(action)
           ips << ip if ip.present?
+          # The destroy audit is the only place a deleted account's login
+          # and email survive.
+          if action == "destroy" && changes.is_a?(Hash)
+            previous_usernames << changes["login"] if changes["login"].present?
+            previous_emails << changes["email"] if changes["email"].present? && changes["email"] != @email
+          end
         # Other account changes
         elsif action == "update"
           next unless changes.respond_to?(:each)

--- a/lib/email_data_report.rb
+++ b/lib/email_data_report.rb
@@ -1,0 +1,203 @@
+# Collects the GDPR/support data associated with an email address: guest
+# activity, plus account history through indexed lookups (a LIKE scan on
+# audits is too expensive, see AO3-6015 / PR #4997).
+class EmailDataReport
+  include Rails.application.routes.url_helpers
+
+  def initialize(email)
+    @email = email.to_s.strip.downcase
+  end
+
+  def to_s
+    parts = ["Data for #{@email}"]
+    parts << previous_usernames_section
+    parts << previous_emails_section
+    parts << ip_addresses_section
+    parts << user_agents_section
+    parts << next_of_kin_section
+    parts << comments_section
+    parts << abuse_reports_section
+    parts << support_tickets_section
+    "#{parts.compact.join("\n\n")}\n"
+  end
+
+  def default_url_options
+    { host: ArchiveConfig.APP_URL }
+  end
+
+  private
+
+  def abuse_reports
+    @abuse_reports ||= AbuseReport.where(email: @email).to_a
+  end
+
+  def comments
+    @comments ||= Comment.where(email: @email).to_a
+  end
+
+  def support_tickets
+    @support_tickets ||= Feedback.where(email: @email).to_a
+  end
+
+  def next_of_kin_for
+    @next_of_kin_for ||= User.where(id: FannishNextOfKin.where(kin_email: @email).select(:user_id)).pluck(:login)
+  end
+
+  # Living accounts that have this as their current, unconfirmed, or past email.
+  def user_ids
+    @user_ids ||= begin
+      ids = User.where(email: @email).or(User.where(unconfirmed_email: @email)).pluck(:id)
+      ids |= UserPastEmail.where(email_address: @email).pluck(:user_id)
+      ids
+    end
+  end
+
+  def audit_history
+    @audit_history ||= begin
+      previous_usernames = []
+      previous_emails = []
+      ips = []
+
+      # Abuse reports do not persist user_agent; support tickets do not
+      # persist ip_address.
+      ips.concat(abuse_reports.filter_map { |report| report.ip_address.presence })
+      ips.concat(comments.filter_map { |comment| comment.ip_address.presence })
+
+      # Audits of admin actions are excluded to avoid revealing admins' IPs.
+      # Unlike get_user_data.rb, destroy is included for deleted accounts.
+      audits = Audited::Audit.where(auditable_type: "User", auditable_id: user_ids)
+        .pluck(:action, :audited_changes, :remote_address)
+      audits.each do |action, changes, ip|
+        # Created or deleted account
+        if %w[create destroy].include?(action)
+          ips << ip if ip.present?
+        # Other account changes
+        elsif action == "update"
+          next unless changes.respond_to?(:each)
+
+          changes.each do |k, v|
+            # Keep the branches separate for the per-key comments.
+            # rubocop:disable Lint/DuplicateBranch
+            case k
+            when "accepted_tos_version"
+              ips << ip if ip.present?
+            # Changed email address
+            when "email"
+              ips << ip if ip.present?
+              previous_emails << v[0] if v.is_a?(Array) && v[0].present?
+            # Changed password, post-Devise
+            when "encrypted_password"
+              ips << ip if ip.present?
+            # Failed login attempt, post-Devise
+            # This is currently only recorded after a password reset or after the
+            # account is locked and unlocked
+            when "failed_attempts"
+              ips << ip if ip.present?
+            # Failed login attempt, pre-Devise
+            when "failed_login_count"
+              ips << ip if ip.present?
+            # Failed login attempt that resulted in account being locked, post-Devise
+            when "locked_at"
+              ips << ip if ip.present?
+            # Changed username
+            when "login"
+              ips << ip if ip.present?
+              previous_usernames << v[0] if v.is_a?(Array) && v[0].present?
+            # Requested password reset email, pre-Devise
+            when "recently_reset"
+              ips << ip if ip.present?
+            # Submitted login form with "Remember me" checked, post-Devise
+            # This is recorded whether the login attempt was successful or not
+            when "remember_created_at"
+              ips << ip if ip.present?
+            # Requested password reset email, post-Devise
+            when "reset_password_sent_at"
+              ips << ip if ip.present?
+            # Logged in, post-Devise
+            when "sign_in_count"
+              ips << ip if ip.present?
+            end
+            # rubocop:enable Lint/DuplicateBranch
+          end
+        end
+      end
+
+      {
+        previous_usernames: previous_usernames.uniq,
+        previous_emails: previous_emails.uniq,
+        ips: ips.uniq
+      }
+    end
+  end
+
+  def user_agents
+    agents = []
+    agents.concat(comments.filter_map { |comment| comment.user_agent.presence })
+    agents.concat(support_tickets.filter_map { |ticket| ticket.user_agent.presence })
+    agents.uniq
+  end
+
+  def previous_usernames_section
+    names = audit_history[:previous_usernames]
+    return if names.empty?
+
+    "Previous Usernames: #{names.to_sentence}"
+  end
+
+  def previous_emails_section
+    emails = audit_history[:previous_emails]
+    return if emails.empty?
+
+    "Previous Email Addresses: #{emails.to_sentence}"
+  end
+
+  def ip_addresses_section
+    ips = audit_history[:ips]
+    return if ips.empty?
+
+    ["IP Addresses:", *ips.map { |ip| "  #{ip}" }].join("\n")
+  end
+
+  def user_agents_section
+    return if user_agents.empty?
+
+    ["User Agents:", *user_agents.map { |user_agent| "  #{user_agent}" }].join("\n")
+  end
+
+  def next_of_kin_section
+    return if next_of_kin_for.empty?
+
+    "Fannish Next of Kin For: #{next_of_kin_for.to_sentence}"
+  end
+
+  def comments_section
+    return if comments.empty?
+
+    urls = comments.map { |comment| comment_url(comment) }
+    ["Comments Left: ", *urls.map { |url| "  #{url}" }].join("\n")
+  end
+
+  def abuse_reports_section
+    return if abuse_reports.empty?
+
+    records_section("Abuse Reports:", abuse_reports)
+  end
+
+  def support_tickets_section
+    return if support_tickets.empty?
+
+    records_section("Support Tickets:", support_tickets)
+  end
+
+  def records_section(header, records)
+    entries = records.map do |record|
+      <<~ENTRY.strip
+        From: #{record.username}
+        Summary: #{record.summary}
+        Content:
+          #{record.comment}
+      ENTRY
+    end
+    [header, *entries].join("\n\n")
+  end
+end

--- a/lib/email_data_report.rb
+++ b/lib/email_data_report.rb
@@ -2,17 +2,13 @@
 # activity, plus account history through indexed lookups (a LIKE scan on
 # audits is too expensive, see AO3-6015 / PR #4997).
 #
-# Deleted accounts only survive in audits; deep_search: true opts into a
-# chunked scan of that table.
+# Deleted accounts only survive in audits; the report ends with the query
+# for Systems to run on a secondary database.
 class EmailDataReport
   include Rails.application.routes.url_helpers
 
-  # Bounds each deep-search query to a primary-key range.
-  AUDIT_SCAN_BATCH_SIZE = 1_000_000
-
-  def initialize(email, deep_search: false)
+  def initialize(email)
     @email = email.to_s.strip.downcase
-    @deep_search = deep_search
   end
 
   def to_s
@@ -25,6 +21,7 @@ class EmailDataReport
     parts << comments_section
     parts << abuse_reports_section
     parts << support_tickets_section
+    parts << deleted_accounts_section
     "#{parts.compact.join("\n\n")}\n"
   end
 
@@ -54,34 +51,22 @@ class EmailDataReport
     @user_ids ||= begin
       ids = User.where(email: @email).or(User.where(unconfirmed_email: @email)).pluck(:id)
       ids |= UserPastEmail.where(email_address: @email).pluck(:user_id)
-      ids |= deleted_user_ids if @deep_search
       ids
     end
   end
 
-  # LIKE matches substrings, so candidates are verified against the exact
-  # email before being included.
-  def deleted_user_ids
-    max_id = Audited::Audit.maximum(:id)
-    return [] if max_id.nil?
-
-    ids = []
-    (Audited::Audit.minimum(:id)..max_id).step(AUDIT_SCAN_BATCH_SIZE) do |start|
-      candidates = Audited::Audit.where(auditable_type: "User")
-        .where(id: start...(start + AUDIT_SCAN_BATCH_SIZE))
-        .where("audited_changes LIKE ?", "%#{Audited::Audit.sanitize_sql_like(@email)}%")
-        .pluck(:auditable_id, :audited_changes)
-      ids.concat(candidates.filter_map { |id, changes| id if email_in_changes?(changes) })
-    end
-    ids.uniq
-  end
-
-  def email_in_changes?(changes)
-    return false unless changes.is_a?(Hash)
-
-    changes.values_at("email", "unconfirmed_email").any? do |value|
-      value == @email || (value.is_a?(Array) && value.include?(@email))
-    end
+  # LIKE matches substrings, so the results still need to be verified
+  # against the exact email.
+  def deleted_accounts_section
+    escaped_email = Audited::Audit.sanitize_sql_like(@email)
+    <<~SECTION.strip
+      Deleted accounts only survive in the audits table, which is too expensive
+      to search on the live database. To look for them, ask Systems to run this
+      on a secondary database:
+        SELECT DISTINCT auditable_id FROM audits
+        WHERE auditable_type = 'User'
+        AND audited_changes LIKE '%#{escaped_email}%';
+    SECTION
   end
 
   def audit_history

--- a/script/get_email_data.rb
+++ b/script/get_email_data.rb
@@ -5,7 +5,4 @@
 print "Enter email: "
 email = gets.chomp
 
-print "Search audits for deleted accounts? This scans the whole audits table and should only be run at low-traffic times. (y/N): "
-deep_search = gets.chomp.strip.casecmp?("y")
-
-puts EmailDataReport.new(email, deep_search: deep_search)
+puts EmailDataReport.new(email)

--- a/script/get_email_data.rb
+++ b/script/get_email_data.rb
@@ -1,0 +1,8 @@
+#!script/rails runner
+# usage:
+# bundle exec rails r script/get_email_data.rb
+
+print "Enter email: "
+email = gets.chomp
+
+puts EmailDataReport.new(email)

--- a/script/get_email_data.rb
+++ b/script/get_email_data.rb
@@ -5,4 +5,7 @@
 print "Enter email: "
 email = gets.chomp
 
-puts EmailDataReport.new(email)
+print "Search audits for deleted accounts? This scans the whole audits table and should only be run at low-traffic times. (y/N): "
+deep_search = gets.chomp.strip.casecmp?("y")
+
+puts EmailDataReport.new(email, deep_search: deep_search)

--- a/spec/lib/email_data_report_spec.rb
+++ b/spec/lib/email_data_report_spec.rb
@@ -5,8 +5,10 @@ describe EmailDataReport do
 
   let(:email) { "guest@example.com" }
 
-  it "prints only a header when no data is found" do
-    expect(subject).to eq("Data for #{email}\n")
+  it "prints only the header and the audits query when no data is found" do
+    expect(subject).to start_with("Data for #{email}\n\nDeleted accounts")
+    expect(subject).not_to include("IP Addresses:")
+    expect(subject).not_to include("Comments Left:")
   end
 
   it "downcases the email before lookup" do
@@ -121,6 +123,18 @@ describe EmailDataReport do
       expect(subject).to include("198.51.100.7")
     end
 
+    it "excludes the IP when an admin made the change" do
+      user.audits.create!(
+        action: "update",
+        auditable: user,
+        user: create(:admin),
+        audited_changes: { "login" => ["admin_changed", user.login] },
+        remote_address: "203.0.113.50"
+      )
+
+      expect(subject).not_to include("203.0.113.50")
+    end
+
     it "finds accounts that currently use the email" do
       current = create(:user, email: email)
       current.audits.create!(
@@ -135,64 +149,17 @@ describe EmailDataReport do
     end
   end
 
-  describe "deep search for deleted accounts" do
-    subject { described_class.new(email, deep_search: true).to_s }
-
-    # A deleted account only exists in the audits table anymore: the user row
-    # and its user_past_emails are gone, so these audits are orphaned.
-    before do
-      Audited::Audit.create!(
-        auditable_type: "User",
-        auditable_id: 424_242,
-        action: "update",
-        audited_changes: { "login" => %w[old_ghost final_ghost] },
-        remote_address: "203.0.113.30"
-      )
-      Audited::Audit.create!(
-        auditable_type: "User",
-        auditable_id: 424_242,
-        action: "destroy",
-        audited_changes: { "login" => "final_ghost", "email" => email },
-        remote_address: "203.0.113.31"
-      )
+  describe "deleted accounts query" do
+    it "ends the report with the audits query for a secondary database" do
+      expect(subject).to include("ask Systems to run this")
+      expect(subject).to include("SELECT DISTINCT auditable_id FROM audits")
+      expect(subject).to include("audited_changes LIKE '%guest@example.com%'")
     end
 
-    it "finds deleted accounts through their audits" do
-      expect(subject).to include("final_ghost")
-      expect(subject).to include("old_ghost")
-      expect(subject).to include("203.0.113.30")
-      expect(subject).to include("203.0.113.31")
-    end
+    it "escapes LIKE wildcards in the email" do
+      report = described_class.new("gu%es_t@example.com").to_s
 
-    it "excludes the admin's IP when an admin deleted the account" do
-      Audited::Audit.create!(
-        auditable_type: "User",
-        auditable_id: 777_777,
-        user: create(:admin),
-        action: "destroy",
-        audited_changes: { "login" => "admin_deleted", "email" => email },
-        remote_address: "203.0.113.50"
-      )
-
-      expect(subject).to include("admin_deleted")
-      expect(subject).not_to include("203.0.113.50")
-    end
-
-    it "ignores audits where the email only matches as a substring" do
-      Audited::Audit.create!(
-        auditable_type: "User",
-        auditable_id: 555_555,
-        action: "destroy",
-        audited_changes: { "login" => "impostor", "email" => "a#{email}" },
-        remote_address: "203.0.113.40"
-      )
-
-      expect(subject).not_to include("impostor")
-      expect(subject).not_to include("203.0.113.40")
-    end
-
-    it "does not scan audits when the deep search is off" do
-      expect(described_class.new(email).to_s).not_to include("final_ghost")
+      expect(report).to include("LIKE '%gu\\%es\\_t@example.com%'")
     end
   end
 end

--- a/spec/lib/email_data_report_spec.rb
+++ b/spec/lib/email_data_report_spec.rb
@@ -134,4 +134,65 @@ describe EmailDataReport do
       expect(subject).to include("192.0.2.9")
     end
   end
+
+  describe "deep search for deleted accounts" do
+    subject { described_class.new(email, deep_search: true).to_s }
+
+    # A deleted account only exists in the audits table anymore: the user row
+    # and its user_past_emails are gone, so these audits are orphaned.
+    before do
+      Audited::Audit.create!(
+        auditable_type: "User",
+        auditable_id: 424_242,
+        action: "update",
+        audited_changes: { "login" => %w[old_ghost final_ghost] },
+        remote_address: "203.0.113.30"
+      )
+      Audited::Audit.create!(
+        auditable_type: "User",
+        auditable_id: 424_242,
+        action: "destroy",
+        audited_changes: { "login" => "final_ghost", "email" => email },
+        remote_address: "203.0.113.31"
+      )
+    end
+
+    it "finds deleted accounts through their audits" do
+      expect(subject).to include("final_ghost")
+      expect(subject).to include("old_ghost")
+      expect(subject).to include("203.0.113.30")
+      expect(subject).to include("203.0.113.31")
+    end
+
+    it "excludes the admin's IP when an admin deleted the account" do
+      Audited::Audit.create!(
+        auditable_type: "User",
+        auditable_id: 777_777,
+        user: create(:admin),
+        action: "destroy",
+        audited_changes: { "login" => "admin_deleted", "email" => email },
+        remote_address: "203.0.113.50"
+      )
+
+      expect(subject).to include("admin_deleted")
+      expect(subject).not_to include("203.0.113.50")
+    end
+
+    it "ignores audits where the email only matches as a substring" do
+      Audited::Audit.create!(
+        auditable_type: "User",
+        auditable_id: 555_555,
+        action: "destroy",
+        audited_changes: { "login" => "impostor", "email" => "a#{email}" },
+        remote_address: "203.0.113.40"
+      )
+
+      expect(subject).not_to include("impostor")
+      expect(subject).not_to include("203.0.113.40")
+    end
+
+    it "does not scan audits when the deep search is off" do
+      expect(described_class.new(email).to_s).not_to include("final_ghost")
+    end
+  end
 end

--- a/spec/lib/email_data_report_spec.rb
+++ b/spec/lib/email_data_report_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+describe EmailDataReport do
+  subject { described_class.new(email).to_s }
+
+  let(:email) { "guest@example.com" }
+
+  it "prints only a header when no data is found" do
+    expect(subject).to eq("Data for #{email}\n")
+  end
+
+  it "downcases the email before lookup" do
+    create(:abuse_report, email: email, username: "Reporter", summary: "Spam", comment: "This is spam.")
+
+    expect(described_class.new("Guest@Example.com").to_s).to include("From: Reporter")
+  end
+
+  describe "guest activity" do
+    it "includes comment URLs, IPs, and user agents" do
+      comment = create(
+        :comment,
+        :by_guest,
+        :on_work_with_guest_comments_on,
+        email: email,
+        ip_address: "203.0.113.10",
+        user_agent: "Lynx/2.8"
+      )
+
+      expect(subject).to include("Comments Left:")
+      expect(subject).to include("/comments/#{comment.id}")
+      expect(subject).to include("203.0.113.10")
+      expect(subject).to include("Lynx/2.8")
+    end
+
+    it "includes abuse report header, name, summary, content, and IP" do
+      create(
+        :abuse_report,
+        email: email,
+        username: "ConcernedFan",
+        summary: "Harassment",
+        comment: "Please look at this.",
+        ip_address: "203.0.113.20"
+      )
+
+      expect(subject).to include("Abuse Reports:")
+      expect(subject).to include("From: ConcernedFan")
+      expect(subject).to include("Summary: Harassment")
+      expect(subject).to include("Please look at this.")
+      expect(subject).to include("203.0.113.20")
+    end
+
+    it "includes support ticket header, name, summary, content, and user agent" do
+      create(
+        :feedback,
+        email: email,
+        username: "HelpfulGuest",
+        summary: "Cannot log in",
+        comment: "The login form errors.",
+        user_agent: "Mozilla/5.0"
+      )
+
+      expect(subject).to include("Support Tickets:")
+      expect(subject).to include("From: HelpfulGuest")
+      expect(subject).to include("Summary: Cannot log in")
+      expect(subject).to include("The login form errors.")
+      expect(subject).to include("Mozilla/5.0")
+    end
+
+    it "lists users for whom the email is fannish next of kin" do
+      user = create(:user, login: "fnok_lister")
+      create(:fannish_next_of_kin, user: user, kin_email: email)
+
+      expect(subject).to include("Fannish Next of Kin For: fnok_lister")
+    end
+  end
+
+  describe "account history" do
+    let(:user) { create(:user, email: "current@example.com") }
+
+    before do
+      user.past_emails.create!(email_address: email, changed_at: Time.current)
+      user.audits.create!(
+        action: "update",
+        auditable: user,
+        audited_changes: { "login" => ["old_guest_login", user.login] },
+        remote_address: "198.51.100.5"
+      )
+      user.audits.create!(
+        action: "update",
+        auditable: user,
+        audited_changes: { "email" => ["prior@example.com", user.email] },
+        remote_address: "198.51.100.6"
+      )
+      user.audits.create!(
+        action: "destroy",
+        auditable: user,
+        audited_changes: { "login" => user.login, "email" => user.email },
+        remote_address: "198.51.100.7"
+      )
+    end
+
+    it "queries audits by auditable_id, not by audited_changes LIKE" do
+      queries = []
+      callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        subject
+      end
+
+      audit_queries = queries.grep(/FROM [`"]?audits[`"]?/i)
+      expect(audit_queries).to be_present
+      expect(audit_queries).to all(match(/auditable_id/i))
+      expect(audit_queries).not_to include(a_string_matching(/audited_changes LIKE/i))
+    end
+
+    it "includes previous usernames, emails, and create/update/destroy IPs" do
+      expect(subject).to include("Previous Usernames: old_guest_login")
+      expect(subject).to include("Previous Email Addresses: prior@example.com")
+      expect(subject).to include("198.51.100.5")
+      expect(subject).to include("198.51.100.6")
+      expect(subject).to include("198.51.100.7")
+    end
+
+    it "finds accounts that currently use the email" do
+      current = create(:user, email: email)
+      current.audits.create!(
+        action: "update",
+        auditable: current,
+        audited_changes: { "login" => ["former_name", current.login] },
+        remote_address: "192.0.2.9"
+      )
+
+      expect(subject).to include("former_name")
+      expect(subject).to include("192.0.2.9")
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6015

## Purpose

Adds `script/get_email_data.rb`, a console script that collects the data associated with a given email address (guest activity and account history), following the same output format as `script/get_user_data.rb`.

The report includes:

* URLs, IP addresses, and user agents for comments left by the email address
* Name, summary, content, and IP addresses of abuse reports
* Name, summary, content, and user agents of support tickets
* Users listing the email address as their fannish next of kin
* Previous usernames, previous email addresses, and IP addresses from audits, including the `destroy` action

PR #4997 was closed because it searched the audits table with `LIKE '%email%'`, which can't use an index and requires a full table scan. This PR only runs indexed queries on the live database:

* User ids are found through `users.email` (indexed), `users.unconfirmed_email` (not indexed, but a single-column scan on `users` is cheap compared to `audits`), and `user_past_emails`, and audits are then loaded by `auditable_id`. Guest data comes from `comments.email` (indexed) and the small `abuse_reports`, `feedbacks`, and `fannish_next_of_kins` tables, as in `get_user_data.rb`.
* Deleted accounts are gone from those tables and their data only survives in audits. Instead of scanning that table, the report ends with the `LIKE` query (escaped with `sanitize_sql_like`) so Systems can run it on a secondary database and pass the resulting user ids back to Support. This follows the discussion on Slack about not scanning the live audits table even as an opt-in.

Notes:

* IPs from audits recorded by an admin (for example, when an admin deleted the account) are excluded, following the same principle as AO3-5486 about not revealing admins' IP addresses.
* User agents from abuse reports and IP addresses from support tickets are not persisted in the database (they're only in-memory attributes), so the report can't include them.
* Accounts deleted before the audits table existed don't have any history to recover.

## Testing Instructions

1. In the Rails console environment, run `bundle exec rails r script/get_email_data.rb`
2. Enter the email address of a guest who has left comments, abuse reports, or support tickets
3. Check the report includes the guest data and ends with the audits query for Systems
4. Create a user with that email, change their username and email address, then run the script again with the old email
5. Check the report includes the previous username, previous email, and the IPs from those changes
6. Check the printed query has the email escaped (try an email containing `%` or `_`)

## References

Replaces the approach from #4997. Output format follows #3393 and #3403 (AO3-5486)

## Credit

Pablo Monfort (he/him), based on previous work by brianjaustin in #4997 and sarken in #3393