### PR TITLE
AO3-7556 Fix 500 when trying to /comments/add_comment_reply on nothing

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,6 +4,7 @@ class CommentsController < ApplicationController
                        :hide_comments, :add_comment_reply,
                        :cancel_comment_reply, :delete_comment,
                        :cancel_comment_delete, :unreviewed, :review_all]
+  before_action :check_commentable_found, only: [:new, :create, :show_comments, :add_comment_reply]
   before_action :check_user_status, only: [:new, :create, :edit, :update, :destroy]
   before_action :load_comment, only: [:show, :edit, :update, :delete_comment, :destroy, :cancel_comment_edit, :cancel_comment_delete, :review, :approve, :reject, :freeze, :unfreeze, :hide, :unhide]
   before_action :check_visibility, only: [:show]
@@ -317,6 +318,17 @@ class CommentsController < ApplicationController
     end
   end
 
+  def check_commentable_found
+    return unless @commentable.nil?
+
+    # i18n-tasks-use t("comments.add_comment_reply.not_found")
+    # i18n-tasks-use t("comments.create.not_found")
+    # i18n-tasks-use t("comments.new.not_found")
+    # i18n-tasks-use t("comments.show_comments.not_found")
+    flash[:error] = t("comments.#{action_name}.not_found")
+    redirect_back_or_to root_path
+  end
+
   def set_page_subtitle
     parent = find_parent
     return unless parent
@@ -359,28 +371,21 @@ class CommentsController < ApplicationController
 
   # GET /comments/new
   def new
-    if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
-      redirect_back_or_to root_path
-    else
-      @comment = Comment.new
-      @controller_name = params[:controller_name] if params[:controller_name]
-      @name =
-        case @commentable.class.name
-        when /Work/
-          @commentable.title
-        when /Chapter/
-          @commentable.work.title
-        when /Tag/
-          @commentable.name
-        when /AdminPost/
-          @commentable.title
-        when /Comment/
-          ts("Previous Comment")
-        else
-          @commentable.class.name
-        end
-    end
+    @comment = Comment.new
+    @controller_name = params[:controller_name] if params[:controller_name]
+    @name =
+      case @commentable.class.name
+      when /Work/, /AdminPost/
+        @commentable.title
+      when /Chapter/
+        @commentable.work.title
+      when /Tag/
+        @commentable.name
+      when /Comment/
+        t(".previous_comment_name")
+      else
+        @commentable.class.name
+      end
   end
 
   # GET /comments/1/edit
@@ -394,55 +399,50 @@ class CommentsController < ApplicationController
   # POST /comments
   # POST /comments.xml
   def create
-    if @commentable.nil?
-      flash[:error] = ts("What did you want to comment on?")
-      redirect_back_or_to root_path
-    else
-      @comment = Comment.new(comment_params)
-      @comment.ip_address = request.remote_ip
-      @comment.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
-      @comment.cloudflare_bot_score = request.env["HTTP_CF_BOT_SCORE"]
-      @comment.cloudflare_ja3_hash = request.env["HTTP_CF_JA3_HASH"]
-      @comment.cloudflare_ja4 = request.env["HTTP_CF_JA4"]
-      @comment.request_host = request.host
-      @comment.commentable = Comment.commentable_object(@commentable)
-      @controller_name = params[:controller_name]
+    @comment = Comment.new(comment_params)
+    @comment.ip_address = request.remote_ip
+    @comment.user_agent = request.env["HTTP_USER_AGENT"]&.to(499)
+    @comment.cloudflare_bot_score = request.env["HTTP_CF_BOT_SCORE"]
+    @comment.cloudflare_ja3_hash = request.env["HTTP_CF_JA3_HASH"]
+    @comment.cloudflare_ja4 = request.env["HTTP_CF_JA4"]
+    @comment.request_host = request.host
+    @comment.commentable = Comment.commentable_object(@commentable)
+    @controller_name = params[:controller_name]
 
-      # First, try saving the comment
-      if @comment.save
-        flash[:comment_notice] = if @comment.unreviewed?
-                                   # i18n-tasks-use t("comments.create.success.moderated.admin_post")
-                                   # i18n-tasks-use t("comments.create.success.moderated.work")
-                                   t("comments.create.success.moderated.#{@comment.ultimate_parent.model_name.i18n_key}")
-                                 else
-                                   t("comments.create.success.not_moderated")
-                                 end
-        respond_to do |format|
-          format.html do
-            if request.referer&.match(/inbox/)
-              redirect_to user_inbox_path(current_user, filters: filter_params, page: params[:page])
-            elsif request.referer&.match(/new/) || (@comment.unreviewed? && current_user)
-              # If the referer is the new comment page, go to the comment's page
-              # instead of reloading the full work.
-              # If the comment is unreviewed and commenter is logged in, take
-              # them to the comment's page so they can access the edit and
-              # delete options for the comment, since unreviewed comments don't
-              # appear on the commentable.
-              redirect_to comment_path(@comment)
-            elsif request.referer == root_url
-              # replying on the homepage
-              redirect_to root_path
-            elsif @comment.unreviewed?
-              redirect_to_all_comments(@commentable)
-            else
-              redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
-            end
+    # First, try saving the comment
+    if @comment.save
+      flash[:comment_notice] = if @comment.unreviewed?
+                                 # i18n-tasks-use t("comments.create.success.moderated.admin_post")
+                                 # i18n-tasks-use t("comments.create.success.moderated.work")
+                                 t("comments.create.success.moderated.#{@comment.ultimate_parent.model_name.i18n_key}")
+                               else
+                                 t("comments.create.success.not_moderated")
+                               end
+      respond_to do |format|
+        format.html do
+          if request.referer&.match(/inbox/)
+            redirect_to user_inbox_path(current_user, filters: filter_params, page: params[:page])
+          elsif request.referer&.match(/new/) || (@comment.unreviewed? && current_user)
+            # If the referer is the new comment page, go to the comment's page
+            # instead of reloading the full work.
+            # If the comment is unreviewed and commenter is logged in, take
+            # them to the comment's page so they can access the edit and
+            # delete options for the comment, since unreviewed comments don't
+            # appear on the commentable.
+            redirect_to comment_path(@comment)
+          elsif request.referer == root_url
+            # replying on the homepage
+            redirect_to root_path
+          elsif @comment.unreviewed?
+            redirect_to_all_comments(@commentable)
+          else
+            redirect_to_comment(@comment, { view_full_work: (params[:view_full_work] == "true"), page: params[:page] })
           end
         end
