### PR TITLE
AO3-7596 Bump mail from 2.8.1 to 2.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,8 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.1)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -404,12 +405,12 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.5.15)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7596

## Purpose

Address a CVE that doesn't affect us.

## References

PR limit does not apply to volunteers with write access to the repository.

## Credit

Bilka
