### PR TITLE
AO3-7594 Update html in invalid_signup_notification.html.erb mailer

### DIFF
--- a/app/views/gift_exchange_mailer/invalid_signup_notification.html.erb
+++ b/app/views/gift_exchange_mailer/invalid_signup_notification.html.erb
@@ -3,13 +3,12 @@
 
   <p><%= t(".see_details.html", challenge_matching_help_link: style_link(t(".see_details.challenge_matching_help"), "#{root_url}help/challenge-matching.html#invalid_signups")) %></p>
 
-  <p><%= t(".signups_here") %>
+  <p><%= t(".signups_here") %></p>
     <ul>
     <% @invalid_signups.each do |signup_id| %>
       <li><%= style_link(t(".signup", signup_id: signup_id), collection_signup_url(@collection, signup_id)) %></li>
     <% end %>
     </ul>
-  </p>
 <% end %>
 
 <% content_for :footer_note do %>


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue
https://otwarchive.atlassian.net/browse/AO3-7594

## Purpose

Updates the HTML to be consistent with the rest of the mailers, by moving the ul element out of the p element.

## Testing Instructions
A visit to the mailer preview at [https://test.archiveofourown.org/rails/mailers/gift_exchange_mailer/](https://test.archiveofourown.org/rails/mailers/gift_exchange_mailer/invalid_signup_notification_collection_email) will confirm the HTML cleanup still displays the list element as intended.

## Credit
bowekatan
She/her