-      else
-        flash[:error] = ts("Couldn't save comment!")
-        render action: "new"
       end
+    else
+      flash[:error] = t(".error")
+      render action: "new"
     end
   end
 
@@ -610,18 +610,13 @@ class CommentsController < ApplicationController
   def show_comments
     respond_to do |format|
       format.html do
-        if @commentable.nil?
-          flash[:error] = t(".error")
-          redirect_back_or_to root_path
-        else
-          # if non-ajax it could mean sudden javascript failure OR being redirected from login
-          # so we're being extra-nice and preserving any intention to comment along with the show comments option
-          options = { show_comments: true }
-          options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
-          options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
-          options[:page] = params[:page]
-          redirect_to_all_comments(@commentable, options)
-        end
+        # if non-ajax it could mean sudden javascript failure OR being redirected from login
+        # so we're being extra-nice and preserving any intention to comment along with the show comments option
+        options = { show_comments: true }
+        options[:add_comment_reply_id] = params[:add_comment_reply_id] if params[:add_comment_reply_id]
+        options[:view_full_work] = params[:view_full_work] if params[:view_full_work]
+        options[:page] = params[:page]
+        redirect_to_all_comments(@commentable, options)
       end
 
       format.js do

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -184,6 +184,8 @@ en:
     index:
       subcollections_page_title: "%{collection_title} - Subcollections"
   comments:
+    add_comment_reply:
+      not_found: What did you want to reply to?
     check_blocked:
       parent: Sorry, you have been blocked by one or more of this work's creators.
       reply: Sorry, you have been blocked by that user.
@@ -203,6 +205,8 @@ en:
       error:
         frozen: Frozen comments cannot be edited.
     create:
+      error: Couldn't save comment!
+      not_found: What did you want to comment on?
       success:
         moderated:
           admin_post: Your comment was received! It will appear publicly after it has been approved.
@@ -219,13 +223,15 @@ en:
     index:
       page_title: Comments on %{name}
     new:
+      not_found: What did you want to comment on?
       page_title: New Comment on %{name}
+      previous_comment_name: Previous Comment
     rate_limited:
       error: You have made too many requests in a short time period. Please wait a while before trying again. If you are receiving this error repeatedly, try browsing more slowly or loading fewer pages at a time.
     show:
       page_title: Comment %{comment_id} on %{name}
     show_comments:
-      error: What did you want to show comments on?
+      not_found: What did you want to show comments on?
     unfreeze:
       error: Sorry, that comment thread could not be unfrozen.
       permission_denied: Sorry, you don't have permission to unfreeze that comment thread.

--- a/spec/controllers/comments/comments_controller_spec.rb
+++ b/spec/controllers/comments/comments_controller_spec.rb
@@ -68,13 +68,6 @@ describe CommentsController do
         end
       end
     end
-
-    context "when no commentable is given" do
-      it "redirects back with a flash error" do
-        get :show_comments
-        it_redirects_to_with_error("/where_i_came_from", "What did you want to show comments on?")
-      end
-    end
   end
 
   describe "GET #hide_comments" do
@@ -504,6 +497,20 @@ describe CommentsController do
       let(:edit_error_message) { "Sorry, you can't comment on a draft." }
       let(:work) { comment.ultimate_parent }
       before { work.update_column(:posted, false) }
+    end
+  end
+
+  context "when no commentable is given" do
+    {
+      new: "What did you want to comment on?",
+      create: "What did you want to comment on?",
+      show_comments: "What did you want to show comments on?",
+      add_comment_reply: "What did you want to reply to?"
+    }.each do |action, error_message|
+      it "GET ##{action} redirects back with a flash error" do
+        get action
+        it_redirects_to_with_error("/where_i_came_from", error_message)
+      end
     end
   end
 end


### PR DESCRIPTION
Since several comment routes have this behavior, hoist it out into a before_action, and add tests for all of them.

# Pull Request Checklist

* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.
* [x] I acknowledge that submitting code created or modified with the help of AI is a bannable offense.

## Issue

https://otwarchive.atlassian.net/browse/AO3-7556

## Purpose

Fixes a 500 when trying to reply to a comment without providing a commentable ID. The user is redirected back from whence they came, with a flash error explaining the problem.

While implementing this I noticed that there are now 4 routes in the comments controller that have this behavior, with different error messages. So I hoisted the behavior into a common before_action, with per-route translation strings.

The refactor dedents a bunch of code, so I suggest reviewing the diff with whitespace changes ignored, to make the diff highlight the right pieces.

## References

Similar fix to #5996 (AO3-7561), just on a different route.

## Credit

David Anderson (he/him)