### PR TITLE
AO3-7495 List metatags in alphabetical order by sortable name

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -163,7 +163,7 @@ module TagsHelper
   def meta_tag_tree(tag)
     meta_ul = "".html_safe
     unless tag.direct_meta_tags.empty?
-      tag.direct_meta_tags.order(:name).each do |meta|
+      tag.direct_meta_tags.order(:sortable_name).each do |meta|
         meta_ul += content_tag(:li, link_to_tag(meta))
         unless meta.direct_meta_tags.empty?
           meta_ul += content_tag(:li, meta_tag_tree(meta))

--- a/features/tags_and_wrangling/tag_wrangling.feature
+++ b/features/tags_and_wrangling/tag_wrangling.feature
@@ -385,22 +385,22 @@ Feature: Tag wrangling
     Then "Angsta" should appear before "Angstb"
       And "Angstb" should appear before "Angstc"
 
-  Scenario: Metatags are listed in alphabetical order
+  Scenario: Metatags are listed in alphabetical order by sortable name
     Given a canonical freeform "Sex and Feels and Pain"
       And a canonical freeform "Smut"
       And it is currently 1 second from now
       # The waits are here so we can be sure the tags are created/attached in
       # a non-sorted order, so the test can check that reordering is happening
-      And a canonical freeform "Angst"
+      And a canonical freeform "The Angst"
       And it is currently 1 second from now
       And a canonical freeform "Fluff"
       And "Smut" is a metatag of the freeform "Sex and Feels and Pain"
       And it is currently 1 second from now
-      And "Angst" is a metatag of the freeform "Sex and Feels and Pain"
+      And "The Angst" is a metatag of the freeform "Sex and Feels and Pain"
       And it is currently 1 second from now
       And "Fluff" is a metatag of the freeform "Sex and Feels and Pain"
     When I view the tag "Sex and Feels and Pain"
-    Then "Angst" should appear before "Fluff"
+    Then "The Angst" should appear before "Fluff"
       And "Fluff" should appear before "Smut"
 
   Scenario: Tags in mass wrangling bins should have a link to the comment page with the comment count.


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7495

## Purpose

Fixes [the merged pr](https://github.com/otwcode/otwarchive/pull/5877/) for listing metatags in alphabetical order, which doesn't order tags by their sortable names.

## Testing Instructions

- Create a tag
- Create two metatags of it, with one having a word that shouldn't effect alphabetical order like "the" or "a"
- Make sure they are sorted by sortable name

## Credit

ömer faruk (he/him)