### PR TITLE
AO3-4122 Prevent duplicate translation languages for admin posts

### DIFF
--- a/app/models/admin_post.rb
+++ b/app/models/admin_post.rb
@@ -34,6 +34,13 @@ class AdminPost < ApplicationRecord
   validates_length_of :content, maximum: ArchiveConfig.CONTENT_MAX,
     too_long: ts("cannot be more than %{max} characters long.", max: ArchiveConfig.CONTENT_MAX)
 
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :translated_post_id,
+            uniqueness: { scope: :language_id,
+                          message: :translation_already_exists },
+            allow_nil: true
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
+
   validate :translated_post_must_exist
 
   validate :translated_post_language_must_differ

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -102,6 +102,7 @@ en:
               invalid_permissions: Comment permissions are invalid.
             translated_post_id:
               must_be_posted_first: cannot be posted before the original post
+              translation_already_exists: already has a translation in this language
         block:
           attributes:
             blocked:

--- a/features/admins/admin_post_news.feature
+++ b/features/admins/admin_post_news.feature
@@ -66,6 +66,15 @@ Feature: Admin Actions to Post News
       And I am logged in as "ordinaryuser"
     Then I should see a translated admin post
 
+  Scenario: Make a second translation of an admin post in the same language
+    Given I have posted an admin post
+      And basic languages
+      And the admin post "Erste Ankuendigung" translating "Default Admin Post" to "Deutsch"
+      And I am logged in as a "translation" admin
+    When I make a translation of an admin post
+    Then I should see "Sorry! We couldn't save this admin post because:"
+      And I should see "Translated post already has a translation in this language"
+
   Scenario: Make a translation of an admin post that doesn't exist
     Given basic languages
       And I am logged in as a "translation" admin

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -160,6 +160,16 @@ Given "the draft admin post {string} with tag(s) {string}" do |title, tags|
   FactoryBot.create(:admin_post, :draft, title: title, comment_permissions: :enable_all, tag_list: tags)
 end
 
+Given "the admin post {string} translating {string} to {string}" do |title, translated_title, lang|
+  admin_post = AdminPost.find_by!(title: translated_title)
+  language = Language.find_by!(name: lang)
+  FactoryBot.create(:admin_post,
+                    title: title,
+                    comment_permissions: :enable_all,
+                    translated_post_id: admin_post.id,
+                    language: language)
+end
+
 Given "the draft admin post {string} translating {string} to {string}" do |title, translated_title, lang|
   admin_post = AdminPost.find_by!(title: translated_title)
   language = Language.find_by!(name: lang)

--- a/spec/models/admin_post_spec.rb
+++ b/spec/models/admin_post_spec.rb
@@ -59,6 +59,61 @@ describe AdminPost do
     end
   end
 
+  describe "translation language uniqueness" do
+    let(:admin_post) { create(:admin_post) }
+    let(:language) { create(:language) }
+    let(:translation) do
+      build(:admin_post, translated_post: admin_post, language: language)
+    end
+    let(:message) { "already has a translation in this language" }
+
+    context "when the original post has a posted translation in the language" do
+      before do
+        create(:admin_post, translated_post: admin_post, language: language)
+      end
+
+      it "adds an error to the translated post" do
+        expect(translation).to be_invalid
+        expect(translation.errors[:translated_post_id]).to include(message)
+      end
+    end
+
+    context "when the original post has a draft translation in the language" do
+      before do
+        create(:admin_post, :draft,
+               translated_post: admin_post, language: language)
+      end
+
+      it "adds an error to the translated post" do
+        expect(translation).to be_invalid
+        expect(translation.errors[:translated_post_id]).to include(message)
+      end
+    end
+
+    context "when another post has a translation in that language" do
+      before do
+        other_post = create(:admin_post)
+        create(:admin_post, translated_post: other_post, language: language)
+      end
+
+      it "does not add an error" do
+        expect(translation).to be_valid
+      end
+    end
+
+    context "when updating the existing translation" do
+      let!(:existing) do
+        create(:admin_post, translated_post: admin_post, language: language)
+      end
+
+      it "does not add an error" do
+        existing.title = "Updated translation title"
+
+        expect(existing).to be_valid
+      end
+    end
+  end
+
   describe "#set_published_at" do
     before { freeze_time }
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4122

## Purpose

Adds a validation so an admin post can't be saved as a translation of another post when that post already has a translation in the same language. The error is reported on the translated post field, alongside the existing "cannot be same language as original post" and "cannot be posted before the original post" errors.

## Testing Instructions

1. Log in as an admin with the translation role.
2. Post a news post in English.
3. Go to Post AO3 News, choose a language (e.g. Deutsch), ID in "Translation of", and post it.
4. Repeat step 3 with the same language and the same "Tran
5. Expected: the post is not saved and the error "Translated post already has a translation in this language" is shown.
6. Repeat step 3 with a different language: the translation is saved.
7. Edit the translation from step 3 (change the title only) and save: no error.

## Credit

Pablo Monfort (he/him)