### PR TITLE
AO3-4052 Require choosing a pseud option when orphaning

### DIFF
--- a/app/controllers/orphans_controller.rb
+++ b/app/controllers/orphans_controller.rb
@@ -35,6 +35,11 @@ class OrphansController < ApplicationController
   end
 
   def create
+    unless params[:use_default].in?(%w[true false])
+      flash[:error] = t(".pseud_option_required")
+      redirect_back_or_to(new_orphan_path(orphan_params)) && return
+    end
+
     use_default = params[:use_default] == "true"
     Creatorship.orphan(@pseuds, @orphans, use_default)
     flash[:notice] = ts("Orphaning was successful.")
@@ -91,5 +96,12 @@ class OrphansController < ApplicationController
       # We don't need to check ownership here because these pseuds are
       # guaranteed to be owned by the current user.
     end
+  end
+
+  private
+
+  def orphan_params
+    params.slice(:series_id, :pseud_id, :work_ids)
+      .permit(:series_id, :pseud_id, work_ids: [])
   end
 end

--- a/app/views/orphans/_choose_pseud.html.erb
+++ b/app/views/orphans/_choose_pseud.html.erb
@@ -1,8 +1,18 @@
-<p>
-  <%= radio_button_tag 'use_default', 'true', true %> 
-  <%= label_tag 'use_default_true', ts('Take my pseud off as well') %>
-</p>
-<p>
-  <%= radio_button_tag 'use_default', 'false' %> 
-  <%= label_tag 'use_default_false', ts('Leave a copy of my pseud on') %>
-</p>
+<dl>
+  <dt><%= t(".prompt") %></dt>
+  <dd>
+    <fieldset>
+      <legend><%= t(".prompt") %></legend>
+      <ul>
+        <li>
+          <%= radio_button_tag "use_default", "true" %>
+          <%= label_tag "use_default_true", t(".remove_pseud") %>
+        </li>
+        <li>
+          <%= radio_button_tag "use_default", "false" %>
+          <%= label_tag "use_default_false", t(".keep_pseud") %>
+        </li>
+      </ul>
+    </fieldset>
+  </dd>
+</dl>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -303,6 +303,9 @@ en:
         unmuted: You have unmuted the user %{name}.
       index:
         page_title: "%{username} - Muted Users"
+  orphans:
+    create:
+      pseud_option_required: You must choose whether to remove or keep your pseud.
   people:
     index:
       collection_page_title: "%{collection_title} - People"

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2732,6 +2732,10 @@ en:
           intro: 'Muting a user will not:'
           prevent_emails: prevent you from receiving comment or subscription emails from this user
   orphans:
+    choose_pseud:
+      keep_pseud: Keep my pseud
+      prompt: What should happen to your pseud?
+      remove_pseud: Remove my pseud
     orphan_user:
       orphaning_bylines_only_message_html: Orphaning will automatically remove your personal information from <strong>bylines only</strong>. It will <strong>not</strong> automatically remove your personal information from anywhere else in the work(s). Social media accounts, contact information, email addresses, names, and any other personal information posted in the title, summary, notes, tags, work body, or comment text will <strong>not</strong> be automatically removed. Comments posted by other users will also <strong>not</strong> be affected by Orphaning. If you want information removed from these places, you should edit or delete it prior to Orphaning. <strong>Once you Orphan the work(s), you will no longer be able to delete information in these places yourself</strong>.
       orphaning_works_message_html: 'Orphaning will <strong>permanently</strong> remove your username and/or pseud from the bylines of: the following work(s), their chapters, associated series, and any comments you may have left on them while logged into this account.'

--- a/features/other_a/orphan_account.feature
+++ b/features/other_a/orphan_account.feature
@@ -21,7 +21,7 @@ Scenario: Orphan all works belonging to a user
   When I go to the orphan all works page
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
-  When I choose "Take my pseud off as well"
+  When I choose "Remove my pseud"
     # Delay before orphaning to make sure the cache is expired
     And it is currently 1 second from now
     And I press "Yes, I'm sure"
@@ -53,7 +53,7 @@ Given I have an orphan account
   When I go to the orphan all works page
   Then I should see "Orphan All Works"
     And I should see "Are you really sure you want to"
