### PR TITLE
AO3-7446 Update cache key for work meta

### DIFF
--- a/app/views/works/_meta.html.erb
+++ b/app/views/works/_meta.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless(@preview_mode, "/v4/#{@work.cache_key}-#{Work.work_blurb_version(@work.id)}-meta-#{hide_warnings?(@work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(@work) ? 'nofreeform' : 'showfreeform'}", skip_digest: true) do %>
+<% cache_unless(@preview_mode, "/v5/#{@work.cache_key}-#{Work.work_blurb_version(@work.id)}-meta-#{hide_warnings?(@work) ? 'nowarn' : 'showwarn'}-#{hide_freeform?(@work) ? 'nofreeform' : 'showfreeform'}", skip_digest: true) do %>
 <h3 class="landmark heading"><%= ts("Work Header") %></h3>
 
 <div class="wrapper">


### PR DESCRIPTION
# Pull Request Checklist

<!-- Mark steps in the checklist as complete by changing `[ ]` to `[X]` -->
* [X] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [X] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [X] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [X] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [X] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7446

## Purpose

Makes the work meta re-cache itself so the [fix for AO3-7446](https://github.com/otwcode/otwarchive/pull/5860) is visible on cached works. 

**Note:** This does not un-bold the text because at the time [I was told](https://transformativeworks.slack.com/archives/G2CRYKP8W/p1780877186802579?thread_ts=1780874977.478949&cid=G2CRYKP8W) that bold text there would match the styling of archive warnings in general; however, both beta testers who looked at this thought that that looked weird/like an issue so if we now disagree with that either on the text itself or both the text and warnings, let me know and I will add that to this PR

## Testing Instructions

Open a cached work, for example:
https://test.archiveofourown.org/works/1122223?view_adult=true
https://test.archiveofourown.org/works/1122328

The link on "Archive Warnings" should be gone and it should no longer be underlined, though it should be bolded.

## References

Fixing [AO3-7446](https://github.com/otwcode/otwarchive/pull/5860)

## Credit

FlyingFalcon they/them


[AO3-7446]: https://otwarchive.atlassian.net/browse/AO3-7446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