### PR TITLE
AO3-7588 Correct Manage Invitations page title

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -20,6 +20,7 @@ class InvitationsController < ApplicationController
   end
 
   def manage
+    @page_subtitle = t(".page_title")
     status = params[:status]
     @invitations = @user.invitations
     if %w(unsent unredeemed redeemed).include?(status)

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -2532,6 +2532,8 @@ en:
       sent_at: Sent at
       sent_to: Sent to
       user_id_deleted: User %{user_id} (Deleted)
+    manage:
+      page_title: Manage Invitations
     user_invitations:
       table:
         actions:

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -48,6 +48,14 @@ describe InvitationsController do
 
         expect(response).to render_template("manage")
       end
+
+      it "assigns the page subtitle" do
+        admin.update!(roles: ["policy_and_abuse"])
+        fake_login_admin(admin)
+        get :manage, params: { user_id: user.login }
+
+        expect(assigns(:page_subtitle)).to eq("Manage Invitations")
+      end
     end
   end
 
@@ -224,7 +232,6 @@ describe InvitationsController do
       invitation = create(:invitation)
       admin.update!(roles: ["policy_and_abuse"])
       fake_login_admin(admin)
- 
       delete :destroy, params: { id: invitation.id }
       it_redirects_to_with_notice(admin_invitations_path, "Invitation successfully destroyed")
     end


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7588

## Purpose

What does this PR do?

Fixes the Manage Invitations browser title so it correctly displays “Manage Invitations” instead of “Manage Invitation.”

## Testing Instructions

How can the Archive's QA team verify that this is working as you intended?

Log in, open Dashboard → Invitations → Manage Invitations, and confirm the browser title displays “Manage Invitations.”

## Credit

What name and pronouns should we use to credit you in the [Archive of Our Own's Release Notes](https://archiveofourown.org/admin_posts?tag=1)?

Jaimin, he/him