-  When I choose "Leave a copy of my pseud on"
+  When I choose "Keep my pseud"
     # Delay before orphaning to make sure the cache is expired
     And it is currently 1 second from now
     And I press "Yes, I'm sure"

--- a/features/other_a/orphan_pseud.feature
+++ b/features/other_a/orphan_pseud.feature
@@ -22,7 +22,7 @@ Feature: Orphan pseud
       And it is currently 1 second from now
     When I follow "Orphan Works"
     Then I should see "Orphan All Works by orphanpseud"
-    When I choose "Take my pseud off as well"
+    When I choose "Remove my pseud"
       And I press "Yes, I'm sure"
     Then I should see "Orphaning was successful."
     When I view the work "Shenanigans"
@@ -50,7 +50,7 @@ Feature: Orphan pseud
       And it is currently 1 second from now
     When I follow "Orphan Works"
     Then I should see "Orphan All Works by orphanpseud"
-    When I choose "Leave a copy of my pseud on"
+    When I choose "Keep my pseud"
       And I press "Yes, I'm sure"
     Then I should see "Orphaning was successful."
     When I view the work "Shenanigans"
@@ -87,7 +87,7 @@ Feature: Orphan pseud
     When I go to halfandhalf's pseuds page
       And I follow "Orphan Works by To Be Orphaned"
     Then I should see "Orphan All Works by To Be Orphaned"
-    When I choose "Take my pseud off as well"
+    When I choose "Remove my pseud"
       And I wait 2 seconds
       And I press "Yes, I'm sure"
     Then I should see "Orphaning was successful."

--- a/features/other_a/orphan_work.feature
+++ b/features/other_a/orphan_work.feature
@@ -28,7 +28,7 @@ Feature: Orphan work
       And it is currently 1 second from now
     When I follow "Orphan Work"
     Then I should see "Read More About The Orphaning Process"
-    When I choose "Take my pseud off as well"
+    When I choose "Remove my pseud"
       And I press "Yes, I'm sure"
       And all indexing jobs have been run
     Then I should see "Orphaning was successful."
@@ -52,7 +52,7 @@ Feature: Orphan work
       And it is currently 1 second from now
     When I follow "Orphan Work"
     Then I should see "Read More About The Orphaning Process"
-    When I choose "Leave a copy of my pseud on"
+    When I choose "Keep my pseud"
     And I press "Yes, I'm sure"
     Then I should see "Orphaning was successful."
     When I go to orphaneer's works page
@@ -67,7 +67,7 @@ Feature: Orphan work
     Given I post the work "Doomed Story"
       And I follow "Edit"
       And I follow "Orphan Work"
-      And I choose "Take my pseud off as well"
+      And I choose "Remove my pseud"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
     Then 0 emails should be delivered
@@ -78,7 +78,7 @@ Feature: Orphan work
     Given I post the work "Awful Concoction"
       And I follow "Edit"
       And I follow "Orphan Work"
-      And I choose "Leave a copy of my pseud on"
+      And I choose "Keep my pseud"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
     Then 0 emails should be delivered
@@ -96,7 +96,7 @@ Feature: Orphan work
       And a chapter is added to "Torrid Idfic"
       And I follow "Edit"
       And I follow "Orphan Work"
-      And I choose "Leave a copy of my pseud on"
+      And I choose "Keep my pseud"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
     Then 0 emails should be delivered
@@ -115,7 +115,7 @@ Feature: Orphan work
       And I view the work "Lazy Purple Sausage"
       And I follow "Edit"
       And I follow "Orphan Work"
-      And I choose "Leave a copy of my pseud on"
+      And I choose "Keep my pseud"
       And I press "Yes, I'm sure"
     When subscription notifications are sent
     Then 0 emails should be delivered
@@ -139,13 +139,26 @@ Feature: Orphan work
     And it is currently 1 second from now
   When I follow "Orphan Works Instead"
   Then I should see "Orphaning a work removes it from your account and re-attaches it to the specially created orphan_account."
-  When I press "Yes, I'm sure"
+  When I choose "Remove my pseud"
+    And I press "Yes, I'm sure"
     And all indexing jobs have been run
   Then I should see "Orphaning was successful."
   When I go to author's works page
   Then I should not see "Glorious"
     And I should not see "Excellent"
     And I should see "Lovely"
