### PR TITLE
AO3-7275 Unreviewed comments link visibility for creators (Broken on Test)

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -344,8 +344,7 @@ class CommentsController < ApplicationController
   end
 
   def unreviewed
-    @comments = @commentable.find_all_comments.unreviewed_only
-    @comments = @comments.not_spam unless logged_in_as_admin?
+    @comments = @commentable.unreviewed_comments_to_show(logged_in_as_admin?)
     @comments = @comments.for_display.page(params[:page])
   end
 

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -74,13 +74,19 @@
   </li>
 
   <%# for author or admin, review comments if moderating them %>
-  <% if (logged_in_as_admin? || (current_user && current_user.is_author_of?(@work))) && @work.find_all_comments.unreviewed_only.exists? %>
-    <li class="comments" id="review_comments">
-      <% unreviewed_count = if logged_in_as_admin?
-                              @work.find_all_comments.unreviewed_only.count
-                            else
-                              @work.find_all_comments.unreviewed_only.not_spam.count
+  <% show_unreviewed_link = if logged_in_as_admin?
+                              @work.find_all_comments.unreviewed_only.exists?
+                            elsif current_user&.is_author_of?(@work)
+                              @work.find_all_comments.unreviewed_only.not_spam.exists?
                             end %>
+
+  <% if show_unreviewed_link %>
+    <% unreviewed_count = if logged_in_as_admin?
+                            @work.find_all_comments.unreviewed_only.count
+                          else
+                            @work.find_all_comments.unreviewed_only.not_spam.count
+                          end %>
+    <li class="comments" id="review_comments">
       <%= link_to t(".unreviewed_comments", count: unreviewed_count), unreviewed_work_comments_path(@work) %>
     </li>
   <% end %>

--- a/app/views/works/_work_header_navigation.html.erb
+++ b/app/views/works/_work_header_navigation.html.erb
@@ -74,20 +74,10 @@
   </li>
 
   <%# for author or admin, review comments if moderating them %>
-  <% show_unreviewed_link = if logged_in_as_admin?
-                              @work.find_all_comments.unreviewed_only.exists?
-                            elsif current_user&.is_author_of?(@work)
-                              @work.find_all_comments.unreviewed_only.not_spam.exists?
-                            end %>
-
-  <% if show_unreviewed_link %>
-    <% unreviewed_count = if logged_in_as_admin?
-                            @work.find_all_comments.unreviewed_only.count
-                          else
-                            @work.find_all_comments.unreviewed_only.not_spam.count
-                          end %>
+  <% unreviewed_comments = @work.unreviewed_comments_to_show(logged_in_as_admin?) %>
+  <% if (logged_in_as_admin? || current_user&.is_author_of?(@work)) && unreviewed_comments.exists? %>
     <li class="comments" id="review_comments">
-      <%= link_to t(".unreviewed_comments", count: unreviewed_count), unreviewed_work_comments_path(@work) %>
+      <%= link_to t(".unreviewed_comments", count: unreviewed_comments.count), unreviewed_work_comments_path(@work) %>
     </li>
   <% end %>
 

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -348,19 +348,18 @@ Feature: Comment Moderation
     Then I should not see "Parent Thread"
 
   Scenario: Creator marks an unreviewed comment as spam and the count updates
-    Given the moderated work "Spam Trap" by "spam_catcher"
-      And I post the comment "Fake spam" on the work "Spam Trap" as a guest
+    Given the moderated work "Test Work" by "spam_catcher"
+    When I post the comment "Fake spam" on the work "Test Work" as a guest
     When I am logged in as "spam_catcher"
-      And I view the work "Spam Trap"
+      And I view the work "Test Work"
     Then I should see "Unreviewed Comments (1)"
     When I follow "Unreviewed Comments"
-      And it is currently 1 second from now
       And I follow "Spam"
-    Then I should see "Unreviewed Comments (0)"
+    Then I should not see "Unreviewed Comments"
       And I should not see "Fake spam"
-    When I am logged out
-      And I am logged in as an admin
-      And I view the work "Spam Trap"
+      And I am logged out
+    When I am logged in as an admin
+      And I view the work "Test Work"
     Then I should see "Unreviewed Comments (1)"
     When I follow "Unreviewed Comments"
     Then I should see "Fake spam"

--- a/features/comments_and_kudos/comment_moderation.feature
+++ b/features/comments_and_kudos/comment_moderation.feature
@@ -350,14 +350,14 @@ Feature: Comment Moderation
   Scenario: Creator marks an unreviewed comment as spam and the count updates
     Given the moderated work "Test Work" by "spam_catcher"
     When I post the comment "Fake spam" on the work "Test Work" as a guest
-    When I am logged in as "spam_catcher"
+      And I am logged in as "spam_catcher"
       And I view the work "Test Work"
     Then I should see "Unreviewed Comments (1)"
     When I follow "Unreviewed Comments"
+      And it is currently 1 second from now
       And I follow "Spam"
     Then I should not see "Unreviewed Comments"
       And I should not see "Fake spam"
-      And I am logged out
     When I am logged in as an admin
       And I view the work "Test Work"
     Then I should see "Unreviewed Comments (1)"

--- a/lib/acts_as_commentable/commentable_entity.rb
+++ b/lib/acts_as_commentable/commentable_entity.rb
@@ -16,6 +16,15 @@ module ActsAsCommentable::CommentableEntity
     self.total_comments.order('thread, threaded_left')
   end
 
+  # Returns the unreviewed comments to show based on admin status
+  def unreviewed_comments_to_show(is_admin)
+    if is_admin
+      self.find_all_comments.unreviewed_only
+    else
+      self.find_all_comments.unreviewed_only.not_spam
+    end
+  end
+
   # Returns the total number of comments
   def count_all_comments
     self.total_comments.count


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7275

## Purpose

What does this PR do?

An earlier fix of AO3-7275 hid unreviewed spam comments from the creator's view but `Unreviewed comments (0)` button was still visible on the work header...this PR updates the rendering logic earlier used so the button disappears for the work creators, but remains visible for the admins (if any unreviewed comments exist)

## References

https://otwarchive.atlassian.net/browse/AO3-7275

https://github.com/otwcode/otwarchive/commit/157e9a83990975dee221df3e0504af7c9476b673

## Credit

Archie Singh (she/her/hers)