### PR TITLE
AO3-4930 Remove Invited collection participant role

### DIFF
--- a/app/controllers/collection_participants_controller.rb
+++ b/app/controllers/collection_participants_controller.rb
@@ -54,14 +54,6 @@ class CollectionParticipantsController < ApplicationController
       @participant.save
       flash[:notice] = t('applied_to_join_collection', default: "You have applied to join %{collection}.", collection: @collection.title)
     else
-      participants.each do |participant|
-        if participant.is_invited?
-          participant.approve_membership!
-          flash[:notice] = t('collection_participants.accepted_invite', default: "You are now a member of %{collection}.", collection: @collection.title)
-          redirect_back_or_to root_path and return
-        end
-      end
-
       flash[:notice] = t('collection_participants.no_invitation', default: "You have already joined (or applied to) this collection.")
     end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -54,7 +54,6 @@ class Collection < ApplicationRecord
 
   has_many :participants, through: :collection_participants, source: :pseud
   has_many :users, through: :participants, source: :user
-  has_many :invited, -> { where(collection_participants: { participant_role: CollectionParticipant::INVITED }) }, through: :collection_participants, source: :pseud
   has_many :owners, -> { where(collection_participants: { participant_role: CollectionParticipant::OWNER }) }, through: :collection_participants, source: :pseud
   has_many :moderators, -> { where(collection_participants: { participant_role: CollectionParticipant::MODERATOR }) }, through: :collection_participants, source: :pseud
   has_many :members, -> { where(collection_participants: { participant_role: CollectionParticipant::MEMBER }) }, through: :collection_participants, source: :pseud

--- a/app/models/collection_participant.rb
+++ b/app/models/collection_participant.rb
@@ -5,15 +5,13 @@ class CollectionParticipant < ApplicationRecord
 
   after_commit :update_collection_index
 
-  PARTICIPANT_ROLES = ["None", "Owner", "Moderator", "Member", "Invited"]
+  PARTICIPANT_ROLES = %w[None Owner Moderator Member].freeze
   NONE = PARTICIPANT_ROLES[0]
   OWNER = PARTICIPANT_ROLES[1]
   MODERATOR = PARTICIPANT_ROLES[2]
   MEMBER = PARTICIPANT_ROLES[3]
-  INVITED = PARTICIPANT_ROLES[4]
   MAINTAINER_ROLES = [PARTICIPANT_ROLES[1], PARTICIPANT_ROLES[2]]
   PARTICIPANT_ROLE_OPTIONS = [ [ts("None"), NONE],
-                         [ts("Invited"), INVITED],
                          [ts("Member"), MEMBER],
                          [ts("Moderator"), MODERATOR],
                          [ts("Owner"), OWNER] ]
@@ -41,7 +39,6 @@ class CollectionParticipant < ApplicationRecord
   def is_moderator? ; self.participant_role == MODERATOR ; end
   def is_maintainer? ; is_owner? || is_moderator? ; end
   def is_member? ; self.participant_role == MEMBER ; end
-  def is_invited? ; self.participant_role == INVITED ; end
   def is_none? ; self.participant_role == NONE ; end
 
   def approve_membership!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,6 @@ class User < ApplicationRecord
 
   has_many :collection_participants, through: :pseuds
   has_many :collections, through: :collection_participants
-  has_many :invited_collections, -> { where("collection_participants.participant_role = ?", CollectionParticipant::INVITED) }, through: :collection_participants, source: :collection
   has_many :participated_collections, -> { where("collection_participants.participant_role IN (?)", [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR, CollectionParticipant::MEMBER]) }, through: :collection_participants, source: :collection
   has_many :maintained_collections, -> { where("collection_participants.participant_role IN (?)", [CollectionParticipant::OWNER, CollectionParticipant::MODERATOR]) }, through: :collection_participants, source: :collection
   has_many :owned_collections, -> { where("collection_participants.participant_role = ?", CollectionParticipant::OWNER) }, through: :collection_participants, source: :collection

--- a/features/collections/collection_participants.feature
+++ b/features/collections/collection_participants.feature
@@ -69,25 +69,6 @@
     And I press "Join"
   Then I should see "You have applied to join Such a nice collection"
 
-  Scenario: A collection owner can preapprove a user to join a closed collection
-  Given I have a moderated closed collection "Such a nice collection"
-    And I am in sam's browser
-    And I am logged in as "sam"
-  When I go to "Such a nice collection" collection's page
-  When I am in the moderator's browser
-    And I am logged in as the owner of "Such a nice collection"
-    And I am on the "Such a nice collection" participants page
-    And I fill in "participants_to_invite" with "sam"
-    And I press "Submit"
-  Then I should see "New members invited: sam"
-  When I select "Invited" from "sam_role"
-    And I submit with the 4th button
-  Then I should see "Updated sam."
-  When I am in sam's browser
-    And I press "Join"
-  Then I should see "You are now a member of Such a nice collection"
-  When I am in the default browser
-
   Scenario: A subcollection profile and blurb do not show duplicates when a moderator is also an owner of the parent collection
     Given a user exists with login: "sam"
       And I have the collection "Collection"

--- a/lib/tasks/after_tasks.rake
+++ b/lib/tasks/after_tasks.rake
@@ -707,5 +707,14 @@ namespace :After do
     $stdout.flush
   end
 
+  desc "Convert collection participants with the removed Invited role to None"
+  task(remove_invited_collection_participant_role: :environment) do
+    # "Invited" is no longer a valid CollectionParticipant role (AO3-4930),
+    # so it is intentionally a string literal here rather than a constant.
+    updated = CollectionParticipant.where(participant_role: "Invited")
+      .update_all(participant_role: CollectionParticipant::NONE)
+    puts "Converted #{updated} invited #{'participant'.pluralize(updated)} to None"
+  end
+
   # This is the end that you have to put new tasks above.
 end

--- a/spec/controllers/collection_participants_controller_spec.rb
+++ b/spec/controllers/collection_participants_controller_spec.rb
@@ -30,35 +30,20 @@ describe CollectionParticipantsController do
       end
 
       context "where there is a collection" do
-        let(:current_role) { CollectionParticipant::NONE }
-
         context "where the user is already a participant" do
           let!(:participant) do
             create(
               :collection_participant,
               collection: collection,
               pseud: user.default_pseud,
-              participant_role: current_role
+              participant_role: CollectionParticipant::NONE
             )
           end
 
-          context "where the user has been invited" do
-            let(:current_role) { CollectionParticipant::INVITED }
-
-            it "approves the participant and redirects to the index" do
-              get :join, params: { collection_id: collection.name }
-              expect(CollectionParticipant.find(participant.id).participant_role).to eq CollectionParticipant::MEMBER
-              it_redirects_to_with_notice(root_path,
-                                          "You are now a member of #{collection.title}.")
-            end
-          end
-
-          context "where the user is not currently invited" do
-            it "redirects to the index and displays a notice that the user has already joined or applied" do
-              get :join, params: { collection_id: collection.name }
-              it_redirects_to_with_notice(root_path,
-                                          "You have already joined (or applied to) this collection.")
-            end
+          it "redirects to the index and displays a notice that the user has already joined or applied" do
+            get :join, params: { collection_id: collection.name }
+            it_redirects_to_with_notice(root_path,
+                                        "You have already joined (or applied to) this collection.")
           end
         end
 

--- a/spec/lib/tasks/after_tasks.rake_spec.rb
+++ b/spec/lib/tasks/after_tasks.rake_spec.rb
@@ -972,3 +972,26 @@ describe "rake After:backfill_missing_pseuds" do
     end
   end
 end
+
+describe "rake After:remove_invited_collection_participant_role" do
+  let(:collection) { create(:collection) }
+  let!(:member) do
+    create(:collection_participant, collection: collection, participant_role: CollectionParticipant::MEMBER)
+  end
+  let!(:invited) do
+    participant = build(:collection_participant, collection: collection)
+    participant.participant_role = "Invited"
+    participant.save!(validate: false)
+    participant
+  end
+
+  it "converts invited participants to none" do
+    subject.invoke
+    expect(invited.reload.participant_role).to eq(CollectionParticipant::NONE)
+  end
+
+  it "does not change other participants" do
+    subject.invoke
+    expect(member.reload.participant_role).to eq(CollectionParticipant::MEMBER)
+  end
+end

--- a/spec/models/collection_participant_spec.rb
+++ b/spec/models/collection_participant_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe CollectionParticipant do
+  describe "validations" do
+    it "does not allow the removed Invited role" do
+      participant = build(:collection_participant, participant_role: "Invited")
+      expect(participant).to be_invalid
+      expect(participant.errors[:participant_role]).to include("That is not a valid participant role.")
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlass as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4930

## Purpose

Removes the "Invited" collection participant role, which had no real purpose.

The only code path that acted on it was `CollectionParticipantsController#join` a participant with the `Invited` role who clicked "Join" was promoted to `Member`. In practice this almost never happened, because nothing in the codebase ever assigns the `Invited` role, adding someone from the participants page already creates them directly as a `Member`. The only way to reach the flow was for a maintainer to add a user and then manually change their role to "Invited" in the dropdown.

Changes:

* `CollectionParticipant`: remove the `INVITED` constant, the "Invited" option from the role dropdown, and `is_invited?`.
* `Collection#invited` and `User#invited_collections`: re
* `CollectionParticipantsController#join`: remove the branch that accepted invitations. Joining a collection you already participate in now always shows "You have already joined (or applied to) this collection."
* Add the `After:remove_invited_collection_participant_role` task to convert any existing `Invited` rows to `None` ("applied to join").
* Remove the "preapprove a user" Cucumber scenario and the controller spec for the invited path; add specs for the after task and for `"Invited"` no longer being a valid role.

## After Deploy Steps

1. Run the after task **before** deploying the code:

   `bundle exec rake After:remove_invited_collection_parti`

It converts any remaining `Invited` collection participants to `None` and prints the number of rows updated. It is idempotent and safe to re-run.

2. Ordering matters: once the new code is live, `Invited` is no longer an allowed `participant_role`. Any leftover row would fail validation ("That is not a valid participant role.") when a maintainer edits that participant, and the role dropdown on the participants page would have no selected option for them.

3. No schema change, no index change, no reindex needed. Safe to include in a regular release.

4. Rollback: revert the code only. Converted rows stay as `None`, which is a valid role in both versions.

## Testing Instructions

1. As a collection owner, go to the collection's Participants page.
2. Check the role dropdown for any participant: it should list None, Member, Moderator and Owner only.
3. Add a new participant via the "participants_to_invite" field: they should be added as a Member, as before.
4. As a user who has already applied to (or is a member of) a moderated collection, press "Join" on the collection page: you should see "You have already joined (or applied to) this collection."
5. As a user who is not yet a participant, press "Join": you should see "You have applied to join …", as before.

## Credit

Pablo Monfort (he/him)