+
+  Scenario: Orphaning without choosing a pseud option shows an error
+    Given I post the work "Undecided"
+      And I view the work "Undecided"
+      And I follow "Edit"
+      And I follow "Orphan Work"
+    When I press "Yes, I'm sure"
+    Then I should see "You must choose whether to remove or keep your pseud."
+      And I should see "Read More About The Orphaning Process"
+    When I view the work "Undecided"
+    Then I should see "orphaneer"
+      And I should not see "orphan_account"
 
   Scenario: Orphaning a shared work should not affect chapters created solely by the other creator
 

--- a/features/step_definitions/orphan_steps.rb
+++ b/features/step_definitions/orphan_steps.rb
@@ -1,11 +1,11 @@
 When /^I choose to take my pseud off$/ do
-  step %{I choose "Take my pseud off as well"}
+  step %{I choose "Remove my pseud"}
   step %{I press "Yes, I'm sure"}
   step %{I should see "Orphaning was successful."}
 end
 
 When /^I choose to (?:keep|leave) my pseud on$/ do
-  step %{I choose "Leave a copy of my pseud on"}
+  step %{I choose "Keep my pseud"}
   step %{I press "Yes, I'm sure"}
   step %{I should see "Orphaning was successful."}
 end

--- a/spec/controllers/orphans_controller_spec.rb
+++ b/spec/controllers/orphans_controller_spec.rb
@@ -189,6 +189,37 @@ describe OrphansController do
     context "when logged in as the owner" do
       before { fake_login_known_user(user.reload) }
 
+      context "when no pseud option is chosen" do
+        let(:error) { "You must choose whether to remove or keep your pseud." }
+
+        it "redirects back to the works orphan page with an error" do
+          post :create, params: { work_ids: [work] }
+
+          it_redirects_to_with_error(
+            new_orphan_path(work_ids: [work.id]), error
+          )
+          expect(work.reload.users).to include(user)
+        end
+
+        it "redirects back to the series orphan page with an error" do
+          post :create, params: { series_id: series }
+
+          it_redirects_to_with_error(
+            new_orphan_path(series_id: series.id), error
+          )
+          expect(series.reload.users).to include(user)
+        end
+
+        it "rejects values other than true or false" do
+          post :create, params: { work_ids: [work], use_default: "maybe" }
+
+          it_redirects_to_with_error(
+            new_orphan_path(work_ids: [work.id]), error
+          )
+          expect(work.reload.users).to include(user)
+        end
+      end
+
       it "successfully orphans a single work and redirects" do
         post :create, params: { work_ids: [work], use_default: "true" }
         expect(work.reload.users).not_to include(user)


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-4052

## Purpose

The orphan page preselected "Take my pseud off as well", so it was easy to orphan without reading the options. This PR:

- Removes the default, so neither option is checked when the page loads.
- Makes `OrphansController#create` reject the form when no option (or an unexpected value) is submitted, with an error and a redirect back to the orphan page.
- Reworded the options to "Remove my pseud" / "Keep my pseud", as suggested in the issue comments, and gave the group a visible prompt ("What should happen to your pseud?") plus a `legend` for screen readers, following the pattern used in the work form.

The partial is shared by the work, series, pseud and account orphan pages, so all four are affected.

## Testing Instructions

1. Log in, open a work you created, click Edit, then "Orphan Work".
2. Neither option should be selected. The group should read "What should happen to your pseud?" with the options "Remove my pseud" and "Keep my pseud".
3. Click "Yes, I'm sure" without choosing: you should stay on the orphan page with the error "You must choose whether to remove or keep your pseud." and the work should still be yours.
4. Choose "Keep my pseud" and confirm: the work is orphaned with a copy of your pseud (`<pseud> (orphan_account)` in the byline, unless the work is in an anonymous collection).
5. Repeat with another work and "Remove my pseud": the byline shows `orphan_account`.
6. The same check applies on the series, pseud and whole-account orphan pages.

<img width="1488" height="597" alt="Screenshot 2026-08-28 at 9 47 23 PM" src="https://github.com/user-attachments/assets/c68fddca-778c-47dd-ac54-fd3be692b24a" />

## Credit

Pablo Monfort (he/him)