### PR TITLE
AO3-7587 move bookmark help to translatable modals

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,5 +1,7 @@
 class HelpController < ApplicationController
   HELP_ACTIONS = %i[
+    bookmark_search_bookmarker_tag
+    bookmark_search_results
     collectibles_add_to_collection
     first_login
     html

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -62,7 +62,7 @@
       </dd>
       <dt>
         <%= f.label :other_bookmark_tag_names, ts("Bookmarker's tags") %>
-        <%= link_to_help "bookmark-search-bookmarker-tag" %>
+        <%= link_to_help_modal(help_bookmark_search_bookmarker_tag_path, t(".bookmark_search_bookmarker_tag_help_title")) %>
       </dt>
       <dd>
         <%= f.text_field :other_bookmark_tag_names, autocomplete_options("tag") %>

--- a/app/views/bookmarks/search_results.html.erb
+++ b/app/views/bookmarks/search_results.html.erb
@@ -19,7 +19,7 @@
 <% if @bookmarks.blank? %>
   <p><%= ts("No results found. You may want to edit your search to make it less specific.") %></p>
 <% else %>
-  <h3 class="heading"><%= search_results_found(@bookmarks) %> <%= link_to_help "bookmark-search-results-help" %></h3>
+  <h3 class="heading"><%= search_results_found(@bookmarks) %> <%= link_to_help_modal(help_bookmark_search_results_path, t(".bookmark_search_results_help_title")) %></h3>
 
   <h3 class="landmark heading">Bookmarks List</h3>
   <ol class="bookmark index group">

--- a/app/views/help/bookmark_search_bookmarker_tag.html.erb
+++ b/app/views/help/bookmark_search_bookmarker_tag.html.erb
@@ -1,0 +1,3 @@
+<h4><%= t(".page_heading") %></h4>
+
+<p><%= t(".description") %></p>

--- a/app/views/help/bookmark_search_results.html.erb
+++ b/app/views/help/bookmark_search_results.html.erb
@@ -1,0 +1,6 @@
+<h4><%= t(".page_heading") %></h4>
+
+<p>
+  <%= t(".description_html",
+        work_search_link: link_to(t(".work_search"), search_works_path)) %>
+</p>

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -701,7 +701,10 @@ en:
         works: Works
       recent_bookmarks_html: These are some of the latest bookmarks created on the Archive. To find more bookmarks, %{choose_fandom_link} or %{advanced_search_link}.
     search_form:
+      bookmark_search_bookmarker_tag_help_title: Bookmark search bookmarker's tags help
       word_count: Word count
+    search_results:
+      bookmark_search_results_help_title: Bookmark search results help
   challenge:
     gift_exchange:
       challenge_signups:
@@ -1215,6 +1218,13 @@ en:
         status_page: status page
         tumblr: ao3org
   help:
+    bookmark_search_bookmarker_tag:
+      description: 'The "Bookmarker''s tags" field searches all tags added to a bookmark. This does not include tags on the bookmarked series or work itself. Tags can be any of the following: Rating, Warning, Category, Fandom, Character, Relationship, Additional Tags. The field will suggest canonical tags as you enter search terms.'
+      page_heading: 'Bookmark Search: Bookmarker''s Tags'
+    bookmark_search_results:
+      description_html: Results are sorted by relevance. Please note that the list will include all bookmarks for a work, as each bookmark is factored into the results individually. To search for works instead of bookmarks, use the %{work_search_link}.
+      page_heading: 'Bookmarks Search: Results'
+      work_search: Work Search
     collectibles_add_to_collection:
       collection_names: Note that you need to use the collection's name, which gets used in the collection's URL, and not the collection's spiffy title (because different collections can have the same title). A collection's name is the equivalent of your user login. Names will be auto-completed for you if you have JavaScript turned on.
       guidance: Enter collection names as a comma-separated list, and the item you are editing will be added to all the collections you specify.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -659,6 +659,8 @@ Rails.application.routes.draw do
   end
 
   # Redirects for moved help files
+  get "/help/bookmark-search-bookmarker-tag.html", to: redirect("/help/bookmark_search_bookmarker_tag")
+  get "/help/bookmark-search-results-help.html", to: redirect("/help/bookmark_search_results")
   get "/help/add-collectible-to-collection.html", to: redirect("/help/collectibles_add_to_collection")
   get "/first_login_help", to: redirect("/help/first_login")
   get "/help/html-help.html", to: redirect("/help/html")

--- a/features/bookmarks/bookmark_search.feature
+++ b/features/bookmarks/bookmark_search.feature
@@ -300,3 +300,20 @@ Feature: Search Bookmarks
     When I fill in "Any field on work" with "bad~query~~!!!"
       And I press "Search Bookmarks"
     Then I should see "Your search failed because of a syntax error. Please try again."
+
+    Scenario: Bookmark search help modals are translated
+    Given I have bookmarks to search
+    When I open help modal "Bookmark search bookmarker's tags help"
+    Then I should see "Bookmark Search: Bookmarker's Tags"
+      And I should see "field searches all tags added to a bookmark"
+      And I should not see "translation missing"
+      And I should not see "<a href"
+    When I go to the search bookmarks page
+      And I fill in "Bookmarker's tags" with "rare"
+      And I press "Search Bookmarks"
+      And I open help modal "Bookmark search results help"
+    Then I should see "Bookmarks Search: Results"
+      And I should see "Results are sorted by relevance."
+      And I should see a link "Work Search" to "/works/search"
+      And I should not see "translation missing"
+      And I should not see "<a href"

--- a/public/help/bookmark-search-bookmarker-tag.html
+++ b/public/help/bookmark-search-bookmarker-tag.html
@@ -1,5 +1,0 @@
-<h4>Bookmark Search: Bookmarker's Tags</h4>
-
-<p>
-    The "Bookmarker's tags" field searches all tags added to a bookmark. This does not include tags on the bookmarked series or work itself. Tags can be any of the following: Rating, Warning, Category, Fandom, Character, Relationship, Additional Tags. The field will suggest canonical tags as you enter search terms.
-</p>

--- a/public/help/bookmark-search-results-help.html
+++ b/public/help/bookmark-search-results-help.html
@@ -1,3 +1,0 @@
-<h4>Bookmarks Search: Results</h4>
-
-<p>Results are sorted by relevance. Please note that the list will include all bookmarks for a work, as each bookmark is factored into the results individually. To search for works instead of bookmarks, use the <a href="/works/search">Work Search</a>.</p>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title 
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7587

## Purpose

this PR moves the bookmark search help text out of static HTML files into translatable HelpController modal views, and updates the bookmark search page to use link_to_help_modal for both help links.

## Credit

Archie Singh (she/her/hers)
